### PR TITLE
Switch back to Java 8

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -49,8 +49,8 @@
 
     <properties>
         <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
-        <maven.compiler.source>11</maven.compiler.source>
-        <maven.compiler.target>11</maven.compiler.target>
+        <maven.compiler.source>1.8</maven.compiler.source>
+        <maven.compiler.target>1.8</maven.compiler.target>
         <aesh.version>2.6</aesh.version>
         <tagSuffix/>
         <jaxb.version>2.2.11</jaxb.version>


### PR DESCRIPTION
This resolves issues described in #299

Internal certs are only installed in default JDK