### PR TITLE
Properly store pig context if default params empty

### DIFF
--- a/pig/src/main/java/org/jboss/pnc/bacon/pig/impl/config/BuildConfig.java
+++ b/pig/src/main/java/org/jboss/pnc/bacon/pig/impl/config/BuildConfig.java
@@ -202,11 +202,23 @@ public class BuildConfig {
     }
 
     // Work around for NCL-3670
+
+    /**
+     * Return the short scm uri path of the scm urls (scmUrl or externalScmUrl respectively)
+     *
+     * If the scmUrl or the getExternalScmUrl is null, this method will also return null
+     *
+     * @return short scm uri path
+     */
     public String getShortScmURIPath() {
         String scmUrl = getScmUrl() != null ? getScmUrl() : getExternalScmUrl();
         try {
-            URI scmUri = new URI(scmUrl);
-            return scmUri.getPath();
+            if (scmUrl != null) {
+                URI scmUri = new URI(scmUrl);
+                return scmUri.getPath();
+            } else {
+                return null;
+            }
         } catch (URISyntaxException e) {
             throw new RuntimeException("Invalid scm URI: " + getScmUrl(), e);
         }


### PR DESCRIPTION
If the default params are empty, storing the Pig Context throws an NPE
as we are trying to parse a null url. This commit will only parse the
url if not-null.

Fixes #218