### PR TITLE
[NCL-5451] Allow user to specify format of output: YAML or JSON

### DIFF
--- a/common/pom.xml
+++ b/common/pom.xml
@@ -36,5 +36,9 @@
             <groupId>org.jboss.pnc</groupId>
             <artifactId>rest-client</artifactId>
         </dependency>
+        <dependency>
+            <groupId>com.fasterxml.jackson.dataformat</groupId>
+            <artifactId>jackson-dataformat-yaml</artifactId>
+        </dependency>
     </dependencies>
 </project>

--- a/common/src/main/java/org/jboss/pnc/bacon/common/ObjectHelper.java
+++ b/common/src/main/java/org/jboss/pnc/bacon/common/ObjectHelper.java
@@ -1,6 +1,7 @@
 package org.jboss.pnc.bacon.common;
 
 import com.fasterxml.jackson.core.JsonFactory;
+import com.fasterxml.jackson.core.JsonProcessingException;
 import com.fasterxml.jackson.databind.ObjectMapper;
 import com.fasterxml.jackson.dataformat.yaml.YAMLFactory;
 
@@ -12,7 +13,11 @@ public class ObjectHelper {
         }
     }
 
-    public static ObjectMapper getOutputMapper(boolean json) {
+    private static ObjectMapper getOutputMapper(boolean json) {
         return json ? new ObjectMapper(new JsonFactory()) : new ObjectMapper(new YAMLFactory());
+    }
+
+    public static void print(boolean json, Object o) throws JsonProcessingException {
+        System.out.println(getOutputMapper(json).writeValueAsString(o));
     }
 }

--- a/common/src/main/java/org/jboss/pnc/bacon/common/ObjectHelper.java
+++ b/common/src/main/java/org/jboss/pnc/bacon/common/ObjectHelper.java
@@ -1,10 +1,18 @@
 package org.jboss.pnc.bacon.common;
 
+import com.fasterxml.jackson.core.JsonFactory;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import com.fasterxml.jackson.dataformat.yaml.YAMLFactory;
+
 public class ObjectHelper {
 
     public static void executeIfNotNull(Object value, Runnable run) {
         if (value != null) {
             run.run();
         }
+    }
+
+    public static ObjectMapper getOutputMapper(boolean json) {
+        return json ? new ObjectMapper(new JsonFactory()) : new ObjectMapper(new YAMLFactory());
     }
 }

--- a/common/src/main/java/org/jboss/pnc/bacon/common/cli/AbstractCommand.java
+++ b/common/src/main/java/org/jboss/pnc/bacon/common/cli/AbstractCommand.java
@@ -17,6 +17,7 @@
  */
 package org.jboss.pnc.bacon.common.cli;
 
+import com.fasterxml.jackson.core.JsonProcessingException;
 import lombok.extern.slf4j.Slf4j;
 import org.aesh.command.Command;
 import org.aesh.command.CommandException;
@@ -39,7 +40,7 @@ import org.jboss.pnc.client.ClientException;
 public class AbstractCommand implements Command {
 
     public interface SubCommandExecuteInterface {
-        void call() throws ClientException;
+        void call() throws ClientException, JsonProcessingException;
     }
 
     @Option(shortName = 'h', overrideRequired = true, hasValue = false, description = "print help")

--- a/common/src/main/java/org/jboss/pnc/bacon/common/cli/AbstractGetSpecificCommand.java
+++ b/common/src/main/java/org/jboss/pnc/bacon/common/cli/AbstractGetSpecificCommand.java
@@ -22,6 +22,8 @@ import org.aesh.command.CommandException;
 import org.aesh.command.CommandResult;
 import org.aesh.command.invocation.CommandInvocation;
 import org.aesh.command.option.Argument;
+import org.aesh.command.option.Option;
+import org.jboss.pnc.bacon.common.ObjectHelper;
 import org.jboss.pnc.client.ClientException;
 
 /**
@@ -36,10 +38,15 @@ public abstract class AbstractGetSpecificCommand<T> extends AbstractCommand {
     @Argument(required = true, description = "Id of item")
     private String id;
 
+    @Option(shortName = 'o', overrideRequired = false, hasValue = false, description = "use json for output (default to yaml)")
+    private boolean jsonOutput = false;
+
     @Override
     public CommandResult execute(CommandInvocation commandInvocation) throws CommandException, InterruptedException {
 
-        return super.executeHelper(commandInvocation, () -> System.out.println(getSpecific(id)));
+        return super.executeHelper(commandInvocation, () -> {
+            System.out.println(ObjectHelper.getOutputMapper(jsonOutput).writeValueAsString(getSpecific(id)));
+        });
     }
 
     public abstract T getSpecific(String id) throws ClientException;

--- a/common/src/main/java/org/jboss/pnc/bacon/common/cli/AbstractGetSpecificCommand.java
+++ b/common/src/main/java/org/jboss/pnc/bacon/common/cli/AbstractGetSpecificCommand.java
@@ -45,7 +45,7 @@ public abstract class AbstractGetSpecificCommand<T> extends AbstractCommand {
     public CommandResult execute(CommandInvocation commandInvocation) throws CommandException, InterruptedException {
 
         return super.executeHelper(commandInvocation, () -> {
-            System.out.println(ObjectHelper.getOutputMapper(jsonOutput).writeValueAsString(getSpecific(id)));
+            ObjectHelper.print(jsonOutput, getSpecific(id));
         });
     }
 

--- a/common/src/main/java/org/jboss/pnc/bacon/common/cli/AbstractListCommand.java
+++ b/common/src/main/java/org/jboss/pnc/bacon/common/cli/AbstractListCommand.java
@@ -49,7 +49,7 @@ public abstract class AbstractListCommand<T> extends AbstractCommand {
     public CommandResult execute(CommandInvocation commandInvocation) throws CommandException, InterruptedException {
 
         return super.executeHelper(commandInvocation, () -> {
-            System.out.println(ObjectHelper.getOutputMapper(jsonOutput).writeValueAsString(getAll(sort, query)));
+            ObjectHelper.print(jsonOutput, getAll(sort, query));
         });
     }
 

--- a/common/src/main/java/org/jboss/pnc/bacon/common/cli/AbstractListCommand.java
+++ b/common/src/main/java/org/jboss/pnc/bacon/common/cli/AbstractListCommand.java
@@ -22,6 +22,7 @@ import org.aesh.command.CommandException;
 import org.aesh.command.CommandResult;
 import org.aesh.command.invocation.CommandInvocation;
 import org.aesh.command.option.Option;
+import org.jboss.pnc.bacon.common.ObjectHelper;
 import org.jboss.pnc.client.RemoteCollection;
 import org.jboss.pnc.client.RemoteResourceException;
 
@@ -41,15 +42,14 @@ public abstract class AbstractListCommand<T> extends AbstractCommand {
     @Option(description = "Query parameter (using RSQL)")
     private String query;
 
+    @Option(shortName = 'o', overrideRequired = false, hasValue = false, description = "use json for output (default to yaml)")
+    private boolean jsonOutput = false;
+
     @Override
     public CommandResult execute(CommandInvocation commandInvocation) throws CommandException, InterruptedException {
 
         return super.executeHelper(commandInvocation, () -> {
-
-            for (T item : getAll(sort, query)) {
-                // TODO: to print in JSON or YAML format
-                System.out.println(item);
-            }
+            System.out.println(ObjectHelper.getOutputMapper(jsonOutput).writeValueAsString(getAll(sort, query)));
         });
     }
 

--- a/pnc/src/main/java/org/jboss/pnc/bacon/pnc/ArtifactCli.java
+++ b/pnc/src/main/java/org/jboss/pnc/bacon/pnc/ArtifactCli.java
@@ -7,8 +7,9 @@ import org.aesh.command.CommandResult;
 import org.aesh.command.GroupCommandDefinition;
 import org.aesh.command.invocation.CommandInvocation;
 import org.aesh.command.option.Option;
-import org.jboss.pnc.bacon.common.cli.AbstractGetSpecificCommand;
+import org.jboss.pnc.bacon.common.ObjectHelper;
 import org.jboss.pnc.bacon.common.cli.AbstractCommand;
+import org.jboss.pnc.bacon.common.cli.AbstractGetSpecificCommand;
 import org.jboss.pnc.bacon.pnc.client.PncClientHelper;
 import org.jboss.pnc.client.ArtifactClient;
 import org.jboss.pnc.client.ClientException;
@@ -49,6 +50,9 @@ public class ArtifactCli extends AbstractCommand {
         @Option
         private String sha256;
 
+        @Option(shortName = 'o', overrideRequired = false, hasValue = false, description = "use json for output (default to yaml)")
+        private boolean jsonOutput = false;
+
         @Override
         public CommandResult execute(CommandInvocation commandInvocation) throws CommandException, InterruptedException {
 
@@ -57,12 +61,9 @@ public class ArtifactCli extends AbstractCommand {
                 if (md5 == null && sha1 == null && sha256 == null) {
                     log.error("You need to use at least one hash option!");
                 } else {
-                    for (Artifact artifact : getClient().getAll(sha256, md5, sha1)) {
-                        // TODO: print in yaml or json
-                        System.out.println(artifact);
-                    }
+                    System.out.println(
+                            ObjectHelper.getOutputMapper(jsonOutput).writeValueAsString(getClient().getAll(sha256, md5, sha1)));
                 }
-
             });
         }
     }

--- a/pnc/src/main/java/org/jboss/pnc/bacon/pnc/ArtifactCli.java
+++ b/pnc/src/main/java/org/jboss/pnc/bacon/pnc/ArtifactCli.java
@@ -61,8 +61,7 @@ public class ArtifactCli extends AbstractCommand {
                 if (md5 == null && sha1 == null && sha256 == null) {
                     log.error("You need to use at least one hash option!");
                 } else {
-                    System.out.println(
-                            ObjectHelper.getOutputMapper(jsonOutput).writeValueAsString(getClient().getAll(sha256, md5, sha1)));
+                    ObjectHelper.print(jsonOutput, getClient().getAll(sha256, md5, sha1));
                 }
             });
         }

--- a/pnc/src/main/java/org/jboss/pnc/bacon/pnc/BrewPushCli.java
+++ b/pnc/src/main/java/org/jboss/pnc/bacon/pnc/BrewPushCli.java
@@ -60,7 +60,7 @@ public class BrewPushCli extends AbstractCommand {
                 BuildPushRequest request = BuildPushRequest.builder().tagPrefix(tagPrefix).reimport(Boolean.valueOf(reimport))
                         .build();
 
-                System.out.println(ObjectHelper.getOutputMapper(jsonOutput).writeValueAsString(client.push(id, request)));
+                ObjectHelper.print(jsonOutput, client.push(id, request));
             });
         }
 
@@ -113,7 +113,7 @@ public class BrewPushCli extends AbstractCommand {
 
                 BuildClient client = new BuildClient(PncClientHelper.getPncConfiguration(false));
 
-                System.out.println(ObjectHelper.getOutputMapper(jsonOutput).writeValueAsString(client.getPushResult(id)));
+                ObjectHelper.print(jsonOutput, client.getPushResult(id));
             });
         }
     }

--- a/pnc/src/main/java/org/jboss/pnc/bacon/pnc/BrewPushCli.java
+++ b/pnc/src/main/java/org/jboss/pnc/bacon/pnc/BrewPushCli.java
@@ -24,6 +24,7 @@ import org.aesh.command.GroupCommandDefinition;
 import org.aesh.command.invocation.CommandInvocation;
 import org.aesh.command.option.Argument;
 import org.aesh.command.option.Option;
+import org.jboss.pnc.bacon.common.ObjectHelper;
 import org.jboss.pnc.bacon.common.cli.AbstractCommand;
 import org.jboss.pnc.bacon.pnc.client.PncClientHelper;
 import org.jboss.pnc.client.BuildClient;
@@ -46,6 +47,9 @@ public class BrewPushCli extends AbstractCommand {
         @Option(name = "reimport", description = "Should we re-import the build in case it was already imported?", defaultValue = "false")
         private String reimport;
 
+        @Option(shortName = 'o', overrideRequired = false, hasValue = false, description = "use json for output (default to yaml)")
+        private boolean jsonOutput = false;
+
         @Override
         public CommandResult execute(CommandInvocation commandInvocation) throws CommandException, InterruptedException {
 
@@ -56,7 +60,7 @@ public class BrewPushCli extends AbstractCommand {
                 BuildPushRequest request = BuildPushRequest.builder().tagPrefix(tagPrefix).reimport(Boolean.valueOf(reimport))
                         .build();
 
-                System.out.println(client.push(id, request));
+                System.out.println(ObjectHelper.getOutputMapper(jsonOutput).writeValueAsString(client.push(id, request)));
             });
         }
 
@@ -99,13 +103,17 @@ public class BrewPushCli extends AbstractCommand {
         @Argument(required = true, description = "Brew Push ID")
         private String id;
 
+        @Option(shortName = 'o', overrideRequired = false, hasValue = false, description = "use json for output (default to yaml)")
+        private boolean jsonOutput = false;
+
         @Override
         public CommandResult execute(CommandInvocation commandInvocation) throws CommandException, InterruptedException {
 
             return super.executeHelper(commandInvocation, () -> {
 
                 BuildClient client = new BuildClient(PncClientHelper.getPncConfiguration(false));
-                System.out.println(client.getPushResult(id));
+
+                System.out.println(ObjectHelper.getOutputMapper(jsonOutput).writeValueAsString(client.getPushResult(id)));
             });
         }
     }

--- a/pnc/src/main/java/org/jboss/pnc/bacon/pnc/BuildCli.java
+++ b/pnc/src/main/java/org/jboss/pnc/bacon/pnc/BuildCli.java
@@ -102,8 +102,7 @@ public class BuildCli extends AbstractCommand {
             buildParams.setTemporaryBuild(Boolean.parseBoolean(temporaryBuild));
 
             return super.executeHelper(commandInvocation, () -> {
-                System.out.println(ObjectHelper.getOutputMapper(jsonOutput)
-                        .writeValueAsString(BuildConfigCli.getClientAuthenticated().trigger(buildConfigId, buildParams)));
+                ObjectHelper.print(jsonOutput, BuildConfigCli.getClientAuthenticated().trigger(buildConfigId, buildParams));
             });
         }
     }

--- a/pnc/src/main/java/org/jboss/pnc/bacon/pnc/BuildCli.java
+++ b/pnc/src/main/java/org/jboss/pnc/bacon/pnc/BuildCli.java
@@ -26,6 +26,7 @@ import org.aesh.command.invocation.CommandInvocation;
 import org.aesh.command.option.Argument;
 import org.aesh.command.option.Option;
 import org.aesh.command.shell.Shell;
+import org.jboss.pnc.bacon.common.ObjectHelper;
 import org.jboss.pnc.bacon.common.cli.AbstractCommand;
 import org.jboss.pnc.bacon.common.cli.AbstractGetSpecificCommand;
 import org.jboss.pnc.bacon.common.cli.AbstractListCommand;
@@ -88,6 +89,8 @@ public class BuildCli extends AbstractCommand {
         private String timestampAlignment;
         @Option(name = "temporary-build", description = "Temporary build, default: false", defaultValue = "false")
         private String temporaryBuild;
+        @Option(shortName = 'o', overrideRequired = false, hasValue = false, description = "use json for output (default to yaml)")
+        private boolean jsonOutput = false;
 
         @Override
         public CommandResult execute(CommandInvocation commandInvocation) throws CommandException, InterruptedException {
@@ -99,7 +102,8 @@ public class BuildCli extends AbstractCommand {
             buildParams.setTemporaryBuild(Boolean.parseBoolean(temporaryBuild));
 
             return super.executeHelper(commandInvocation, () -> {
-                System.out.println(BuildConfigCli.getClientAuthenticated().trigger(buildConfigId, buildParams));
+                System.out.println(ObjectHelper.getOutputMapper(jsonOutput)
+                        .writeValueAsString(BuildConfigCli.getClientAuthenticated().trigger(buildConfigId, buildParams)));
             });
         }
     }

--- a/pnc/src/main/java/org/jboss/pnc/bacon/pnc/BuildConfigCli.java
+++ b/pnc/src/main/java/org/jboss/pnc/bacon/pnc/BuildConfigCli.java
@@ -92,6 +92,8 @@ public class BuildConfigCli extends AbstractCommand {
         private String productVersionId;
         @Option(name = "build-type", description = "Build Type. Options are: MVN,GRADLE. Default: MVN", defaultValue = "MVN")
         private String buildType;
+        @Option(shortName = 'o', overrideRequired = false, hasValue = false, description = "use json for output (default to yaml)")
+        private boolean jsonOutput = false;
 
         @Override
         public CommandResult execute(CommandInvocation commandInvocation) throws CommandException, InterruptedException {
@@ -107,7 +109,8 @@ public class BuildConfigCli extends AbstractCommand {
                 ObjectHelper.executeIfNotNull(productVersionId, () -> buildConfigurationBuilder
                         .productVersion(ProductVersionRef.refBuilder().id(productVersionId).build()));
 
-                System.out.println(getClientAuthenticated().createNew(buildConfigurationBuilder.build()));
+                System.out.println(ObjectHelper.getOutputMapper(jsonOutput)
+                        .writeValueAsString(getClientAuthenticated().createNew(buildConfigurationBuilder.build())));
             });
         }
 

--- a/pnc/src/main/java/org/jboss/pnc/bacon/pnc/BuildConfigCli.java
+++ b/pnc/src/main/java/org/jboss/pnc/bacon/pnc/BuildConfigCli.java
@@ -109,8 +109,7 @@ public class BuildConfigCli extends AbstractCommand {
                 ObjectHelper.executeIfNotNull(productVersionId, () -> buildConfigurationBuilder
                         .productVersion(ProductVersionRef.refBuilder().id(productVersionId).build()));
 
-                System.out.println(ObjectHelper.getOutputMapper(jsonOutput)
-                        .writeValueAsString(getClientAuthenticated().createNew(buildConfigurationBuilder.build())));
+                ObjectHelper.print(jsonOutput, getClientAuthenticated().createNew(buildConfigurationBuilder.build()));
             });
         }
 

--- a/pnc/src/main/java/org/jboss/pnc/bacon/pnc/GroupConfigCli.java
+++ b/pnc/src/main/java/org/jboss/pnc/bacon/pnc/GroupConfigCli.java
@@ -88,8 +88,7 @@ public class GroupConfigCli extends AbstractCommand {
                 ObjectHelper.executeIfNotNull(buildConfigurationIds,
                         () -> groupConfigurationBuilder.buildConfigs(addBuildConfigs(buildConfigurationIds)));
 
-                System.out.println(ObjectHelper.getOutputMapper(jsonOutput)
-                        .writeValueAsString(getClientAuthenticated().createNew(groupConfigurationBuilder.build())));
+                ObjectHelper.print(jsonOutput, getClientAuthenticated().createNew(groupConfigurationBuilder.build()));
             });
         }
     }

--- a/pnc/src/main/java/org/jboss/pnc/bacon/pnc/GroupConfigCli.java
+++ b/pnc/src/main/java/org/jboss/pnc/bacon/pnc/GroupConfigCli.java
@@ -38,7 +38,6 @@ import org.jboss.pnc.dto.GroupConfiguration;
 import org.jboss.pnc.dto.ProductVersionRef;
 
 import java.util.HashMap;
-import java.util.LinkedList;
 import java.util.Optional;
 
 @GroupCommandDefinition(name = "group-config", description = "Group configuration", groupCommands = {
@@ -73,6 +72,9 @@ public class GroupConfigCli extends AbstractCommand {
         @Option(name = "build-configuration-ids", description = "Build configuration ids in Group Config. Comma separated")
         private String buildConfigurationIds;
 
+        @Option(shortName = 'o', overrideRequired = false, hasValue = false, description = "use json for output (default to yaml)")
+        private boolean jsonOutput = false;
+
         @Override
         public CommandResult execute(CommandInvocation commandInvocation) throws CommandException, InterruptedException {
 
@@ -86,7 +88,8 @@ public class GroupConfigCli extends AbstractCommand {
                 ObjectHelper.executeIfNotNull(buildConfigurationIds,
                         () -> groupConfigurationBuilder.buildConfigs(addBuildConfigs(buildConfigurationIds)));
 
-                System.out.println(getClientAuthenticated().createNew(groupConfigurationBuilder.build()));
+                System.out.println(ObjectHelper.getOutputMapper(jsonOutput)
+                        .writeValueAsString(getClientAuthenticated().createNew(groupConfigurationBuilder.build())));
             });
         }
     }

--- a/pnc/src/main/java/org/jboss/pnc/bacon/pnc/ProductCli.java
+++ b/pnc/src/main/java/org/jboss/pnc/bacon/pnc/ProductCli.java
@@ -86,8 +86,7 @@ public class ProductCli extends AbstractCommand {
                 Product product = Product.builder().name(name).abbreviation(abbreviation).description(description)
                         .productCode(productCode).pgmSystemName(systemCode).build();
 
-                System.out.println(ObjectHelper.getOutputMapper(jsonOutput)
-                        .writeValueAsString(getClientAuthenticated().createNew(product)));
+                ObjectHelper.print(jsonOutput, getClientAuthenticated().createNew(product));
             });
         }
     }

--- a/pnc/src/main/java/org/jboss/pnc/bacon/pnc/ProductCli.java
+++ b/pnc/src/main/java/org/jboss/pnc/bacon/pnc/ProductCli.java
@@ -75,6 +75,9 @@ public class ProductCli extends AbstractCommand {
         @Option(name = "system-code", description = "The eventual code needed to integrate with external systems, portals, etc, i.e. jbosseap", defaultValue = "")
         private String systemCode;
 
+        @Option(shortName = 'o', overrideRequired = false, hasValue = false, description = "use json for output (default to yaml)")
+        private boolean jsonOutput = false;
+
         @Override
         public CommandResult execute(CommandInvocation commandInvocation) throws CommandException, InterruptedException {
 
@@ -83,7 +86,8 @@ public class ProductCli extends AbstractCommand {
                 Product product = Product.builder().name(name).abbreviation(abbreviation).description(description)
                         .productCode(productCode).pgmSystemName(systemCode).build();
 
-                System.out.println(getClientAuthenticated().createNew(product));
+                System.out.println(ObjectHelper.getOutputMapper(jsonOutput)
+                        .writeValueAsString(getClientAuthenticated().createNew(product)));
             });
         }
     }

--- a/pnc/src/main/java/org/jboss/pnc/bacon/pnc/ProductMilestoneCli.java
+++ b/pnc/src/main/java/org/jboss/pnc/bacon/pnc/ProductMilestoneCli.java
@@ -81,6 +81,8 @@ public class ProductMilestoneCli extends AbstractCommand {
         private String startDate;
         @Option(required = true, name = "end-date", description = "End date: Format: <yyyy>-<mm>-<dd>")
         private String endDate;
+        @Option(shortName = 'o', overrideRequired = false, hasValue = false, description = "use json for output (default to yaml)")
+        private boolean jsonOutput = false;
 
         @Override
         public CommandResult execute(CommandInvocation commandInvocation) throws CommandException, InterruptedException {
@@ -104,7 +106,8 @@ public class ProductMilestoneCli extends AbstractCommand {
                         .productVersion(productVersionRef).issueTrackerUrl(issueTrackerUrl).startingDate(startDateInstant)
                         .plannedEndDate(endDateInstant).build();
 
-                System.out.println(getClientAuthenticated().createNew(milestone));
+                System.out.println(ObjectHelper.getOutputMapper(jsonOutput)
+                        .writeValueAsString(getClientAuthenticated().createNew(milestone)));
             });
         }
     }

--- a/pnc/src/main/java/org/jboss/pnc/bacon/pnc/ProductMilestoneCli.java
+++ b/pnc/src/main/java/org/jboss/pnc/bacon/pnc/ProductMilestoneCli.java
@@ -106,8 +106,7 @@ public class ProductMilestoneCli extends AbstractCommand {
                         .productVersion(productVersionRef).issueTrackerUrl(issueTrackerUrl).startingDate(startDateInstant)
                         .plannedEndDate(endDateInstant).build();
 
-                System.out.println(ObjectHelper.getOutputMapper(jsonOutput)
-                        .writeValueAsString(getClientAuthenticated().createNew(milestone)));
+                ObjectHelper.print(jsonOutput, getClientAuthenticated().createNew(milestone));
             });
         }
     }

--- a/pnc/src/main/java/org/jboss/pnc/bacon/pnc/ProductReleaseCli.java
+++ b/pnc/src/main/java/org/jboss/pnc/bacon/pnc/ProductReleaseCli.java
@@ -73,6 +73,8 @@ public class ProductReleaseCli extends AbstractCommand {
         private String downloadUrl;
         @Option(name = "issue-tracker-url", description = "Link to issues fixed in this release")
         private String issueTrackerUrl;
+        @Option(shortName = 'o', overrideRequired = false, hasValue = false, description = "use json for output (default to yaml)")
+        private boolean jsonOutput = false;
 
         @Override
         public CommandResult execute(CommandInvocation commandInvocation) throws CommandException, InterruptedException {
@@ -97,7 +99,8 @@ public class ProductReleaseCli extends AbstractCommand {
                         .productVersion(productMilestone.getProductVersion()).supportLevel(SupportLevel.valueOf(supportLevel))
                         .downloadUrl(downloadUrl).issueTrackerUrl(issueTrackerUrl).build();
 
-                System.out.println(getClientAuthenticated().createNew(productRelease));
+                System.out.println(ObjectHelper.getOutputMapper(jsonOutput)
+                        .writeValueAsString(getClientAuthenticated().createNew(productRelease)));
             });
         }
     }
@@ -163,14 +166,16 @@ public class ProductReleaseCli extends AbstractCommand {
     @CommandDefinition(name = "list-support-levels", description = "List supported levels")
     public class ListSupportLevel extends AbstractCommand {
 
+        @Option(shortName = 'o', overrideRequired = false, hasValue = false, description = "use json for output (default to yaml)")
+        private boolean jsonOutput = false;
+
         @Override
         public CommandResult execute(CommandInvocation commandInvocation) throws CommandException, InterruptedException {
 
             return super.executeHelper(commandInvocation, () -> {
-                // TODO: YAML or JSON format?
-                for (SupportLevel supportLevel : getClient().getAllSupportLevel()) {
-                    System.out.println(supportLevel);
-                }
+                System.out
+                        .println(ObjectHelper.getOutputMapper(jsonOutput).writeValueAsString(getClient().getAllSupportLevel()));
+
             });
         }
     }

--- a/pnc/src/main/java/org/jboss/pnc/bacon/pnc/ProductReleaseCli.java
+++ b/pnc/src/main/java/org/jboss/pnc/bacon/pnc/ProductReleaseCli.java
@@ -99,8 +99,7 @@ public class ProductReleaseCli extends AbstractCommand {
                         .productVersion(productMilestone.getProductVersion()).supportLevel(SupportLevel.valueOf(supportLevel))
                         .downloadUrl(downloadUrl).issueTrackerUrl(issueTrackerUrl).build();
 
-                System.out.println(ObjectHelper.getOutputMapper(jsonOutput)
-                        .writeValueAsString(getClientAuthenticated().createNew(productRelease)));
+                ObjectHelper.print(jsonOutput, getClientAuthenticated().createNew(productRelease));
             });
         }
     }
@@ -173,8 +172,7 @@ public class ProductReleaseCli extends AbstractCommand {
         public CommandResult execute(CommandInvocation commandInvocation) throws CommandException, InterruptedException {
 
             return super.executeHelper(commandInvocation, () -> {
-                System.out
-                        .println(ObjectHelper.getOutputMapper(jsonOutput).writeValueAsString(getClient().getAllSupportLevel()));
+                ObjectHelper.print(jsonOutput, getClient().getAllSupportLevel());
 
             });
         }

--- a/pnc/src/main/java/org/jboss/pnc/bacon/pnc/ProductVersionCli.java
+++ b/pnc/src/main/java/org/jboss/pnc/bacon/pnc/ProductVersionCli.java
@@ -94,8 +94,7 @@ public class ProductVersionCli extends AbstractCommand {
                 ProductVersion productVersion = ProductVersion.builder().product(productRef).version(this.productVersion)
                         .build();
 
-                System.out.println(ObjectHelper.getOutputMapper(jsonOutput)
-                        .writeValueAsString(getClientAuthenticated().createNew(productVersion)));
+                ObjectHelper.print(jsonOutput, getClientAuthenticated().createNew(productVersion));
             });
         }
     }

--- a/pnc/src/main/java/org/jboss/pnc/bacon/pnc/ProductVersionCli.java
+++ b/pnc/src/main/java/org/jboss/pnc/bacon/pnc/ProductVersionCli.java
@@ -76,6 +76,8 @@ public class ProductVersionCli extends AbstractCommand {
         private String productVersion;
         @Option(required = true, name = "product-id", description = "Product ID of product version")
         private String productId;
+        @Option(shortName = 'o', overrideRequired = false, hasValue = false, description = "use json for output (default to yaml)")
+        private boolean jsonOutput = false;
 
         @Override
         public CommandResult execute(CommandInvocation commandInvocation) throws CommandException, InterruptedException {
@@ -92,7 +94,8 @@ public class ProductVersionCli extends AbstractCommand {
                 ProductVersion productVersion = ProductVersion.builder().product(productRef).version(this.productVersion)
                         .build();
 
-                System.out.println(getClientAuthenticated().createNew(productVersion));
+                System.out.println(ObjectHelper.getOutputMapper(jsonOutput)
+                        .writeValueAsString(getClientAuthenticated().createNew(productVersion)));
             });
         }
     }

--- a/pnc/src/main/java/org/jboss/pnc/bacon/pnc/ProjectCli.java
+++ b/pnc/src/main/java/org/jboss/pnc/bacon/pnc/ProjectCli.java
@@ -71,6 +71,8 @@ public class ProjectCli extends AbstractCommand {
         private String projectUrl;
         @Option(name = "issue-tracker-url", description = "Issue-Tracker-URL of project", defaultValue = "")
         private String issueTrackerUrl;
+        @Option(shortName = 'o', overrideRequired = false, hasValue = false, description = "use json for output (default to yaml)")
+        private boolean jsonOutput = false;
 
         @Override
         public CommandResult execute(CommandInvocation commandInvocation) throws CommandException, InterruptedException {
@@ -80,7 +82,8 @@ public class ProjectCli extends AbstractCommand {
                 Project project = Project.builder().name(name).description(description).projectUrl(projectUrl)
                         .issueTrackerUrl(issueTrackerUrl).build();
 
-                System.out.println(getClientAuthenticated().createNew(project));
+                System.out.println(ObjectHelper.getOutputMapper(jsonOutput)
+                        .writeValueAsString(getClientAuthenticated().createNew(project)));
             });
         }
     }

--- a/pnc/src/main/java/org/jboss/pnc/bacon/pnc/ProjectCli.java
+++ b/pnc/src/main/java/org/jboss/pnc/bacon/pnc/ProjectCli.java
@@ -82,8 +82,7 @@ public class ProjectCli extends AbstractCommand {
                 Project project = Project.builder().name(name).description(description).projectUrl(projectUrl)
                         .issueTrackerUrl(issueTrackerUrl).build();
 
-                System.out.println(ObjectHelper.getOutputMapper(jsonOutput)
-                        .writeValueAsString(getClientAuthenticated().createNew(project)));
+                ObjectHelper.print(jsonOutput, getClientAuthenticated().createNew(project));
             });
         }
     }

--- a/pnc/src/main/java/org/jboss/pnc/bacon/pnc/ScmRepositoryCli.java
+++ b/pnc/src/main/java/org/jboss/pnc/bacon/pnc/ScmRepositoryCli.java
@@ -79,8 +79,7 @@ public class ScmRepositoryCli extends AbstractCommand {
                 CreateAndSyncSCMRequest createAndSyncSCMRequest = CreateAndSyncSCMRequest.builder()
                         .preBuildSyncEnabled(Boolean.valueOf(preBuildSync)).scmUrl(scmUrl).build();
 
-                System.out.println(ObjectHelper.getOutputMapper(jsonOutput)
-                        .writeValueAsString(getClientAuthenticated().createNew(createAndSyncSCMRequest)));
+                ObjectHelper.print(jsonOutput, getClientAuthenticated().createNew(createAndSyncSCMRequest));
             });
         }
     }

--- a/pnc/src/main/java/org/jboss/pnc/bacon/pnc/ScmRepositoryCli.java
+++ b/pnc/src/main/java/org/jboss/pnc/bacon/pnc/ScmRepositoryCli.java
@@ -24,6 +24,7 @@ import org.aesh.command.GroupCommandDefinition;
 import org.aesh.command.invocation.CommandInvocation;
 import org.aesh.command.option.Argument;
 import org.aesh.command.option.Option;
+import org.jboss.pnc.bacon.common.ObjectHelper;
 import org.jboss.pnc.bacon.common.cli.AbstractCommand;
 import org.jboss.pnc.bacon.common.cli.AbstractGetSpecificCommand;
 import org.jboss.pnc.bacon.common.cli.AbstractListCommand;
@@ -68,6 +69,9 @@ public class ScmRepositoryCli extends AbstractCommand {
         @Option(name = "pre-build-sync", description = "Pre-build-sync feature: Default: true", defaultValue = "true")
         private String preBuildSync;
 
+        @Option(shortName = 'o', overrideRequired = false, hasValue = false, description = "use json for output (default to yaml)")
+        private boolean jsonOutput = false;
+
         @Override
         public CommandResult execute(CommandInvocation commandInvocation) throws CommandException, InterruptedException {
 
@@ -75,7 +79,8 @@ public class ScmRepositoryCli extends AbstractCommand {
                 CreateAndSyncSCMRequest createAndSyncSCMRequest = CreateAndSyncSCMRequest.builder()
                         .preBuildSyncEnabled(Boolean.valueOf(preBuildSync)).scmUrl(scmUrl).build();
 
-                System.out.println(getClientAuthenticated().createNew(createAndSyncSCMRequest));
+                System.out.println(ObjectHelper.getOutputMapper(jsonOutput)
+                        .writeValueAsString(getClientAuthenticated().createNew(createAndSyncSCMRequest)));
             });
         }
     }


### PR DESCRIPTION
Commit changes default output for commands with relevant info to yaml, using `-o/--jsonOutput `output could be changed to json format.