### PR TITLE
[#317] Allow user to specify brew tag prefix for PiG config

### DIFF
--- a/pig/src/main/java/org/jboss/pnc/bacon/pig/impl/config/PigConfiguration.java
+++ b/pig/src/main/java/org/jboss/pnc/bacon/pig/impl/config/PigConfiguration.java
@@ -67,6 +67,9 @@ public class PigConfiguration {
     private String micro;
     private Map<String, Map<String, ?>> addons = new HashMap<>();
     private String releaseStorageUrl;
+
+    /** Allow user to override brewTag auto-generated in PNC for a product version */
+    private String brewTagPrefix;
     private static final Integer maxTries = 256;
 
     private void init() {


### PR DESCRIPTION
This is done by specifying in your `build-config.yaml`:
```yaml
...
version: 1.0.0
group: test boo
brewTagPrefix: fb-1.0-pnc
builds:
  - ...
```

if the brewTagPrefix is null, the product version is not updated with
the brew tag prefix. Note that the product version has a brew tag prefix
generated automatically by default. This provides a way to override that
value.