### PR TITLE
[NCL-5465] Edit error messages to more elegant and user friendly format

### DIFF
--- a/auth/src/main/java/org/jboss/pnc/bacon/auth/DirectKeycloakClientImpl.java
+++ b/auth/src/main/java/org/jboss/pnc/bacon/auth/DirectKeycloakClientImpl.java
@@ -137,7 +137,7 @@ public class DirectKeycloakClientImpl implements KeycloakClient {
                     .refreshTokenExpiresIn(now.plusSeconds(response.getRefreshExpiresIn())).build();
 
         } catch (Exception e) {
-            e.printStackTrace();
+            log.error(e.getMessage());
             return null;
         }
     }

--- a/auth/src/main/java/org/jboss/pnc/bacon/auth/model/CacheFile.java
+++ b/auth/src/main/java/org/jboss/pnc/bacon/auth/model/CacheFile.java
@@ -48,7 +48,7 @@ public class CacheFile {
             mapper.writeValue(new File(CACHE_FILE), cacheFile);
             setOwnerFilePermissions(CACHE_FILE);
         } catch (Exception e) {
-            e.printStackTrace();
+            log.error(e.getMessage());
         }
     }
 
@@ -69,7 +69,7 @@ public class CacheFile {
                 return Optional.empty();
             }
         } catch (Exception e) {
-            e.printStackTrace();
+            log.error(e.getMessage());
             return Optional.empty();
         }
     }

--- a/common/src/main/java/org/jboss/pnc/bacon/common/cli/AbstractCommand.java
+++ b/common/src/main/java/org/jboss/pnc/bacon/common/cli/AbstractCommand.java
@@ -170,7 +170,7 @@ public class AbstractCommand implements Command {
         try {
             callback.call();
         } catch (Exception e) {
-            log.error("Something wrong happened", e);
+            log.error("Something wrong happened: {}", e.getMessage());
             return CommandResult.FAILURE;
         }
         return CommandResult.SUCCESS;

--- a/common/src/main/java/org/jboss/pnc/bacon/common/cli/VersionInfo.java
+++ b/common/src/main/java/org/jboss/pnc/bacon/common/cli/VersionInfo.java
@@ -40,7 +40,7 @@ public class VersionInfo {
                 log.warn("Incomplete manifest file, missing version.");
             }
         } catch (IOException e) {
-            log.warn("Cannot read manifest file.", e);
+            log.warn("Cannot read manifest file. {}", e.getMessage());
         }
     }
 

--- a/config/src/main/java/org/jboss/pnc/bacon/config/Config.java
+++ b/config/src/main/java/org/jboss/pnc/bacon/config/Config.java
@@ -65,10 +65,8 @@ public class Config {
     public static void initialize() throws IOException {
         File configFile = new File(configLocation);
         if (!configFile.exists()) {
-            log.error(
-                    "Config file: '{}' does not exist. Please create a config file and either name it 'config.yaml' and put it in the working directory or specify it with -Dconfig",
-                    configLocation);
-            throw new IOException("Config file " + configLocation + " does not exist!");
+            throw new IOException("Config file " + configLocation
+                    + " does not exist! Please create a config file and either name it 'config.yaml' and put it in the working directory or specify it with -Dconfig");
         } else if (configFile.length() == 0) {
             log.warn("Config file: {} has no content", configLocation);
             instance = new Config();


### PR DESCRIPTION
Mainly made sure errors are logged and displayed without stacktrace for pnc commands, I also went through pig to be sure nothing is just printed out, didn't remove logging of stacktrace  (don't know if it can be helpful for user in pig, open to suggestions)