### PR TITLE
Fix eg config.yaml alignment for keycloak and check

### DIFF
--- a/config.yaml
+++ b/config.yaml
@@ -21,39 +21,37 @@ profile:
   pnc:
       url: ""
       bifrostBaseurl: ""
-
 # ******************************************************************************
 # Authentication information
 #
 # Uncomment this section if you want to create / update / delete
 # ******************************************************************************
-#      keycloak:
-#          url: ""
-#          realm: ""
-#          username: ""
+#  keycloak:
+#      url: ""
+#      realm: ""
+#      username: ""
 #
-#          # if regular user
-#          clientId: ""
+#      # if regular user
+#      clientId: ""
 #
-#          # if service account
-#          clientSecret: ""
+#      # if service account
+#      clientSecret: ""
 - name: "coolProfile"
   pnc:
       url: ""
       bifrostBaseurl: ""
-
 # ******************************************************************************
 # Authentication information
 #
 # Uncomment this section if you want to create / update / delete
 # ******************************************************************************
-#      keycloak:
-#          url: ""
-#          realm: ""
-#          username: ""
+#  keycloak:
+#      url: ""
+#      realm: ""
+#      username: ""
 #
-#          # if regular user
-#          clientId: ""
+#      # if regular user
+#      clientId: ""
 #
-#          # if service account
-#          clientSecret: ""
+#      # if service account
+#      clientSecret: ""

--- a/pnc/src/main/java/org/jboss/pnc/bacon/pnc/client/PncClientHelper.java
+++ b/pnc/src/main/java/org/jboss/pnc/bacon/pnc/client/PncClientHelper.java
@@ -65,6 +65,10 @@ public class PncClientHelper {
         KeycloakConfig keycloakConfig = config.getActiveProfile().getKeycloak();
         String bearerToken = "";
 
+        if (authenticationNeeded && keycloakConfig == null) {
+            Fail.fail("Keycloak section is needed in the configuration file!");
+        }
+
         if (authenticationNeeded && keycloakConfig != null) {
             keycloakConfig.validate();
             bearerToken = getBearerToken(keycloakConfig);


### PR DESCRIPTION
Add check to make sure that the keycloak section in the configuration is
filled if we require authentication.

e.g when the Keycloak section is not specified in the configuration file
```
➜  bacon git:(fix-config) ✗ java -jar cli/target/bacon.jar pnc build start 100 -v -p ~/
[DEBUG] - Log level set to DEBUG
[DEBUG] - Config file set from flag to /home/dcheung//config.yaml
[ERROR] - Keycloak section is needed in the configuration file!
```