### PR TITLE
Remove ambiguity between the -c and -p option in pig

### DIFF
--- a/auth/src/main/java/org/jboss/pnc/bacon/auth/DirectKeycloakClientImpl.java
+++ b/auth/src/main/java/org/jboss/pnc/bacon/auth/DirectKeycloakClientImpl.java
@@ -100,9 +100,6 @@ public class DirectKeycloakClientImpl implements KeycloakClient {
         }
     }
 
-    /**
-     * TODO: save current token in a file
-     */
     @Override
     public Credential getCredentialServiceAccount(
             String keycloakBaseUrl,

--- a/common/src/main/java/org/jboss/pnc/bacon/common/cli/AbstractCommand.java
+++ b/common/src/main/java/org/jboss/pnc/bacon/common/cli/AbstractCommand.java
@@ -57,14 +57,14 @@ public class AbstractCommand implements Command {
     @Option(shortName = 'v', overrideRequired = true, hasValue = false, description = "Verbose output")
     private boolean verbose = false;
 
-    @Option(shortName = 'p', description = "Path to configuration folder")
+    @Option(shortName = 'p', description = "Path to PNC configuration folder")
     private String configPath = null;
 
     @Option(
             shortName = 'P',
             overrideRequired = false,
             defaultValue = { "default" },
-            description = "Configuration profile")
+            description = "PNC Configuration profile")
     private String profile;
 
     public boolean printHelpOrVersionIfPresent(CommandInvocation commandInvocation) {

--- a/pig/src/main/java/org/jboss/pnc/bacon/pig/Pig.java
+++ b/pig/src/main/java/org/jboss/pnc/bacon/pig/Pig.java
@@ -56,7 +56,7 @@ public class Pig extends AbstractCommand {
     public static final String TEMP_BUILD_DEFAULT = "false";
     public static final String TEMP_BUILD = "tempBuild";
     public static final char TEMP_BUILD_SHORT = 't';
-    public static final String CONFIG_DESC = "location of configuration file";
+    public static final String CONFIG_DESC = "Location of Pig configuration file";
     public static final String CONFIG_DEFAULT = "build-config.yaml";
     public static final char CONFIG_SHORT = 'c';
     public static final String REMOVE_M2_DUPLICATES_DESC = "If enabled, only the newest versions of each of the dependencies (groupId:artifactId) "

--- a/pnc/src/main/java/org/jboss/pnc/bacon/pnc/BuildCli.java
+++ b/pnc/src/main/java/org/jboss/pnc/bacon/pnc/BuildCli.java
@@ -204,7 +204,7 @@ public class BuildCli extends AbstractCommand {
                 try {
                     buildLogs = CREATOR.getClient().getBuildLogs(buildId);
                 } catch (Exception e) {
-                    e.printStackTrace(); // TODO, client should return Optional.empty not throw the exception (NCL-5348)
+                    e.printStackTrace();
                     buildLogs = Optional.empty();
                 }
                 // is there a stored record


### PR DESCRIPTION
The -c option is especifically for pig, whereas the '-p' option
is to specify the config folder for PNC.