### PR TITLE
[NCL-5523] Name listy commands appropriately

### DIFF
--- a/pnc/src/main/java/org/jboss/pnc/bacon/pnc/ProductMilestoneCli.java
+++ b/pnc/src/main/java/org/jboss/pnc/bacon/pnc/ProductMilestoneCli.java
@@ -188,7 +188,7 @@ public class ProductMilestoneCli extends AbstractCommand {
         }
     }
 
-    @CommandDefinition(name = "get-performed-builds", description = "Get performed builds")
+    @CommandDefinition(name = "list-performed-builds", description = "List performed builds")
     public class PerformedBuilds extends AbstractListCommand<Build> {
 
         @Argument(required = true, description = "Milestone id")

--- a/pnc/src/main/java/org/jboss/pnc/bacon/pnc/ProjectCli.java
+++ b/pnc/src/main/java/org/jboss/pnc/bacon/pnc/ProjectCli.java
@@ -105,7 +105,7 @@ public class ProjectCli extends AbstractCommand {
         }
     }
 
-    @CommandDefinition(name = "get-build-configurations", description = "List build configurations for a project")
+    @CommandDefinition(name = "list-build-configurations", description = "List build configurations for a project")
     public class ListBuildConfigurations extends AbstractListCommand<BuildConfiguration> {
 
         @Argument(required = true, description = "Project id")
@@ -117,7 +117,7 @@ public class ProjectCli extends AbstractCommand {
         }
     }
 
-    @CommandDefinition(name = "get-builds", description = "List builds for a project")
+    @CommandDefinition(name = "list-builds", description = "List builds for a project")
     public class ListBuilds extends AbstractListCommand<Build> {
 
         @Argument(required = true, description = "Project id")


### PR DESCRIPTION
Instead of the commands starting with 'get-', they now start with 'list-'

This affects the project 'list-build-configurations', 'list-builds', and
product-milestone 'list-performed-builds'