### PR TITLE
[NCL-5509] Fix Authentication broken in multicall commands

### DIFF
--- a/pnc/src/main/java/org/jboss/pnc/bacon/pnc/ArtifactCli.java
+++ b/pnc/src/main/java/org/jboss/pnc/bacon/pnc/ArtifactCli.java
@@ -10,7 +10,7 @@ import org.aesh.command.option.Option;
 import org.jboss.pnc.bacon.common.ObjectHelper;
 import org.jboss.pnc.bacon.common.cli.AbstractCommand;
 import org.jboss.pnc.bacon.common.cli.AbstractGetSpecificCommand;
-import org.jboss.pnc.bacon.pnc.client.PncClientHelper;
+import org.jboss.pnc.bacon.pnc.common.ClientCreator;
 import org.jboss.pnc.client.ArtifactClient;
 import org.jboss.pnc.client.ClientException;
 import org.jboss.pnc.dto.Artifact;
@@ -20,21 +20,14 @@ import org.jboss.pnc.dto.Artifact;
         ArtifactCli.ListFromHash.class })
 public class ArtifactCli extends AbstractCommand {
 
-    private static ArtifactClient clientCache;
-
-    private static ArtifactClient getClient() {
-        if (clientCache == null) {
-            clientCache = new ArtifactClient(PncClientHelper.getPncConfiguration(false));
-        }
-        return clientCache;
-    }
+    private static final ClientCreator<ArtifactClient> CREATOR = new ClientCreator<>(ArtifactClient::new);
 
     @CommandDefinition(name = "get", description = "Get artifact")
     public class Get extends AbstractGetSpecificCommand<Artifact> {
 
         @Override
         public Artifact getSpecific(String id) throws ClientException {
-            return getClient().getSpecific(id);
+            return CREATOR.getClient().getSpecific(id);
         }
     }
 
@@ -61,7 +54,7 @@ public class ArtifactCli extends AbstractCommand {
                 if (md5 == null && sha1 == null && sha256 == null) {
                     log.error("You need to use at least one hash option!");
                 } else {
-                    ObjectHelper.print(jsonOutput, getClient().getAll(sha256, md5, sha1));
+                    ObjectHelper.print(jsonOutput, CREATOR.getClient().getAll(sha256, md5, sha1));
                 }
             });
         }

--- a/pnc/src/main/java/org/jboss/pnc/bacon/pnc/BrewPushCli.java
+++ b/pnc/src/main/java/org/jboss/pnc/bacon/pnc/BrewPushCli.java
@@ -26,7 +26,7 @@ import org.aesh.command.option.Argument;
 import org.aesh.command.option.Option;
 import org.jboss.pnc.bacon.common.ObjectHelper;
 import org.jboss.pnc.bacon.common.cli.AbstractCommand;
-import org.jboss.pnc.bacon.pnc.client.PncClientHelper;
+import org.jboss.pnc.bacon.pnc.common.ClientCreator;
 import org.jboss.pnc.client.BuildClient;
 import org.jboss.pnc.client.GroupBuildClient;
 import org.jboss.pnc.dto.requests.BuildPushRequest;
@@ -35,6 +35,9 @@ import org.jboss.pnc.dto.requests.GroupBuildPushRequest;
 @GroupCommandDefinition(name = "brew-push", description = "brew-push", groupCommands = { BrewPushCli.Build.class,
         BrewPushCli.GroupBuild.class, BrewPushCli.Status.class, })
 public class BrewPushCli extends AbstractCommand {
+
+    private static final ClientCreator<BuildClient> BUILD_CREATOR = new ClientCreator<>(BuildClient::new);
+    private static final ClientCreator<GroupBuildClient> GROUP_BUILD_CREATOR = new ClientCreator<>(GroupBuildClient::new);
 
     @CommandDefinition(name = "build", description = "Push build to Brew")
     public class Build extends AbstractCommand {
@@ -55,12 +58,10 @@ public class BrewPushCli extends AbstractCommand {
 
             return super.executeHelper(commandInvocation, () -> {
 
-                BuildClient client = new BuildClient(PncClientHelper.getPncConfiguration(true));
-
                 BuildPushRequest request = BuildPushRequest.builder().tagPrefix(tagPrefix).reimport(Boolean.valueOf(reimport))
                         .build();
 
-                ObjectHelper.print(jsonOutput, client.push(id, request));
+                ObjectHelper.print(jsonOutput, BUILD_CREATOR.getClientAuthenticated().push(id, request));
             });
         }
 
@@ -83,11 +84,8 @@ public class BrewPushCli extends AbstractCommand {
 
             return super.executeHelper(commandInvocation, () -> {
 
-                GroupBuildClient client = new GroupBuildClient(PncClientHelper.getPncConfiguration(true));
-
                 GroupBuildPushRequest request = GroupBuildPushRequest.builder().tagPrefix(tagPrefix).build();
-
-                client.brewPush(id, request);
+                GROUP_BUILD_CREATOR.getClientAuthenticated().brewPush(id, request);
             });
         }
 
@@ -111,9 +109,7 @@ public class BrewPushCli extends AbstractCommand {
 
             return super.executeHelper(commandInvocation, () -> {
 
-                BuildClient client = new BuildClient(PncClientHelper.getPncConfiguration(false));
-
-                ObjectHelper.print(jsonOutput, client.getPushResult(id));
+                ObjectHelper.print(jsonOutput, BUILD_CREATOR.getClient().getPushResult(id));
             });
         }
     }

--- a/pnc/src/main/java/org/jboss/pnc/bacon/pnc/BuildCli.java
+++ b/pnc/src/main/java/org/jboss/pnc/bacon/pnc/BuildCli.java
@@ -32,11 +32,8 @@ import org.jboss.pnc.bacon.common.cli.AbstractGetSpecificCommand;
 import org.jboss.pnc.bacon.common.cli.AbstractListCommand;
 import org.jboss.pnc.bacon.config.Config;
 import org.jboss.pnc.bacon.pnc.client.BifrostClient;
-import org.jboss.pnc.bacon.pnc.client.PncClientHelper;
-import org.jboss.pnc.client.BuildClient;
-import org.jboss.pnc.client.ClientException;
-import org.jboss.pnc.client.RemoteCollection;
-import org.jboss.pnc.client.RemoteResourceException;
+import org.jboss.pnc.bacon.pnc.common.ClientCreator;
+import org.jboss.pnc.client.*;
 import org.jboss.pnc.dto.Artifact;
 import org.jboss.pnc.dto.Build;
 import org.jboss.pnc.enums.RebuildMode;
@@ -59,21 +56,9 @@ import java.util.Optional;
 @Slf4j
 public class BuildCli extends AbstractCommand {
 
-    private static BuildClient clientCache;
-
-    private static BuildClient getClient() {
-        if (clientCache == null) {
-            clientCache = new BuildClient(PncClientHelper.getPncConfiguration(false));
-        }
-        return clientCache;
-    }
-
-    private static BuildClient getClientAuthenticated() {
-        if (clientCache == null) {
-            clientCache = new BuildClient(PncClientHelper.getPncConfiguration(true));
-        }
-        return clientCache;
-    }
+    private static final ClientCreator<BuildClient> CREATOR = new ClientCreator<>(BuildClient::new);
+    private static final ClientCreator<BuildConfigurationClient> BC_CREATOR = new ClientCreator<>(
+            BuildConfigurationClient::new);
 
     @CommandDefinition(name = "start", description = "Start a new build")
     public class Start extends AbstractCommand {
@@ -102,7 +87,7 @@ public class BuildCli extends AbstractCommand {
             buildParams.setTemporaryBuild(Boolean.parseBoolean(temporaryBuild));
 
             return super.executeHelper(commandInvocation, () -> {
-                ObjectHelper.print(jsonOutput, BuildConfigCli.getClientAuthenticated().trigger(buildConfigId, buildParams));
+                ObjectHelper.print(jsonOutput, BC_CREATOR.getClientAuthenticated().trigger(buildConfigId, buildParams));
             });
         }
     }
@@ -117,7 +102,7 @@ public class BuildCli extends AbstractCommand {
         public CommandResult execute(CommandInvocation commandInvocation) throws CommandException, InterruptedException {
 
             return super.executeHelper(commandInvocation, () -> {
-                getClientAuthenticated().cancel(buildId);
+                CREATOR.getClientAuthenticated().cancel(buildId);
             });
         }
     }
@@ -127,7 +112,7 @@ public class BuildCli extends AbstractCommand {
 
         @Override
         public RemoteCollection<Build> getAll(String sort, String query) throws RemoteResourceException {
-            return getClient().getAll(null, null, Optional.ofNullable(sort), Optional.ofNullable(query));
+            return CREATOR.getClient().getAll(null, null, Optional.ofNullable(sort), Optional.ofNullable(query));
         }
     }
 
@@ -139,7 +124,7 @@ public class BuildCli extends AbstractCommand {
 
         @Override
         public RemoteCollection<Artifact> getAll(String sort, String query) throws RemoteResourceException {
-            return getClient().getBuiltArtifacts(buildId, Optional.ofNullable(sort), Optional.ofNullable(query));
+            return CREATOR.getClient().getBuiltArtifacts(buildId, Optional.ofNullable(sort), Optional.ofNullable(query));
         }
     }
 
@@ -151,7 +136,7 @@ public class BuildCli extends AbstractCommand {
 
         @Override
         public RemoteCollection<Artifact> getAll(String sort, String query) throws RemoteResourceException {
-            return getClient().getDependencyArtifacts(buildId, Optional.ofNullable(sort), Optional.ofNullable(query));
+            return CREATOR.getClient().getDependencyArtifacts(buildId, Optional.ofNullable(sort), Optional.ofNullable(query));
         }
     }
 
@@ -160,7 +145,7 @@ public class BuildCli extends AbstractCommand {
 
         @Override
         public Build getSpecific(String id) throws ClientException {
-            return getClient().getSpecific(id);
+            return CREATOR.getClient().getSpecific(id);
         }
     }
 
@@ -181,7 +166,7 @@ public class BuildCli extends AbstractCommand {
             try {
                 Optional<InputStream> buildLogs;
                 try {
-                    buildLogs = getClient().getBuildLogs(buildId);
+                    buildLogs = CREATOR.getClient().getBuildLogs(buildId);
                 } catch (Exception e) {
                     e.printStackTrace(); // TODO, client should return Optional.empty not throw the exception (NCL-5348)
                     buildLogs = Optional.empty();
@@ -221,7 +206,7 @@ public class BuildCli extends AbstractCommand {
 
                 String filename = id + "-sources.tar.gz";
 
-                Response response = getClient().getInternalScmArchiveLink(id);
+                Response response = CREATOR.getClient().getInternalScmArchiveLink(id);
 
                 InputStream in = (InputStream) response.getEntity();
 

--- a/pnc/src/main/java/org/jboss/pnc/bacon/pnc/EnvironmentCli.java
+++ b/pnc/src/main/java/org/jboss/pnc/bacon/pnc/EnvironmentCli.java
@@ -22,7 +22,7 @@ import org.aesh.command.GroupCommandDefinition;
 import org.jboss.pnc.bacon.common.cli.AbstractCommand;
 import org.jboss.pnc.bacon.common.cli.AbstractGetSpecificCommand;
 import org.jboss.pnc.bacon.common.cli.AbstractListCommand;
-import org.jboss.pnc.bacon.pnc.client.PncClientHelper;
+import org.jboss.pnc.bacon.pnc.common.ClientCreator;
 import org.jboss.pnc.client.ClientException;
 import org.jboss.pnc.client.EnvironmentClient;
 import org.jboss.pnc.client.RemoteCollection;
@@ -35,21 +35,14 @@ import java.util.Optional;
         EnvironmentCli.List.class })
 public class EnvironmentCli extends AbstractCommand {
 
-    private static EnvironmentClient clientCache;
-
-    private static EnvironmentClient getClient() {
-        if (clientCache == null) {
-            clientCache = new EnvironmentClient(PncClientHelper.getPncConfiguration(false));
-        }
-        return clientCache;
-    }
+    private static final ClientCreator<EnvironmentClient> CREATOR = new ClientCreator<>(EnvironmentClient::new);
 
     @CommandDefinition(name = "get", description = "Get environment")
     public class Get extends AbstractGetSpecificCommand<Environment> {
 
         @Override
         public Environment getSpecific(String id) throws ClientException {
-            return getClient().getSpecific(id);
+            return CREATOR.getClient().getSpecific(id);
         }
     }
 
@@ -58,7 +51,7 @@ public class EnvironmentCli extends AbstractCommand {
 
         @Override
         public RemoteCollection<Environment> getAll(String sort, String query) throws RemoteResourceException {
-            return getClient().getAll(Optional.ofNullable(sort), Optional.ofNullable(query));
+            return CREATOR.getClient().getAll(Optional.ofNullable(sort), Optional.ofNullable(query));
         }
     }
 

--- a/pnc/src/main/java/org/jboss/pnc/bacon/pnc/GroupBuildCli.java
+++ b/pnc/src/main/java/org/jboss/pnc/bacon/pnc/GroupBuildCli.java
@@ -26,7 +26,7 @@ import org.aesh.command.option.Argument;
 import org.jboss.pnc.bacon.common.cli.AbstractCommand;
 import org.jboss.pnc.bacon.common.cli.AbstractGetSpecificCommand;
 import org.jboss.pnc.bacon.common.cli.AbstractListCommand;
-import org.jboss.pnc.bacon.pnc.client.PncClientHelper;
+import org.jboss.pnc.bacon.pnc.common.ClientCreator;
 import org.jboss.pnc.client.ClientException;
 import org.jboss.pnc.client.GroupBuildClient;
 import org.jboss.pnc.client.RemoteCollection;
@@ -40,21 +40,7 @@ import java.util.Optional;
         GroupBuildCli.List.class, GroupBuildCli.ListBuilds.class, GroupBuildCli.Get.class })
 public class GroupBuildCli extends AbstractCommand {
 
-    private static GroupBuildClient clientCache;
-
-    private static GroupBuildClient getClient() {
-        if (clientCache == null) {
-            clientCache = new GroupBuildClient(PncClientHelper.getPncConfiguration(false));
-        }
-        return clientCache;
-    }
-
-    private static GroupBuildClient getClientAuthenticated() {
-        if (clientCache == null) {
-            clientCache = new GroupBuildClient(PncClientHelper.getPncConfiguration(true));
-        }
-        return clientCache;
-    }
+    private static final ClientCreator<GroupBuildClient> CREATOR = new ClientCreator<>(GroupBuildClient::new);
 
     @CommandDefinition(name = "cancel", description = "Cancel a group build")
     public class Cancel extends AbstractCommand {
@@ -66,7 +52,7 @@ public class GroupBuildCli extends AbstractCommand {
         public CommandResult execute(CommandInvocation commandInvocation) throws CommandException, InterruptedException {
 
             return super.executeHelper(commandInvocation, () -> {
-                getClientAuthenticated().cancel(groupBuildId);
+                CREATOR.getClientAuthenticated().cancel(groupBuildId);
             });
         }
     }
@@ -76,7 +62,7 @@ public class GroupBuildCli extends AbstractCommand {
 
         @Override
         public RemoteCollection<GroupBuild> getAll(String sort, String query) throws RemoteResourceException {
-            return getClient().getAll(Optional.ofNullable(sort), Optional.ofNullable(query));
+            return CREATOR.getClient().getAll(Optional.ofNullable(sort), Optional.ofNullable(query));
         }
     }
 
@@ -88,7 +74,7 @@ public class GroupBuildCli extends AbstractCommand {
 
         @Override
         public RemoteCollection<Build> getAll(String sort, String query) throws RemoteResourceException {
-            return getClient().getBuilds(groupBuildId, null, Optional.ofNullable(sort), Optional.ofNullable(query));
+            return CREATOR.getClient().getBuilds(groupBuildId, null, Optional.ofNullable(sort), Optional.ofNullable(query));
         }
     }
 
@@ -97,7 +83,7 @@ public class GroupBuildCli extends AbstractCommand {
 
         @Override
         public GroupBuild getSpecific(String id) throws ClientException {
-            return getClient().getSpecific(id);
+            return CREATOR.getClient().getSpecific(id);
         }
     }
 }

--- a/pnc/src/main/java/org/jboss/pnc/bacon/pnc/ProductVersionCli.java
+++ b/pnc/src/main/java/org/jboss/pnc/bacon/pnc/ProductVersionCli.java
@@ -30,7 +30,7 @@ import org.jboss.pnc.bacon.common.ObjectHelper;
 import org.jboss.pnc.bacon.common.cli.AbstractCommand;
 import org.jboss.pnc.bacon.common.cli.AbstractGetSpecificCommand;
 import org.jboss.pnc.bacon.common.cli.AbstractListCommand;
-import org.jboss.pnc.bacon.pnc.client.PncClientHelper;
+import org.jboss.pnc.bacon.pnc.common.ClientCreator;
 import org.jboss.pnc.client.ClientException;
 import org.jboss.pnc.client.ProductVersionClient;
 import org.jboss.pnc.client.RemoteCollection;
@@ -51,23 +51,7 @@ import java.util.Optional;
 @Slf4j
 public class ProductVersionCli extends AbstractCommand {
 
-    private static ProductVersionClient clientCache;
-
-    private static ProductVersionClient getClient() {
-
-        if (clientCache == null) {
-            clientCache = new ProductVersionClient(PncClientHelper.getPncConfiguration(false));
-        }
-        return clientCache;
-    }
-
-    private static ProductVersionClient getClientAuthenticated() {
-
-        if (clientCache == null) {
-            clientCache = new ProductVersionClient(PncClientHelper.getPncConfiguration(true));
-        }
-        return clientCache;
-    }
+    private static final ClientCreator<ProductVersionClient> CREATOR = new ClientCreator<>(ProductVersionClient::new);
 
     @CommandDefinition(name = "create", description = "Create a product version")
     public class Create extends AbstractCommand {
@@ -94,7 +78,7 @@ public class ProductVersionCli extends AbstractCommand {
                 ProductVersion productVersion = ProductVersion.builder().product(productRef).version(this.productVersion)
                         .build();
 
-                ObjectHelper.print(jsonOutput, getClientAuthenticated().createNew(productVersion));
+                ObjectHelper.print(jsonOutput, CREATOR.getClientAuthenticated().createNew(productVersion));
             });
         }
     }
@@ -104,7 +88,7 @@ public class ProductVersionCli extends AbstractCommand {
 
         @Override
         public ProductVersion getSpecific(String id) throws ClientException {
-            return getClient().getSpecific(id);
+            return CREATOR.getClient().getSpecific(id);
         }
     }
 
@@ -117,7 +101,7 @@ public class ProductVersionCli extends AbstractCommand {
         @Override
         public RemoteCollection<BuildConfiguration> getAll(String sort, String query) throws RemoteResourceException {
 
-            return getClient().getBuildConfigurations(id, Optional.ofNullable(sort), Optional.ofNullable(query));
+            return CREATOR.getClient().getBuildConfigurations(id, Optional.ofNullable(sort), Optional.ofNullable(query));
         }
     }
 
@@ -130,7 +114,7 @@ public class ProductVersionCli extends AbstractCommand {
         @Override
         public RemoteCollection<GroupConfiguration> getAll(String sort, String query) throws RemoteResourceException {
 
-            return getClient().getGroupConfigurations(id, Optional.ofNullable(sort), Optional.ofNullable(query));
+            return CREATOR.getClient().getGroupConfigurations(id, Optional.ofNullable(sort), Optional.ofNullable(query));
         }
     }
 
@@ -144,7 +128,7 @@ public class ProductVersionCli extends AbstractCommand {
         public RemoteCollection<org.jboss.pnc.dto.ProductMilestone> getAll(String sort, String query)
                 throws RemoteResourceException {
 
-            return getClient().getMilestones(id, Optional.ofNullable(sort), Optional.ofNullable(query));
+            return CREATOR.getClient().getMilestones(id, Optional.ofNullable(sort), Optional.ofNullable(query));
         }
     }
 
@@ -157,7 +141,7 @@ public class ProductVersionCli extends AbstractCommand {
         @Override
         public RemoteCollection<ProductRelease> getAll(String sort, String query) throws RemoteResourceException {
 
-            return getClient().getReleases(id, Optional.ofNullable(sort), Optional.ofNullable(query));
+            return CREATOR.getClient().getReleases(id, Optional.ofNullable(sort), Optional.ofNullable(query));
         }
     }
 
@@ -173,7 +157,7 @@ public class ProductVersionCli extends AbstractCommand {
 
             return super.executeHelper(commandInvocation, () -> {
 
-                ProductVersion pV = getClient().getSpecific(id);
+                ProductVersion pV = CREATOR.getClient().getSpecific(id);
                 ProductVersion.Builder updated = pV.toBuilder();
                 ObjectHelper.executeIfNotNull(productVersion, () -> {
 
@@ -184,7 +168,7 @@ public class ProductVersionCli extends AbstractCommand {
 
                     updated.version(productVersion);
                 });
-                getClientAuthenticated().update(id, updated.build());
+                CREATOR.getClientAuthenticated().update(id, updated.build());
             });
         }
     }

--- a/pnc/src/main/java/org/jboss/pnc/bacon/pnc/ScmRepositoryCli.java
+++ b/pnc/src/main/java/org/jboss/pnc/bacon/pnc/ScmRepositoryCli.java
@@ -28,7 +28,7 @@ import org.jboss.pnc.bacon.common.ObjectHelper;
 import org.jboss.pnc.bacon.common.cli.AbstractCommand;
 import org.jboss.pnc.bacon.common.cli.AbstractGetSpecificCommand;
 import org.jboss.pnc.bacon.common.cli.AbstractListCommand;
-import org.jboss.pnc.bacon.pnc.client.PncClientHelper;
+import org.jboss.pnc.bacon.pnc.common.ClientCreator;
 import org.jboss.pnc.client.ClientException;
 import org.jboss.pnc.client.RemoteCollection;
 import org.jboss.pnc.client.RemoteResourceException;
@@ -44,21 +44,7 @@ import java.util.Optional;
         ScmRepositoryCli.ListBuildConfigs.class, })
 public class ScmRepositoryCli extends AbstractCommand {
 
-    private static SCMRepositoryClient clientCache;
-
-    private static SCMRepositoryClient getClient() {
-        if (clientCache == null) {
-            clientCache = new SCMRepositoryClient(PncClientHelper.getPncConfiguration(false));
-        }
-        return clientCache;
-    }
-
-    private static SCMRepositoryClient getClientAuthenticated() {
-        if (clientCache == null) {
-            clientCache = new SCMRepositoryClient(PncClientHelper.getPncConfiguration(true));
-        }
-        return clientCache;
-    }
+    private static final ClientCreator<SCMRepositoryClient> CREATOR = new ClientCreator<>(SCMRepositoryClient::new);
 
     @CommandDefinition(name = "create-and-sync", description = "Create a repository")
     public class CreateAndSync extends AbstractCommand {
@@ -79,7 +65,7 @@ public class ScmRepositoryCli extends AbstractCommand {
                 CreateAndSyncSCMRequest createAndSyncSCMRequest = CreateAndSyncSCMRequest.builder()
                         .preBuildSyncEnabled(Boolean.valueOf(preBuildSync)).scmUrl(scmUrl).build();
 
-                ObjectHelper.print(jsonOutput, getClientAuthenticated().createNew(createAndSyncSCMRequest));
+                ObjectHelper.print(jsonOutput, CREATOR.getClientAuthenticated().createNew(createAndSyncSCMRequest));
             });
         }
     }
@@ -89,7 +75,7 @@ public class ScmRepositoryCli extends AbstractCommand {
 
         @Override
         public SCMRepository getSpecific(String id) throws ClientException {
-            return getClient().getSpecific(id);
+            return CREATOR.getClient().getSpecific(id);
         }
     }
 
@@ -104,7 +90,7 @@ public class ScmRepositoryCli extends AbstractCommand {
 
         @Override
         public RemoteCollection<SCMRepository> getAll(String sort, String query) throws RemoteResourceException {
-            return getClient().getAll(matchUrl, searchUrl, Optional.ofNullable(sort), Optional.ofNullable(query));
+            return CREATOR.getClient().getAll(matchUrl, searchUrl, Optional.ofNullable(sort), Optional.ofNullable(query));
         }
     }
 
@@ -116,7 +102,7 @@ public class ScmRepositoryCli extends AbstractCommand {
 
         @Override
         public RemoteCollection<BuildConfiguration> getAll(String sort, String query) throws RemoteResourceException {
-            return getClient().getBuildsConfigs(scmRepositoryId, Optional.ofNullable(sort), Optional.ofNullable(query));
+            return CREATOR.getClient().getBuildsConfigs(scmRepositoryId, Optional.ofNullable(sort), Optional.ofNullable(query));
         }
     }
 }

--- a/pnc/src/main/java/org/jboss/pnc/bacon/pnc/admin/AnnouncementBannerCli.java
+++ b/pnc/src/main/java/org/jboss/pnc/bacon/pnc/admin/AnnouncementBannerCli.java
@@ -24,7 +24,7 @@ import org.aesh.command.GroupCommandDefinition;
 import org.aesh.command.invocation.CommandInvocation;
 import org.aesh.command.option.Argument;
 import org.jboss.pnc.bacon.common.cli.AbstractCommand;
-import org.jboss.pnc.bacon.pnc.client.PncClientHelper;
+import org.jboss.pnc.bacon.pnc.common.ClientCreator;
 import org.jboss.pnc.client.GenericSettingClient;
 
 @GroupCommandDefinition(name = "announcement-banner", description = "Announcement banner related tasks", groupCommands = {
@@ -32,21 +32,7 @@ import org.jboss.pnc.client.GenericSettingClient;
         AnnouncementBannerCli.GetAnnouncementBanner.class })
 public class AnnouncementBannerCli extends AbstractCommand {
 
-    private static GenericSettingClient clientCache;
-
-    private static GenericSettingClient getClient() {
-        if (clientCache == null) {
-            clientCache = new GenericSettingClient(PncClientHelper.getPncConfiguration(false));
-        }
-        return clientCache;
-    }
-
-    private static GenericSettingClient getClientAuthenticated() {
-        if (clientCache == null) {
-            clientCache = new GenericSettingClient(PncClientHelper.getPncConfiguration(true));
-        }
-        return clientCache;
-    }
+    private static final ClientCreator<GenericSettingClient> CREATOR = new ClientCreator<>(GenericSettingClient::new);
 
     @CommandDefinition(name = "set", description = "This will set the announcement banner")
     public class SetAnnouncementBanner extends AbstractCommand {
@@ -57,7 +43,7 @@ public class AnnouncementBannerCli extends AbstractCommand {
         @Override
         public CommandResult execute(CommandInvocation commandInvocation) throws CommandException, InterruptedException {
             return super.executeHelper(commandInvocation, () -> {
-                getClientAuthenticated().setAnnouncementBanner(announcement);
+                CREATOR.getClientAuthenticated().setAnnouncementBanner(announcement);
             });
         }
     }
@@ -68,7 +54,7 @@ public class AnnouncementBannerCli extends AbstractCommand {
         @Override
         public CommandResult execute(CommandInvocation commandInvocation) throws CommandException, InterruptedException {
             return super.executeHelper(commandInvocation, () -> {
-                getClientAuthenticated().setAnnouncementBanner("");
+                CREATOR.getClientAuthenticated().setAnnouncementBanner("");
             });
         }
     }
@@ -79,7 +65,7 @@ public class AnnouncementBannerCli extends AbstractCommand {
         @Override
         public CommandResult execute(CommandInvocation commandInvocation) throws CommandException, InterruptedException {
             return super.executeHelper(commandInvocation, () -> {
-                System.out.println(getClient().getAnnouncementBanner().getBanner());
+                System.out.println(CREATOR.getClient().getAnnouncementBanner().getBanner());
             });
         }
     }

--- a/pnc/src/main/java/org/jboss/pnc/bacon/pnc/admin/MaintenanceModeCli.java
+++ b/pnc/src/main/java/org/jboss/pnc/bacon/pnc/admin/MaintenanceModeCli.java
@@ -24,7 +24,7 @@ import org.aesh.command.GroupCommandDefinition;
 import org.aesh.command.invocation.CommandInvocation;
 import org.aesh.command.option.Argument;
 import org.jboss.pnc.bacon.common.cli.AbstractCommand;
-import org.jboss.pnc.bacon.pnc.client.PncClientHelper;
+import org.jboss.pnc.bacon.pnc.common.ClientCreator;
 import org.jboss.pnc.client.GenericSettingClient;
 
 @GroupCommandDefinition(name = "maintenance-mode", description = "Maintenance mode related tasks", groupCommands = {
@@ -32,21 +32,7 @@ import org.jboss.pnc.client.GenericSettingClient;
         MaintenanceModeCli.StatusMaintenanceMode.class })
 public class MaintenanceModeCli extends AbstractCommand {
 
-    private static GenericSettingClient clientCache;
-
-    private static GenericSettingClient getClient() {
-        if (clientCache == null) {
-            clientCache = new GenericSettingClient(PncClientHelper.getPncConfiguration(false));
-        }
-        return clientCache;
-    }
-
-    private static GenericSettingClient getClientAuthenticated() {
-        if (clientCache == null) {
-            clientCache = new GenericSettingClient(PncClientHelper.getPncConfiguration(true));
-        }
-        return clientCache;
-    }
+    private static final ClientCreator<GenericSettingClient> CREATOR = new ClientCreator<>(GenericSettingClient::new);
 
     @CommandDefinition(name = "activate", description = "This will disable any new builds from being accepted")
     public class ActivateMaintenanceMode extends AbstractCommand {
@@ -57,8 +43,7 @@ public class MaintenanceModeCli extends AbstractCommand {
         @Override
         public CommandResult execute(CommandInvocation commandInvocation) throws CommandException, InterruptedException {
             return super.executeHelper(commandInvocation, () -> {
-                getClientAuthenticated().activateMaintenanceMode(reason);
-
+                CREATOR.getClientAuthenticated().activateMaintenanceMode(reason);
             });
         }
     }
@@ -69,9 +54,7 @@ public class MaintenanceModeCli extends AbstractCommand {
         @Override
         public CommandResult execute(CommandInvocation commandInvocation) throws CommandException, InterruptedException {
             return super.executeHelper(commandInvocation, () -> {
-                getClientAuthenticated().deactivateMaintenanceMode();
-                ;
-
+                CREATOR.getClientAuthenticated().deactivateMaintenanceMode();
             });
         }
     }
@@ -82,9 +65,9 @@ public class MaintenanceModeCli extends AbstractCommand {
         @Override
         public CommandResult execute(CommandInvocation commandInvocation) throws CommandException, InterruptedException {
             return super.executeHelper(commandInvocation, () -> {
-                if (getClient().isInMaintenanceMode()) {
+                if (CREATOR.getClient().isInMaintenanceMode()) {
                     System.out.println("PNC is in maintenance mode");
-                    System.out.println(getClient().getAnnouncementBanner().getBanner());
+                    System.out.println(CREATOR.getClient().getAnnouncementBanner().getBanner());
                 } else {
                     System.out.println("PNC is NOT in maintenance mode");
                 }

--- a/pnc/src/main/java/org/jboss/pnc/bacon/pnc/common/ClientCreator.java
+++ b/pnc/src/main/java/org/jboss/pnc/bacon/pnc/common/ClientCreator.java
@@ -1,0 +1,63 @@
+package org.jboss.pnc.bacon.pnc.common;
+
+import lombok.extern.slf4j.Slf4j;
+import org.jboss.pnc.bacon.pnc.client.PncClientHelper;
+import org.jboss.pnc.client.ClientBase;
+import org.jboss.pnc.client.Configuration;
+
+import java.util.function.Function;
+
+/**
+ * Helper class to create the PNC CLI client to use in the CLI objects. There are 2 variants, the unauthenticated one and the
+ * authenticated one
+ *
+ * @param <T> : PNC client to initialize
+ */
+@Slf4j
+public class ClientCreator<T extends ClientBase> {
+
+    private T client;
+    private T clientAuthenticated;
+
+    private Function<Configuration, T> constructor;
+
+    /**
+     * Example: ClientCreator<BuildClient> CREATOR = new ClientCreator<>(BuildClient::new);
+     *
+     * @param constructor: constructor of the client
+     */
+    public ClientCreator(Function<Configuration, T> constructor) {
+        this.constructor = constructor;
+    }
+
+    /**
+     * Get the un-authenticated PNC Client object. If already created, object is cached
+     *
+     * @return Un-authenticated PNC Client
+     */
+    public T getClient() {
+
+        if (client == null) {
+            client = getClientPrivate(false);
+        }
+        return client;
+    }
+
+    /**
+     * Get the authenticated PNC Client object. If already created, object is cached
+     *
+     * @return Authenticated PNC Client
+     */
+    public T getClientAuthenticated() {
+
+        if (clientAuthenticated != null) {
+            clientAuthenticated = getClientPrivate(true);
+        }
+        return clientAuthenticated;
+    }
+
+    @SuppressWarnings("unchecked")
+    private T getClientPrivate(boolean authenticated) {
+        return constructor.apply(PncClientHelper.getPncConfiguration(authenticated));
+    }
+}


### PR DESCRIPTION
This is done by getting rid of the duplicate 'getClient' and
'getClientAuthenticated' methods in the various Cli classes and
replacing it with the `ClientCreator` class which contains the logic.

It uses reflection to create a new instance of the Client and properly
caches the un-authenticated, and authenticated clients.