### PR TITLE
[#304] Fix the addition of double scheme in pig README

### DIFF
--- a/pig/src/main/resources/README.ftl
+++ b/pig/src/main/resources/README.ftl
@@ -43,7 +43,7 @@
     <tr>
         <td>${build.name}</td>
         <td>
-            <a href="http://${pncUrl}/pnc-web/#/build-records/${build.id}">Build
+            <a href="${pncUrl}/pnc-web/#/build-records/${build.id}">Build
                 #${build.id}</a>
         </td>
         <td>${build.internalScmUrl}</td>


### PR DESCRIPTION
PiG generates a README.html file from the README.ftl template file.
Since we now specifies the scheme of PNC Orch's link in our config, the
generated README.html has the scheme specified twice:

```
http://http://orch-stage.DOMAIN/pnc-web/#/build-records/14160
```

This commit fixes this. Thanks to @goldmann for noticing and reporting
this ♥