### PR TITLE
[NCL-5943] fix NoSuccessfulBuildException on unchanged BuildConfig when a temporary build is not rebuilt after a regular build

### DIFF
--- a/pig/src/main/java/org/jboss/pnc/bacon/pig/impl/pnc/BuildInfoCollector.java
+++ b/pig/src/main/java/org/jboss/pnc/bacon/pig/impl/pnc/BuildInfoCollector.java
@@ -72,7 +72,9 @@ public class BuildInfoCollector {
                     queryParam = query("status==%s;temporaryBuild==%s", BuildStatus.SUCCESS, false);
                     break;
                 case TEMPORARY:
-                    queryParam = query("status==%s;temporaryBuild==%s", BuildStatus.SUCCESS, true);
+                    // NCL-5943 Cannot ignore permanent(regular) builds because they cause NO_REBUILD_REQUIRED even for
+                    // temporary builds. That means "latest build" for a temporary build can be permanent(regular).
+                    queryParam = query("status==%s", BuildStatus.SUCCESS);
                     break;
                 default:
                     queryParam = Optional.empty();


### PR DESCRIPTION
Hi guys. This should fix NCL-5943(#326) but as I am not familiar with PIG I fear this specific solution($1) might have side-effects which I cannot predict. 

Other possible solution($2) is to handle this case just before throwing an exception here:
https://github.com/project-ncl/bacon/blob/869832e483c9fd9564b5474054394c92e38a71c8/pig/src/main/java/org/jboss/pnc/bacon/pig/impl/pnc/BuildInfoCollector.java#L89

Should I go with $1, try to improve $1 or go with $2 