### PR TITLE
Fix license generation and other bugs

### DIFF
--- a/cli/pom.xml
+++ b/cli/pom.xml
@@ -60,36 +60,60 @@
                 </configuration>
             </plugin>
             <plugin>
-                <groupId>org.apache.maven.plugins</groupId>
-                <artifactId>maven-assembly-plugin</artifactId>
-                <version>3.3.0</version>
+                <groupId>org.codehaus.plexus</groupId>
+                <artifactId>plexus-component-metadata</artifactId>
+                <version>1.7.1</version>
                 <executions>
                     <execution>
+                        <goals>
+                            <goal>generate-metadata</goal>
+                        </goals>
+                    </execution>
+                </executions>
+            </plugin>
+            <plugin>
+                <groupId>org.apache.maven.plugins</groupId>
+                <artifactId>maven-shade-plugin</artifactId>
+                <version>3.0.0</version>
+                <executions>
+                    <execution>
+                        <id>shade-for-licenses-to-work</id>
                         <phase>package</phase>
                         <goals>
-                            <goal>single</goal>
+                            <goal>shade</goal>
                         </goals>
                         <configuration>
                             <finalName>bacon</finalName>
-                            <appendAssemblyId>false</appendAssemblyId>
-                            <archive>
-                                <manifest>
+                            <transformers>
+                                <transformer implementation="org.apache.maven.plugins.shade.resource.ManifestResourceTransformer">
+                                    <manifestEntries>
+                                        <Implementation-Version>${project.version}</Implementation-Version>
+                                        <Implementation-SCM-Revision>${git.commit.id.abbrev}</Implementation-SCM-Revision>
+                                        <Implementation-SCM-Branch>${git.branch}</Implementation-SCM-Branch>
+                                    </manifestEntries>
                                     <mainClass>org.jboss.pnc.bacon.cli.App</mainClass>
-                                </manifest>
-                                <manifestSections>
-                                    <manifestSection>
-                                        <name>Versions</name>
-                                        <manifestEntries>
-                                            <Implementation-Version>${project.version}</Implementation-Version>
-                                            <Implementation-SCM-Revision>${git.commit.id.abbrev}</Implementation-SCM-Revision>
-                                            <Implementation-SCM-Branch>${git.branch}</Implementation-SCM-Branch>
-                                        </manifestEntries>
-                                    </manifestSection>
-                                </manifestSections>
-                            </archive>
-                            <descriptorRefs>
-                                <descriptorRef>jar-with-dependencies</descriptorRef>
-                            </descriptorRefs>
+                                </transformer>
+                                <transformer implementation="org.apache.maven.plugins.shade.resource.ComponentsXmlResourceTransformer"/>
+                                <transformer implementation="org.apache.maven.plugins.shade.resource.ServicesResourceTransformer"/>
+                                <transformer implementation="org.apache.maven.plugins.shade.resource.AppendingTransformer">
+                                    <resource>META-INF/sisu/javax.inject.Named</resource>
+                                </transformer>
+                            </transformers>
+                            <createDependencyReducedPom>true</createDependencyReducedPom>
+                            <!-- If we're deploying this we should have a different classifier -->
+                            <shadedArtifactAttached>true</shadedArtifactAttached>
+                            <shadedClassifierName>shaded</shadedClassifierName>
+                            <!-- We don't want the signing stuff, this can be disabled with maven also -->
+                            <filters>
+                                <filter>
+                                    <artifact>*:*</artifact>
+                                    <excludes>
+                                        <exclude>META-INF/*.SF</exclude>
+                                        <exclude>META-INF/*.DSA</exclude>
+                                        <exclude>META-INF/*.RSA</exclude>
+                                    </excludes>
+                                </filter>
+                            </filters>
                         </configuration>
                     </execution>
                 </executions>

--- a/common/src/main/java/org/jboss/pnc/bacon/common/cli/VersionInfo.java
+++ b/common/src/main/java/org/jboss/pnc/bacon/common/cli/VersionInfo.java
@@ -27,10 +27,7 @@ public class VersionInfo {
         InputStream manifestStream = getClass().getClassLoader().getResourceAsStream(manifestName);
         try {
             Manifest manifest = new Manifest(manifestStream);
-            Attributes attributes = manifest.getEntries().get("Versions");
-            if (attributes == null) {
-                log.warn("Missing 'Versions' section in the Manifest file.");
-            }
+            Attributes attributes = manifest.getMainAttributes();
             revision = attributes.getValue("Implementation-SCM-Revision");
             if (revision == null) {
                 log.warn("Incomplete manifest file, missing revision property.");

--- a/pig/src/main/java/org/jboss/pnc/bacon/pig/impl/license/LicenseGenerator.java
+++ b/pig/src/main/java/org/jboss/pnc/bacon/pig/impl/license/LicenseGenerator.java
@@ -67,7 +67,8 @@ public class LicenseGenerator {
 
             generator.generateLicensesForGavs(gavsToLicenseGeneratorGavs(gavs), licensesDirectory.getAbsolutePath());
             // Checking if the URL for licenses are present and are valid
-            File xmlFile = new File(licensesDirectory.getAbsolutePath());
+            File xmlFile = new File(licensesDirectory.getAbsolutePath(), "licenses.xml");
+            System.out.println(licensesDirectory.getAbsolutePath());
             boolean isInvalidLicensesPresent = XmlUtils
                     .isValidNodePresent(xmlFile, "//license[not(url)] or //url[not(string(.))]");
             if (isInvalidLicensesPresent) {

--- a/pig/src/main/java/org/jboss/pnc/bacon/pig/impl/pnc/BuildInfoCollector.java
+++ b/pig/src/main/java/org/jboss/pnc/bacon/pig/impl/pnc/BuildInfoCollector.java
@@ -62,9 +62,9 @@ public class BuildInfoCollector {
     public PncBuild getLatestBuild(String configId) {
         try {
             BuildsFilterParameters filter = new BuildsFilterParameters();
-            filter.setLatest(true);
+            // Note: sort by id not allowed
             Iterator<Build> buildIterator = buildConfigClient
-                    .getBuilds(configId, filter, of("=desc=id"), query("status=='", BuildStatus.SUCCESS + "'"))
+                    .getBuilds(configId, filter, of("=desc=submitTime"), query("status==%s", BuildStatus.SUCCESS))
                     .iterator();
 
             if (!buildIterator.hasNext()) {

--- a/pig/src/main/resources/license-generator.properties
+++ b/pig/src/main/resources/license-generator.properties
@@ -1,4 +1,4 @@
 # to run with PNC stage, you need to set the `INDY_REPO_URL` environment variable to http://indy-stage.psi.redhat.com/
 repository.names=${names}
 repository.urls=${urls}
-$licenseServiceUrl
+${licenseServiceUrl}

--- a/pig/src/main/resources/release.sh
+++ b/pig/src/main/resources/release.sh
@@ -3,36 +3,10 @@
 set -e
 # mstodo: 
 
-<#noparse>
-function getPushStatus() {
-    pnc brew-push status $1 | grep "status" | cut -d : -f 2 | tr -d '[:space:]' | tr -d '"'
-}
-
-function waitForPush() {
-    while true
-    do
-        status=$(getPushStatus $1)
-        if [ "${status}" == "SUCCESS" ]
-        then
-            break;
-        fi
-
-        if [ "${status}" == "SYSTEM_ERROR" ] || [ "${status}" == "CANCELED" ] || [ "${status}" == "FAILED" ]
-        then
-            echo "Failed to push build $1 to Brew"
-            exit 1
-        fi
-        echo "Waiting for build $1 to be pushed to Brew"
-        sleep 5
-    done
-}
-</#noparse>
-
 <#list buildsToPush as build>
-pnc brew-push build ${build} ${brewTag}
-waitForPush ${build}
+pnc brew-push build ${build} --tag-prefix="${brewTag}" --wait
 </#list>
 
 /bin/bash ${nvrListScriptLocation} ${repoZipLocation} ${targetPath} ${kojiHubUrl}
 
-pnc close-milestone ${milestoneId} --wait
+pnc product-milestone close ${milestoneId}

--- a/pig/src/main/resources/uploadToCandidates.sh
+++ b/pig/src/main/resources/uploadToCandidates.sh
@@ -1,0 +1,11 @@
+#!/usr/bin/expect
+
+set timeout 1800
+spawn ssh -o StrictHostKeyChecking=no -o UserKnownHostsFile=/dev/null $::env(LOGIN)@rcm-guest.app.eng.bos.redhat.com
+expect {
+  password { send "$::env(PASSWORD)\r" ; exp_continue }
+  bash { send "kinit\r" }
+}
+expect Password { send "$::env(PASSWORD)\r" }
+expect bash { send "/mnt/redhat/scripts/rel-eng/utility/bus-clients/stage-mw-release ${productWithVersion}\r" }
+expect bash

--- a/pnc/src/main/java/org/jboss/pnc/bacon/pnc/GroupConfigCli.java
+++ b/pnc/src/main/java/org/jboss/pnc/bacon/pnc/GroupConfigCli.java
@@ -178,7 +178,8 @@ public class GroupConfigCli extends AbstractCommand {
 
             return super.executeHelper(commandInvocation, () -> {
                 for (String bcid : attributes) {
-                    CREATOR.getClientAuthenticated().addBuildConfig(id, BuildConfigurationRef.refBuilder().id(bcid).build());
+                    CREATOR.getClientAuthenticated()
+                            .addBuildConfig(id, BuildConfigurationRef.refBuilder().id(bcid).build());
                 }
             });
         }


### PR DESCRIPTION
This is done by:
- replacing maven-assembly-plugin to maven-shade-plugin, which does some
  magic to make plexus container happy (cli/pom.xml)
- Make VersionInfo read from main manifest attribute to get version info
- Update license-generator.properties to properly do template
  substitution
- Check license error from xml file, not xml folder
  (LicenseGenerator.java)