### PR TITLE
[NCL-4338] Fail if credentials are not valid

### DIFF
--- a/pnc/src/main/java/org/jboss/pnc/bacon/pnc/client/PncClientHelper.java
+++ b/pnc/src/main/java/org/jboss/pnc/bacon/pnc/client/PncClientHelper.java
@@ -54,6 +54,10 @@ public class PncClientHelper {
         if (keycloakConfig != null) {
             keycloakConfig.validate();
             bearerToken = getBearerToken(keycloakConfig);
+
+            if (bearerToken == null || bearerToken.isEmpty()) {
+                Fail.fail("Credentials don't seem to be valid");
+            }
         }
 
         config.getPnc().validate();
@@ -74,6 +78,12 @@ public class PncClientHelper {
         }
     }
 
+    /**
+     * Return null if it couldn't get the authentication token. This generally means that
+     * the credentials are not valid
+     * @param keycloakConfig
+     * @return
+     */
     private static String getBearerToken(KeycloakConfig keycloakConfig) {
 
         log.debug("Authenticating to keycloak");


### PR DESCRIPTION
The output looks something like this:

```
[DEBUG] - clientSecret is not specified in the config file! Assuming this is a regular user
[DEBUG] - Authenticating to keycloak
[DEBUG] - Getting token via username/password
[ERROR] - Credentials don't seem to be valid
```
