### PR TITLE
Print progress dot in stderr

### DIFF
--- a/pig/src/main/java/org/jboss/pnc/bacon/pig/impl/utils/SleepUtils.java
+++ b/pig/src/main/java/org/jboss/pnc/bacon/pig/impl/utils/SleepUtils.java
@@ -46,14 +46,14 @@ public class SleepUtils {
         do {
             sleep(checkInterval);
             if (printDot) {
-                System.out.print(".");
+                System.err.print(".");
             }
         } while (!condition.get());
     }
 
     /**
      * Wait until the <code>condition</code> returns a non null value or time out is reached
-     * 
+     *
      * @param condition the condition to evaluate
      * @param checkInterval [seconds] amount of time to wait before attempts
      * @param timeout [seconds] timeout


### PR DESCRIPTION
Since some apps consume our stdout for data, we should print the dot
progress to indicate something is in progress in stderr instead of
stdout.

Partially Fixes #289