### PR TITLE
[NCL-5452] Allow user to specify verbosity

### DIFF
--- a/cli/src/main/resources/logback-test.xml
+++ b/cli/src/main/resources/logback-test.xml
@@ -61,7 +61,7 @@
     <logger name="org.infinispan" level="WARN"/>
     <!-- from koji-build-finder -->
 
-    <root level="debug">
+    <root level="info">
         <appender-ref ref="STDERR"/>
     </root>
 </configuration>

--- a/common/pom.xml
+++ b/common/pom.xml
@@ -33,6 +33,10 @@
             <artifactId>slf4j-api</artifactId>
         </dependency>
         <dependency>
+            <groupId>ch.qos.logback</groupId>
+            <artifactId>logback-classic</artifactId>
+        </dependency>
+        <dependency>
             <groupId>org.jboss.pnc</groupId>
             <artifactId>rest-client</artifactId>
         </dependency>

--- a/common/src/main/java/org/jboss/pnc/bacon/common/ObjectHelper.java
+++ b/common/src/main/java/org/jboss/pnc/bacon/common/ObjectHelper.java
@@ -1,10 +1,23 @@
 package org.jboss.pnc.bacon.common;
 
+import ch.qos.logback.classic.Level;
+
 public class ObjectHelper {
 
     public static void executeIfNotNull(Object value, Runnable run) {
         if (value != null) {
             run.run();
         }
+    }
+
+    public static void setRootLoggingLevel(Level level) {
+        ch.qos.logback.classic.Logger root = (ch.qos.logback.classic.Logger) org.slf4j.LoggerFactory
+                .getLogger(ch.qos.logback.classic.Logger.ROOT_LOGGER_NAME);
+        root.setLevel(level);
+    }
+
+    public static void setLoggingLevel(String loggerName, Level level) {
+        ch.qos.logback.classic.Logger logger = (ch.qos.logback.classic.Logger) org.slf4j.LoggerFactory.getLogger(loggerName);
+        logger.setLevel(level);
     }
 }

--- a/common/src/main/java/org/jboss/pnc/bacon/common/cli/AbstractCommand.java
+++ b/common/src/main/java/org/jboss/pnc/bacon/common/cli/AbstractCommand.java
@@ -17,6 +17,7 @@
  */
 package org.jboss.pnc.bacon.common.cli;
 
+import ch.qos.logback.classic.Level;
 import lombok.extern.slf4j.Slf4j;
 import org.aesh.command.Command;
 import org.aesh.command.CommandException;
@@ -25,6 +26,7 @@ import org.aesh.command.GroupCommandDefinition;
 import org.aesh.command.invocation.CommandInvocation;
 import org.aesh.command.option.Option;
 import org.aesh.command.shell.Shell;
+import org.jboss.pnc.bacon.common.ObjectHelper;
 import org.jboss.pnc.client.ClientException;
 
 /**
@@ -47,6 +49,9 @@ public class AbstractCommand implements Command {
 
     @Option(shortName = 'V', overrideRequired = true, hasValue = false, description = "print version")
     private boolean version = false;
+
+    @Option(shortName = 'v', overrideRequired = true, hasValue = false, description = "Verbose output")
+    private boolean verbose = false;
 
     public boolean printHelpOrVersionIfPresent(CommandInvocation commandInvocation) {
 
@@ -71,6 +76,22 @@ public class AbstractCommand implements Command {
         }
 
         return activated;
+    }
+
+    /**
+     * Set the verbosity of logback if the verbosity flag is set
+     *
+     */
+    private void setVerbosityIfPresent() {
+
+        if (verbose) {
+            ObjectHelper.setRootLoggingLevel(Level.DEBUG);
+
+            // Add more loggers that you want to switch to DEBUG here
+            ObjectHelper.setLoggingLevel("org.jboss.pnc.client", Level.DEBUG);
+
+            log.debug("Log level set to DEBUG");
+        }
     }
 
     /**
@@ -118,6 +139,9 @@ public class AbstractCommand implements Command {
      * @throws InterruptedException
      */
     private CommandResult executePrivate(CommandInvocation commandInvocation) {
+
+        setVerbosityIfPresent();
+
         boolean helpNoFinalCommandPrinted = false;
         boolean helpOrVersionPrinted = printHelpOrVersionIfPresent(commandInvocation);
 


### PR DESCRIPTION
This commit add the '-v' or '--verbose' flag to `AbstractCommand` to allow the
user to specify the desired verbosity of the output. The verbose flag
should therefore be available to all the commands.

All the log output is printed to stderr, as before. This is so that
users who want to consume the stdout output into a file (or pipe it)
doesn't also get the log data.

Example:
```
\# Piping stdout to /dev/null to hide output
$ java -jar cli/target/bacon.jar pnc product list > /dev/null

\# Verbose flag used
$ java -jar cli/target/bacon.jar pnc product list --verbose > /dev/null
[DEBUG] - Log level set to DEBUG
[INFO ] - Bootstrapping http engine with request retry handler...
[DEBUG] - Requesting: GET http://<url>/pnc-rest-new/rest-new/generic-setting/announcement-banner Headers: Accept:[application/json].
[INFO ] - Bootstrapping http engine with request retry handler...
[DEBUG] - Loading first page.
[DEBUG] - Requesting: GET http://<url>/pnc-rest-new/rest-new/products?pageSize=50&pageIndex=0 Headers: Accept:[application/json].
```