### PR TITLE
Fix checking for existing SCM Repository in pig

### DIFF
--- a/pig/src/main/java/org/jboss/pnc/bacon/pig/impl/config/BuildConfig.java
+++ b/pig/src/main/java/org/jboss/pnc/bacon/pig/impl/config/BuildConfig.java
@@ -226,39 +226,6 @@ public class BuildConfig {
         // TODO!
     }
 
-    public boolean matchesRepository(SCMRepository repository) {
-        String currentInternalUrl = repository.getInternalUrl();
-
-        // currentInternalUrl cannot be null, if the url from the config is not null, they have to be the same
-        if (scmUrl != null) {
-            return areSameRepoUrls(scmUrl, currentInternalUrl);
-        }
-
-        // if the internal scm url is not provided in the config, check if external scm urls are the same
-        return externalScmUrl != null && areSameRepoUrls(repository.getExternalUrl(), externalScmUrl);
-    }
-
-    private boolean areSameRepoUrls(String scmUrl1, String scmUrl2) {
-        if (scmUrl1 == null ^ scmUrl2 == null) {
-            throw new RuntimeException("trying to compare null and non-null scm url: " + scmUrl1 + ", " + scmUrl2);
-        }
-        String normalizedUrl1 = normalize(scmUrl1);
-        String normalizedUrl2 = normalize(scmUrl2);
-        return normalizedUrl1.equals(normalizedUrl2);
-    }
-
-    private String normalize(String url) {
-        if (!url.endsWith(".git")) {
-            url += ".git";
-        }
-
-        if (url.startsWith("https")) {
-            url = url.replaceFirst("https", "http");
-        }
-
-        return url;
-    }
-
     public boolean isUpgradableFrom(BuildConfiguration oldConfig) {
         String oldInternalUrl = oldConfig.getScmRepository().getInternalUrl();
         if (scmUrl != null && !StringUtils.equals(scmUrl, oldInternalUrl)) {

--- a/pig/src/main/java/org/jboss/pnc/bacon/pig/impl/pnc/PncEntitiesImporter.java
+++ b/pig/src/main/java/org/jboss/pnc/bacon/pig/impl/pnc/PncEntitiesImporter.java
@@ -344,7 +344,16 @@ public class PncEntitiesImporter {
         }
 
         try {
-            return toStream(repoClient.getAll(matchUrl, null)).filter(buildConfig::matchesRepository).findAny();
+            List<SCMRepository> foundRepository = toStream(repoClient.getAll(matchUrl, null))
+                    .collect(Collectors.toList());
+            if (foundRepository.isEmpty()) {
+                return Optional.empty();
+            } else if (foundRepository.size() == 1) {
+                return Optional.of(foundRepository.get(0));
+            } else {
+                throw new RuntimeException(
+                        "There exists more then one SCM Repository for url: " + matchUrl + " " + foundRepository);
+            }
         } catch (RemoteResourceException e) {
             throw new RuntimeException("Failed to search for repository by " + matchUrl, e);
         }


### PR DESCRIPTION
Don't use buildConfig::matchesRepository in the check as PNC's match endpoint
should be always returning single matching SCM Repository if it exists.