### PR TITLE
[NCL-5297] Add maintenance mode and announcement banner commands.

### DIFF
--- a/pnc/src/main/java/org/jboss/pnc/bacon/pnc/AdminCli.java
+++ b/pnc/src/main/java/org/jboss/pnc/bacon/pnc/AdminCli.java
@@ -19,30 +19,14 @@ package org.jboss.pnc.bacon.pnc;
 
 import org.aesh.command.GroupCommandDefinition;
 import org.jboss.pnc.bacon.common.cli.AbstractCommand;
+import org.jboss.pnc.bacon.pnc.admin.AnnouncementBannerCli;
+import org.jboss.pnc.bacon.pnc.admin.MaintenanceModeCli;
 
-/**
- * @author Michal Szynkiewicz, michal.l.szynkiewicz@gmail.com
- * <br>
- * Date: 12/13/18
- */
 @GroupCommandDefinition(
-        name = "pnc",
-        description = "PNC sub-command",
+        name = "admin",
+        description = "Admin related tasks",
         groupCommands = {
-                AdminCli.class,
-                ArtifactCli.class,
-                BrewPushCli.class,
-                BuildCli.class,
-                BuildConfigCli.class,
-                EnvironmentCli.class,
-                GroupBuildCli.class,
-                GroupConfigCli.class,
-                ProductCli.class,
-                ProductMilestoneCli.class,
-                ProductReleaseCli.class,
-                ProductVersionCli.class,
-                ProjectCli.class,
-                ScmRepositoryCli.class
+                AnnouncementBannerCli.class,
+                MaintenanceModeCli.class
         })
-public class Pnc extends AbstractCommand {
-}
+public class AdminCli extends AbstractCommand {}

--- a/pnc/src/main/java/org/jboss/pnc/bacon/pnc/BuildCli.java
+++ b/pnc/src/main/java/org/jboss/pnc/bacon/pnc/BuildCli.java
@@ -17,6 +17,7 @@
  */
 package org.jboss.pnc.bacon.pnc;
 
+import lombok.extern.slf4j.Slf4j;
 import org.aesh.command.CommandDefinition;
 import org.aesh.command.CommandException;
 import org.aesh.command.CommandResult;
@@ -61,6 +62,7 @@ import java.util.Optional;
         BuildCli.GetLog.class,
         BuildCli.DownloadSources.class
 })
+@Slf4j
 public class BuildCli extends AbstractCommand {
 
 

--- a/pnc/src/main/java/org/jboss/pnc/bacon/pnc/admin/AnnouncementBannerCli.java
+++ b/pnc/src/main/java/org/jboss/pnc/bacon/pnc/admin/AnnouncementBannerCli.java
@@ -1,0 +1,91 @@
+/*
+ * JBoss, Home of Professional Open Source.
+ * Copyright 2018 Red Hat, Inc., and individual contributors
+ * as indicated by the @author tags.
+ * <p>
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ * <p>
+ * http://www.apache.org/licenses/LICENSE-2.0
+ * <p>
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.jboss.pnc.bacon.pnc.admin;
+
+import org.aesh.command.CommandDefinition;
+import org.aesh.command.CommandException;
+import org.aesh.command.CommandResult;
+import org.aesh.command.GroupCommandDefinition;
+import org.aesh.command.invocation.CommandInvocation;
+import org.aesh.command.option.Argument;
+import org.jboss.pnc.bacon.common.cli.AbstractCommand;
+import org.jboss.pnc.bacon.pnc.client.PncClientHelper;
+import org.jboss.pnc.client.GenericSettingClient;
+
+@GroupCommandDefinition(
+        name = "announcement-banner",
+        description = "Announcement banner related tasks",
+        groupCommands = {
+                AnnouncementBannerCli.SetAnnouncementBanner.class,
+                AnnouncementBannerCli.UnsetAnnouncementBanner.class,
+                AnnouncementBannerCli.GetAnnouncementBanner.class
+        })
+public class AnnouncementBannerCli extends AbstractCommand {
+
+    private static GenericSettingClient clientCache;
+
+    private static GenericSettingClient getClient() {
+        if (clientCache == null) {
+            clientCache = new GenericSettingClient(PncClientHelper.getPncConfiguration(false));
+        }
+        return clientCache;
+    }
+
+    private static GenericSettingClient getClientAuthenticated() {
+        if (clientCache == null) {
+            clientCache = new GenericSettingClient(PncClientHelper.getPncConfiguration(true));
+        }
+        return clientCache;
+    }
+
+    @CommandDefinition(name = "set", description = "This will set the announcement banner")
+    public class SetAnnouncementBanner extends AbstractCommand {
+
+        @Argument(required = true, description = "Announcement")
+        private String announcement;
+
+        @Override
+        public CommandResult execute(CommandInvocation commandInvocation) throws CommandException, InterruptedException {
+            return super.executeHelper(commandInvocation, () -> {
+                getClientAuthenticated().setAnnouncementBanner(announcement);
+            });
+        }
+    }
+
+    @CommandDefinition(name = "unset", description = "This will unset the announcement banner")
+    public class UnsetAnnouncementBanner extends AbstractCommand {
+
+        @Override
+        public CommandResult execute(CommandInvocation commandInvocation) throws CommandException, InterruptedException {
+            return super.executeHelper(commandInvocation, () -> {
+                getClientAuthenticated().setAnnouncementBanner("");
+            });
+        }
+    }
+
+    @CommandDefinition(name = "get", description = "This will get the announcement banner, if any set")
+    public class GetAnnouncementBanner extends AbstractCommand {
+
+        @Override
+        public CommandResult execute(CommandInvocation commandInvocation) throws CommandException, InterruptedException {
+            return super.executeHelper(commandInvocation, () -> {
+                System.out.println(getClient().getAnnouncementBanner().getBanner());
+            });
+        }
+    }
+}

--- a/pnc/src/main/java/org/jboss/pnc/bacon/pnc/admin/MaintenanceModeCli.java
+++ b/pnc/src/main/java/org/jboss/pnc/bacon/pnc/admin/MaintenanceModeCli.java
@@ -1,0 +1,100 @@
+/*
+ * JBoss, Home of Professional Open Source.
+ * Copyright 2018 Red Hat, Inc., and individual contributors
+ * as indicated by the @author tags.
+ * <p>
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ * <p>
+ * http://www.apache.org/licenses/LICENSE-2.0
+ * <p>
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.jboss.pnc.bacon.pnc.admin;
+
+import org.aesh.command.CommandDefinition;
+import org.aesh.command.CommandException;
+import org.aesh.command.CommandResult;
+import org.aesh.command.GroupCommandDefinition;
+import org.aesh.command.invocation.CommandInvocation;
+import org.aesh.command.option.Argument;
+import org.jboss.pnc.bacon.common.cli.AbstractCommand;
+import org.jboss.pnc.bacon.pnc.client.PncClientHelper;
+import org.jboss.pnc.client.GenericSettingClient;
+
+@GroupCommandDefinition(
+        name = "maintenance-mode",
+        description = "Maintenance mode related tasks",
+        groupCommands = {
+                MaintenanceModeCli.ActivateMaintenanceMode.class,
+                MaintenanceModeCli.DeactivateMaintenanceMode.class,
+                MaintenanceModeCli.StatusMaintenanceMode.class
+        })
+public class MaintenanceModeCli extends AbstractCommand {
+
+    private static GenericSettingClient clientCache;
+
+    private static GenericSettingClient getClient() {
+        if (clientCache == null) {
+            clientCache = new GenericSettingClient(PncClientHelper.getPncConfiguration(false));
+        }
+        return clientCache;
+    }
+
+    private static GenericSettingClient getClientAuthenticated() {
+        if (clientCache == null) {
+            clientCache = new GenericSettingClient(PncClientHelper.getPncConfiguration(true));
+        }
+        return clientCache;
+    }
+
+    @CommandDefinition(name = "activate", description = "This will disable any new builds from being accepted")
+    public class ActivateMaintenanceMode extends AbstractCommand {
+
+        @Argument(required = true, description = "Reason")
+        private String reason;
+
+        @Override
+        public CommandResult execute(CommandInvocation commandInvocation) throws CommandException, InterruptedException {
+            return super.executeHelper(commandInvocation, () -> {
+                getClientAuthenticated().activateMaintenanceMode(reason);
+
+            });
+        }
+    }
+
+
+    @CommandDefinition(name = "deactivate", description = "Deactivate maintenance mode and accept new builds")
+    public class DeactivateMaintenanceMode extends AbstractCommand {
+
+        @Override
+        public CommandResult execute(CommandInvocation commandInvocation) throws CommandException, InterruptedException {
+            return super.executeHelper(commandInvocation, () -> {
+                getClientAuthenticated().deactivateMaintenanceMode();;
+
+            });
+        }
+    }
+
+    @CommandDefinition(name = "status", description = "Know whether we are in maintenance mode or not")
+    public class StatusMaintenanceMode extends AbstractCommand {
+
+        @Override
+        public CommandResult execute(CommandInvocation commandInvocation) throws CommandException, InterruptedException {
+            return super.executeHelper(commandInvocation, () -> {
+                if (getClient().isInMaintenanceMode()) {
+                    System.out.println("PNC is in maintenance mode");
+                    System.out.println(getClient().getAnnouncementBanner().getBanner());
+                } else {
+                    System.out.println("PNC is NOT in maintenance mode");
+                }
+
+            });
+        }
+    }
+}

--- a/pnc/src/main/java/org/jboss/pnc/bacon/pnc/client/PncClientHelper.java
+++ b/pnc/src/main/java/org/jboss/pnc/bacon/pnc/client/PncClientHelper.java
@@ -26,6 +26,8 @@ import org.jboss.pnc.bacon.common.Fail;
 import org.jboss.pnc.bacon.config.Config;
 import org.jboss.pnc.bacon.config.KeycloakConfig;
 import org.jboss.pnc.client.Configuration;
+import org.jboss.pnc.client.GenericSettingClient;
+import org.jboss.pnc.client.RemoteResourceException;
 
 import java.net.URI;
 import java.net.URISyntaxException;
@@ -83,6 +85,18 @@ public class PncClientHelper {
                     .bearerToken(bearerToken)
                     .pageSize(50)
                     .build();
+
+            GenericSettingClient genericSettingClient = new GenericSettingClient(configuration);
+            try {
+                String banner = genericSettingClient.getAnnouncementBanner().getBanner();
+                if (banner != null && !banner.isEmpty()) {
+                    log.warn("***********************");
+                    log.warn("Announcement: {}", banner);
+                    log.warn("***********************");
+                }
+            } catch (RemoteResourceException e) {
+                log.error(e.getMessage());
+            }
 
         } catch (URISyntaxException e) {
             Fail.fail(e.getMessage());


### PR DESCRIPTION
The commands can be found inside the top-level admin command

Activating the maintenance mode with the reason
```
➜  cli git:(ncl-5297) ✗ java -jar cli/target/bacon.jar pnc admin maintenance-mode activate "testing me"
[DEBUG] - clientSecret is not specified in the config file! Assuming this is a regular user
[DEBUG] - Authenticating to keycloak
[DEBUG] - Using cached credential details
```

The maintenance mode 'reason' is used to set the announcement banner.

Running any other command will print the announcement banner
```
➜  cli git:(ncl-5297) ✗ java -jar cli/target/bacon.jar pnc admin maintenance-mode status
[WARN ] - ***********************
[WARN ] - Announcement: testing me
[WARN ] - ***********************
PNC is in maintenance mode
testing me
```

When the maintenance mode is deactivated, the announcement banner is
also reset.