### PR TITLE
Remove withJansi from logback-test.xml

### DIFF
--- a/cli/src/main/resources/logback-test.xml
+++ b/cli/src/main/resources/logback-test.xml
@@ -34,7 +34,6 @@
 <configuration>
     <appender name="STDERR" class="ch.qos.logback.core.ConsoleAppender">
         <target>System.err</target>
-        <withJansi>true</withJansi>
         <encoder>
             <pattern>[%highlight(%-5level)] - %msg%n</pattern>
         </encoder>


### PR DESCRIPTION
The default value is false. There is no need to change it since it's not required on modern platforms and it breaks the tests. And it won't work unless you also have jansi on the classpath.