### PR TITLE
[NCL-5996] Return non-zero return code if failure

### DIFF
--- a/bacon_install.py
+++ b/bacon_install.py
@@ -272,6 +272,7 @@ def main():
         bacon_install.run()
     except Exception as e:
         print(e)
+        sys.exit(1)
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
```
~/projects/work/bacon ncl-5996 !1 ❯ python3 bacon_install.py update
Downloading: https://repo.maven.org/maven2/org/jboss/pnc/bacon/cli/maven-metadata.xml
Something wrong happened while downloading the link: https://repo.maven.org/maven2/org/jboss/pnc/bacon/cli/maven-metadata.xml
~/pr/work/bacon ncl-5996 !1 ❯ echo $?                                       ✘ 1
1
```

Thanks to @goldmann for reporting this issue! :)