### PR TITLE
Properly use the '-h' in pig * commands

### DIFF
--- a/pig/src/main/java/org/jboss/pnc/bacon/pig/Pig.java
+++ b/pig/src/main/java/org/jboss/pnc/bacon/pig/Pig.java
@@ -113,10 +113,9 @@ public class Pig extends AbstractCommand {
         public CommandResult execute(CommandInvocation commandInvocation)
                 throws CommandException, InterruptedException {
 
-            Fail.failIfNull(configDir, "You need to specify the configuration directory!");
-
             return super.executeHelper(commandInvocation, () -> {
 
+                Fail.failIfNull(configDir, "You need to specify the configuration directory!");
                 // validate the PiG config
                 PigConfig pig = Config.instance().getActiveProfile().getPig();
                 if (pig == null) {


### PR DESCRIPTION
The config dir check was eagerly being run before the check for help /
version flags. This commit fixes it