### PR TITLE
[NCL-5445] Add bash completion support for CLI 2.x

### DIFF
--- a/cli/src/main/java/org/jboss/pnc/bacon/cli/App.java
+++ b/cli/src/main/java/org/jboss/pnc/bacon/cli/App.java
@@ -21,14 +21,27 @@ import java.util.Arrays;
 import java.util.stream.Collectors;
 import lombok.extern.slf4j.Slf4j;
 import org.aesh.command.AeshCommandRuntimeBuilder;
+import org.aesh.command.CommandResult;
 import org.aesh.command.CommandRuntime;
 import org.aesh.command.GroupCommandDefinition;
+import org.aesh.command.activator.CommandActivator;
+import org.aesh.command.activator.OptionActivator;
+import org.aesh.command.builder.CommandBuilder;
+import org.aesh.command.completer.CompleterInvocation;
+import org.aesh.command.converter.ConverterInvocation;
 import org.aesh.command.impl.registry.AeshCommandRegistryBuilder;
+import org.aesh.command.invocation.CommandInvocation;
 import org.aesh.command.parser.CommandLineParserException;
 import org.aesh.command.parser.OptionParserException;
 import org.aesh.command.parser.RequiredOptionException;
 import org.aesh.command.registry.CommandRegistry;
-import org.apache.commons.lang.StringEscapeUtils;
+import org.aesh.command.settings.SettingsBuilder;
+import org.aesh.command.validator.ValidatorInvocation;
+import org.aesh.readline.Prompt;
+import org.aesh.readline.ReadlineConsole;
+import org.aesh.readline.terminal.formatting.Color;
+import org.aesh.readline.terminal.formatting.TerminalColor;
+import org.aesh.readline.terminal.formatting.TerminalString;
 import org.jboss.bacon.da.Da;
 import org.jboss.pnc.bacon.common.cli.AbstractCommand;
 import org.jboss.pnc.bacon.common.exception.FatalException;
@@ -46,30 +59,61 @@ public class App extends AbstractCommand {
 
     public void run(String[] args) throws Exception {
 
-        CommandRegistry registry = AeshCommandRegistryBuilder.builder().command(this.getClass()).create();
+        CommandRegistry registry;
 
-        CommandRuntime runtime = AeshCommandRuntimeBuilder.builder().commandRegistry(registry).build();
+        if (args.length == 0) {
+            registry = AeshCommandRegistryBuilder.builder()
+                    .command(Pnc.class)
+                    .command(Da.class)
+                    .command(Pig.class)
+                    .command(CommandBuilder.builder().name("exit").command(commandInvocation -> {
+                        commandInvocation.stop();
+                        return CommandResult.SUCCESS;
+                    }).create())
+                    .create();
+            SettingsBuilder<CommandInvocation, ConverterInvocation, CompleterInvocation, ValidatorInvocation, OptionActivator, CommandActivator> builder = SettingsBuilder
+                    .builder()
+                    .logging(true)
+                    .enableAlias(false)
+                    .enableExport(false)
+                    .enableMan(true)
+                    .enableSearchInPaging(true)
+                    .readInputrc(false)
+                    .commandRegistry(registry);
 
-        try {
+            ReadlineConsole console = new ReadlineConsole(builder.build());
+            console.setPrompt(
+                    new Prompt(
+                            new TerminalString(
+                                    "[bacon@console]$ ",
+                                    new TerminalColor(Color.DEFAULT, Color.DEFAULT, Color.Intensity.BRIGHT))));
 
-            runtime.executeCommand(buildCLIOutput(args));
-        } catch (OptionParserException | RequiredOptionException ex) {
-            log.error("Missing argument/option: {}", ex.getMessage());
-            throw new FatalException();
-        } catch (CommandLineParserException ex) {
-            log.error("Wrong arguments: {}", ex.getMessage());
-            throw new FatalException();
-        } catch (RuntimeException ex) {
-            if (ex.getMessage().contains(FatalException.class.getCanonicalName())) {
+            console.start();
+        } else {
+            registry = AeshCommandRegistryBuilder.builder().command(this.getClass()).create();
+
+            CommandRuntime runtime = AeshCommandRuntimeBuilder.builder().commandRegistry(registry).build();
+            try {
+                runtime.executeCommand(buildCLIOutput(args));
+
+            } catch (OptionParserException | RequiredOptionException ex) {
+                log.error("Missing argument/option: {}", ex.getMessage());
+                throw new FatalException();
+            } catch (CommandLineParserException ex) {
+                log.error("Wrong arguments: {}", ex.getMessage());
+                throw new FatalException();
+            } catch (RuntimeException ex) {
+                if (ex.getMessage().contains(FatalException.class.getCanonicalName())) {
+                    throw new FatalException();
+                }
+                // if stacktrace not thrown from aesh
+                if (!ex.getCause().getClass().getCanonicalName().contains("aesh")) {
+                    log.error("Stacktrace", ex);
+                }
+
+                // signal that an error has occurred
                 throw new FatalException();
             }
-            // if stacktrace not thrown from aesh
-            if (!ex.getCause().getClass().getCanonicalName().contains("aesh")) {
-                log.error("Stacktrace", ex);
-            }
-
-            // signal that an error has occurred
-            throw new FatalException();
         }
     }
 


### PR DESCRIPTION
Native bash completion is not straight forward as it might have seem so I decided to use aesh console to simplify and add reliability to this issue.

Bacon usage can now be split into 2 cases
-bacon console (for comfort manual usage with completion of available commands)
when running bacon without arguments `java -jar bacon.jar` it starts bacon console where you can specify commands directly without running java -jar bacon.jar for every command.
![bacon-console](https://user-images.githubusercontent.com/5735284/80698905-6b3f4180-8adb-11ea-8844-cae42c47fde0.gif)

-script usage (bacon how it functioned until now)
adding arguments to command will cause to not start bacon console and allow bacon to be still used as it was until now
![bacon](https://user-images.githubusercontent.com/5735284/80699431-3aabd780-8adc-11ea-99b1-d211ddeca0c2.gif)

possible improvements: loading config and profile for whole console session... ?