### PR TITLE
[NCL-5206] Don't store krb password in main config.yaml

### DIFF
--- a/auth/pom.xml
+++ b/auth/pom.xml
@@ -13,6 +13,10 @@
 
     <dependencies>
         <dependency>
+            <groupId>org.jboss.pnc.bacon</groupId>
+            <artifactId>common</artifactId>
+        </dependency>
+        <dependency>
             <groupId>org.projectlombok</groupId>
             <artifactId>lombok</artifactId>
         </dependency>
@@ -53,6 +57,10 @@
         <dependency>
             <groupId>com.fasterxml.jackson.core</groupId>
             <artifactId>jackson-databind</artifactId>
+        </dependency>
+        <dependency>
+            <groupId>com.fasterxml.jackson.datatype</groupId>
+            <artifactId>jackson-datatype-jsr310</artifactId>
         </dependency>
     </dependencies>
 </project>

--- a/auth/src/main/java/org/jboss/pnc/bacon/auth/DirectKeycloakClientImpl.java
+++ b/auth/src/main/java/org/jboss/pnc/bacon/auth/DirectKeycloakClientImpl.java
@@ -5,19 +5,23 @@ import com.mashape.unirest.http.HttpResponse;
 import com.mashape.unirest.http.ObjectMapper;
 import com.mashape.unirest.http.Unirest;
 import lombok.extern.slf4j.Slf4j;
+import org.jboss.pnc.bacon.auth.model.CacheFile;
 import org.jboss.pnc.bacon.auth.model.Credential;
 import org.jboss.pnc.bacon.auth.model.KeycloakResponse;
 import org.jboss.pnc.bacon.auth.spi.KeycloakClient;
+import org.jboss.pnc.bacon.common.Fail;
 
-import java.io.File;
+import java.io.Console;
 import java.io.IOException;
-import java.util.Date;
+import java.time.Instant;
+import java.util.Optional;
 
 /**
  * Authenticates to Keycloak using direct flow!
  */
 @Slf4j
 public class DirectKeycloakClientImpl implements KeycloakClient {
+
 
     static {
         setupUnirest();
@@ -47,13 +51,22 @@ public class DirectKeycloakClientImpl implements KeycloakClient {
         });
     }
 
-    /**
-     * TODO: save current token in a file
-     */
     @Override
     public Credential getCredential(String keycloakBaseUrl, String realm, String client,
-                                    String username, String password) throws KeycloakClientException {
+                                    String username) throws KeycloakClientException {
 
+        Optional<Credential> cachedCredential = CacheFile.getCredentialFromCacheFile(keycloakBaseUrl, realm, username);
+
+        if (cachedCredential.isPresent()) {
+
+            Credential cred = cachedCredential.get();
+            if (cred.isValid()) {
+                log.debug("Using cached credential details");
+                return refreshCredentialIfNeededAndReturnNewCredential(keycloakBaseUrl, realm, username, cred);
+            }
+        }
+
+        // if we're here, it means we couldn't use / get the credential in the cached file
         String keycloakEndpoint = keycloakEndpoint(keycloakBaseUrl, realm);
 
         try {
@@ -64,22 +77,25 @@ public class DirectKeycloakClientImpl implements KeycloakClient {
                     .field("grant_type", "password")
                     .field("client_id", client)
                     .field("username", username)
-                    .field("password", password)
+                    .field("password", askForPassword())
                     .asObject(KeycloakResponse.class);
 
             KeycloakResponse response = postResponse.getBody();
-            Date date = new Date();
+            Instant now = Instant.now();
 
-            return Credential.builder()
+            Credential credential = Credential.builder()
                     .keycloakBaseUrl(keycloakBaseUrl)
                     .realm(realm)
                     .client(client)
                     .username(username)
                     .accessToken(response.getAccessToken())
-                    .accessTokenTime(date)
+                    .accessTokenExpiresIn(now.plusSeconds(response.getExpiresIn()))
                     .refreshToken(response.getRefreshToken())
-                    .refreshTokenTime(date)
+                    .refreshTokenExpiresIn(now.plusSeconds(response.getRefreshExpiresIn()))
                     .build();
+
+            CacheFile.writeCredentialToCacheFile(keycloakBaseUrl, realm, username, credential);
+            return credential;
 
         } catch (Exception e) {
             throw new KeycloakClientException(e);
@@ -90,8 +106,8 @@ public class DirectKeycloakClientImpl implements KeycloakClient {
      * TODO: save current token in a file
      */
     @Override
-    public Credential getCredential(String keycloakBaseUrl, String realm,
-                                    String serviceAccountUsername, String secret) throws KeycloakClientException {
+    public Credential getCredentialServiceAccount(String keycloakBaseUrl, String realm,
+                                                  String serviceAccountUsername, String secret) throws KeycloakClientException {
 
         String keycloakEndpoint = keycloakEndpoint(keycloakBaseUrl, realm);
 
@@ -106,16 +122,16 @@ public class DirectKeycloakClientImpl implements KeycloakClient {
                     .asObject(KeycloakResponse.class);
 
             KeycloakResponse response = postResponse.getBody();
-            Date date = new Date();
+            Instant now = Instant.now();
 
             return Credential.builder()
                     .keycloakBaseUrl(keycloakBaseUrl)
                     .realm(realm)
                     .client(serviceAccountUsername)
                     .accessToken(response.getAccessToken())
-                    .accessTokenTime(date)
+                    .accessTokenExpiresIn(now.plusSeconds(response.getExpiresIn()))
                     .refreshToken(response.getRefreshToken())
-                    .refreshTokenTime(date)
+                    .refreshTokenExpiresIn(now.plusSeconds(response.getRefreshExpiresIn()))
                     .build();
 
         } catch (Exception e) {
@@ -123,19 +139,53 @@ public class DirectKeycloakClientImpl implements KeycloakClient {
         }
     }
 
-    // TODO
-    private void writeCredentialToFile(Credential credential, File file) {
+    private Credential refreshToken(Credential credential) {
 
+        try {
+            String keycloakEndpoint = keycloakEndpoint(credential.getKeycloakBaseUrl(), credential.getRealm());
+            HttpResponse<KeycloakResponse> postResponse = Unirest.post(keycloakEndpoint)
+                    .field("grant_type", "refresh_token")
+                    .field("client_id", credential.getClient())
+                    .field("refresh_token", credential.getRefreshToken())
+                    .asObject(KeycloakResponse.class);
+
+            KeycloakResponse response = postResponse.getBody();
+            Instant now = Instant.now();
+
+            return credential.toBuilder()
+                    .accessToken(response.getAccessToken())
+                    .accessTokenExpiresIn(now.plusSeconds(response.getExpiresIn()))
+                    .refreshToken(response.getRefreshToken())
+                    .refreshTokenExpiresIn(now.plusSeconds(response.getRefreshExpiresIn()))
+                    .build();
+
+        } catch (Exception e) {
+            e.printStackTrace();
+            return null;
+        }
     }
 
-    // TODO
-    private Credential readCredentialFromFile(File file) {
-        return null;
+    private static String askForPassword() {
 
+        Console console = System.console();
+
+        if (console == null) {
+            Fail.fail("Couldn't get console instance");
+        }
+        char[] passwordArray = console.readPassword("Enter your password: ");
+        return new String(passwordArray);
     }
 
-    // TODO
-    private boolean needToRefreshAccessToken(Credential credential, long expiry) {
-        return false;
+    private Credential refreshCredentialIfNeededAndReturnNewCredential(String keycloakUrl, String realm, String username, Credential cred) {
+
+        if (cred.needsNewAccessToken()) {
+            // if needs a refresh
+            log.info("Refreshing access token...");
+            Credential refreshed = refreshToken(cred);
+            CacheFile.writeCredentialToCacheFile(keycloakUrl, realm, username, refreshed);
+            return refreshed;
+        } else {
+            return cred;
+        }
     }
 }

--- a/auth/src/main/java/org/jboss/pnc/bacon/auth/model/CacheFile.java
+++ b/auth/src/main/java/org/jboss/pnc/bacon/auth/model/CacheFile.java
@@ -1,0 +1,90 @@
+package org.jboss.pnc.bacon.auth.model;
+
+import com.fasterxml.jackson.datatype.jsr310.JavaTimeModule;
+import lombok.Getter;
+import lombok.Setter;
+import lombok.extern.slf4j.Slf4j;
+import org.apache.commons.codec.digest.DigestUtils;
+import org.jboss.pnc.bacon.common.Constant;
+
+import java.io.File;
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.nio.file.Paths;
+import java.util.HashMap;
+import java.util.Map;
+import java.util.Optional;
+
+@Getter
+@Setter
+@Slf4j
+public class CacheFile {
+
+    public static final String CACHE_FILE = Constant.CONFIG_FOLDER + "/" + "saved-user.json";
+
+    private Map<String, Credential> cachedData;
+    private static com.fasterxml.jackson.databind.ObjectMapper mapper;
+
+    static {
+      mapper = new com.fasterxml.jackson.databind.ObjectMapper();
+      mapper.registerModule(new JavaTimeModule());
+    }
+
+    public static void writeCredentialToCacheFile(String keycloakUrl, String realm, String username, Credential credential) {
+        log.debug("Writing credential to cache file");
+
+        createConfigFolderIfAbsent();
+
+        try {
+            Map<String, Credential> data = new HashMap<>();
+            data.put(generateUsernameMd5(keycloakUrl, realm, username), credential);
+
+            CacheFile cacheFile = new CacheFile();
+            cacheFile.setCachedData(data);
+            mapper.writeValue(new File(CACHE_FILE), cacheFile);
+
+        } catch (Exception e) {
+            e.printStackTrace();
+        }
+    }
+
+    public static Optional<Credential> getCredentialFromCacheFile(String keycloakUrl, String realm, String username) {
+
+        String key = generateUsernameMd5(keycloakUrl, realm, username);
+
+        if (!fileExists(CACHE_FILE)) {
+            return Optional.empty();
+        }
+
+        try {
+            CacheFile cacheFile = mapper.readValue(new File(CACHE_FILE), CacheFile.class);
+
+            if (cacheFile.getCachedData() != null && cacheFile.getCachedData().containsKey(key)) {
+                return Optional.of(cacheFile.getCachedData().get(key));
+            } else {
+                return Optional.empty();
+            }
+        } catch (Exception e) {
+            e.printStackTrace();
+            return Optional.empty();
+        }
+    }
+
+    private static void createConfigFolderIfAbsent() {
+        if (!fileExists(Constant.CONFIG_FOLDER)) {
+            log.debug("Creating config folder...");
+            new File(Constant.CONFIG_FOLDER).mkdirs();
+        }
+    }
+
+    private static String generateUsernameMd5(String keycloakUrl, String realm, String username) {
+        return DigestUtils.md5Hex(keycloakUrl + ":" + realm + ":" + username);
+    }
+
+    private static boolean fileExists(String pathString) {
+
+        Path path = Paths.get(pathString);
+        return Files.exists(path);
+    }
+
+}

--- a/auth/src/main/java/org/jboss/pnc/bacon/auth/model/Credential.java
+++ b/auth/src/main/java/org/jboss/pnc/bacon/auth/model/Credential.java
@@ -1,14 +1,19 @@
 package org.jboss.pnc.bacon.auth.model;
 
+import com.fasterxml.jackson.annotation.JsonIgnore;
+import com.fasterxml.jackson.databind.annotation.JsonDeserialize;
+import com.fasterxml.jackson.databind.annotation.JsonPOJOBuilder;
 import lombok.Builder;
 import lombok.Data;
-import lombok.ToString;
+import lombok.extern.slf4j.Slf4j;
 
-import java.util.Date;
+import java.time.Instant;
+import java.time.temporal.ChronoUnit;
 
 @Data
-@Builder
-@ToString
+@Builder(toBuilder = true, builderClassName = "Builder")
+@JsonDeserialize(builder = Credential.Builder.class)
+@Slf4j
 public class Credential {
 
     private String keycloakBaseUrl;
@@ -22,6 +27,29 @@ public class Credential {
     private String accessToken;
     private String refreshToken;
 
-    private Date accessTokenTime;
-    private Date refreshTokenTime;
+    private Instant accessTokenExpiresIn;
+    private Instant refreshTokenExpiresIn;
+
+    @JsonIgnore
+    public boolean isValid() {
+
+        if (accessToken == null || refreshToken == null || accessTokenExpiresIn == null || refreshTokenExpiresIn == null) {
+            return false;
+        } else {
+            // return whether we have reached the expiry date or not
+            return Instant.now().until(refreshTokenExpiresIn, ChronoUnit.SECONDS) > 0;
+        }
+    }
+
+    public boolean needsNewAccessToken() {
+
+        if (!isValid()) {
+            return true;
+        } else {
+            return Instant.now().until(accessTokenExpiresIn, ChronoUnit.HOURS) < 20;
+        }
+    }
+
+    @JsonPOJOBuilder(withPrefix = "")
+    public static class Builder {}
 }

--- a/auth/src/main/java/org/jboss/pnc/bacon/auth/model/KeycloakResponse.java
+++ b/auth/src/main/java/org/jboss/pnc/bacon/auth/model/KeycloakResponse.java
@@ -13,4 +13,12 @@ public class KeycloakResponse {
 
     @JsonProperty(value = "refresh_token")
     private String refreshToken;
+
+    /** Unit in second */
+    @JsonProperty(value = "expires_in")
+    private int expiresIn;
+
+    /** Unit in second */
+    @JsonProperty(value = "refresh_expires_in")
+    private int refreshExpiresIn;
 }

--- a/auth/src/main/java/org/jboss/pnc/bacon/auth/spi/KeycloakClient.java
+++ b/auth/src/main/java/org/jboss/pnc/bacon/auth/spi/KeycloakClient.java
@@ -12,11 +12,10 @@ public interface KeycloakClient {
      * @param realm
      * @param client
      * @param username
-     * @param password
      *
      * @return Credential object that contains all the information
      */
-    Credential getCredential(String keycloakBaseUrl, String realm, String client, String username, String password) throws KeycloakClientException;
+    Credential getCredential(String keycloakBaseUrl, String realm, String client, String username) throws KeycloakClientException;
 
     /**
      * Authenticate based on service account and service account secret
@@ -28,7 +27,7 @@ public interface KeycloakClient {
      *
      * @return Credential object that contains all the information
      */
-    Credential getCredential(String keycloakBaseUrl, String realm, String serviceAccountUsername, String secret) throws KeycloakClientException;
+    Credential getCredentialServiceAccount(String keycloakBaseUrl, String realm, String serviceAccountUsername, String secret) throws KeycloakClientException;
 
 
     default String keycloakEndpoint(String keycloakBaseUrl, String realm) {

--- a/common/src/main/java/org/jboss/pnc/bacon/common/Constant.java
+++ b/common/src/main/java/org/jboss/pnc/bacon/common/Constant.java
@@ -1,0 +1,6 @@
+package org.jboss.pnc.bacon.common;
+
+public class Constant {
+
+    public static final String CONFIG_FOLDER = System.getProperty("user.home") + "/.config/pnc-bacon";
+}

--- a/config.yaml
+++ b/config.yaml
@@ -32,7 +32,6 @@ pnc:
 #
 #     # if regular user
 #     clientId: ""
-#     password: ""
 #
 #     # if service account
 #     clientSecret: ""

--- a/config/src/main/java/org/jboss/pnc/bacon/config/KeycloakConfig.java
+++ b/config/src/main/java/org/jboss/pnc/bacon/config/KeycloakConfig.java
@@ -59,7 +59,6 @@ public class KeycloakConfig implements Validate {
         } else {
             log.debug("clientSecret is not specified in the config file! Assuming this is a regular user");
             Fail.failIfNull(clientId, "You need to specify the client id for your regular account in the config file");
-            Fail.failIfNull(password, "You need to specify the password for your regular account in the config file");
         }
 
     }

--- a/pnc/src/main/java/org/jboss/pnc/bacon/pnc/client/PncClientHelper.java
+++ b/pnc/src/main/java/org/jboss/pnc/bacon/pnc/client/PncClientHelper.java
@@ -110,8 +110,7 @@ public class PncClientHelper {
                         keycloakConfig.getUrl(),
                         keycloakConfig.getRealm(),
                         keycloakConfig.getClientId(),
-                        keycloakConfig.getUsername(),
-                        keycloakConfig.getPassword());
+                        keycloakConfig.getUsername());
             }
 
             return credential.getAccessToken();


### PR DESCRIPTION
This commit removes the requirement of specifying the Kerberos password
in the config.yaml. Instead, it asks for the password.

In addition, caching of the access / refresh tokens is added to speed up
authentication on subsequent requests.

Keycloak tells us how much time the refresh and access tokens are valid.
If the access token will expire in less than 20 hours, we'll use the
refresh token to request a new access/refresh tokens and save it in our
cached location.

If the refresh token is already expired, we'll just go back to ask the
user for their password, as is the case for the PNC Web UI.

The cached tokens are invalidated if the config.yaml has an altered
keycloak url, username, realm. This is because those tokens
can't be used with the different settings.