### PR TITLE
Remove overrideRequired from some options

### DIFF
--- a/common/src/main/java/org/jboss/pnc/bacon/common/cli/AbstractCommand.java
+++ b/common/src/main/java/org/jboss/pnc/bacon/common/cli/AbstractCommand.java
@@ -58,7 +58,7 @@ public class AbstractCommand implements Command {
     @Option(shortName = 'V', overrideRequired = true, hasValue = false, description = "print version")
     private boolean version = false;
 
-    @Option(shortName = 'v', overrideRequired = true, hasValue = false, description = "Verbose output")
+    @Option(shortName = 'v', hasValue = false, description = "Verbose output")
     private boolean verbose = false;
 
     @Option(shortName = 'p', description = "Path to PNC configuration folder")

--- a/pig/src/main/java/org/jboss/pnc/bacon/pig/Pig.java
+++ b/pig/src/main/java/org/jboss/pnc/bacon/pig/Pig.java
@@ -90,7 +90,6 @@ public class Pig extends AbstractCommand {
                 shortName = TEMP_BUILD_SHORT,
                 name = TEMP_BUILD,
                 hasValue = false,
-                overrideRequired = true,
                 defaultValue = TEMP_BUILD_DEFAULT,
                 description = TEMP_BUILD_DESC)
         boolean tempBuild;
@@ -142,28 +141,21 @@ public class Pig extends AbstractCommand {
 
         // TODO: it is doable to do this step with build group id only, add this functionality
         // @Option(shortName = 'b',
-        // overrideRequired = true,
         // description = "id of the group to build. Exactly one of {config, build-group} has to be provided")
         // private Integer buildGroupId;
 
         @Option(
                 name = TEMP_BUILD_TIME_STAMP,
-                overrideRequired = true,
                 hasValue = false,
                 defaultValue = TEMP_BUILD_TIME_STAMP_DEFAULT,
                 description = TEMP_BUILD_TIME_STAMP_DESC)
         private boolean tempBuildTS;
 
-        @Option(
-                name = REBUILD_MODE,
-                overrideRequired = true,
-                defaultValue = REBUILD_MODE_DEFAULT,
-                description = REBUILD_MODE_DESC)
+        @Option(name = REBUILD_MODE, defaultValue = REBUILD_MODE_DEFAULT, description = REBUILD_MODE_DESC)
         private String rebuildMode;
 
         @Option(
                 name = "skipRepo",
-                overrideRequired = true,
                 hasValue = false,
                 defaultValue = "false",
                 description = "Skip maven repository generation")
@@ -171,7 +163,6 @@ public class Pig extends AbstractCommand {
 
         @Option(
                 name = "skipPncUpdate",
-                overrideRequired = true,
                 hasValue = false,
                 defaultValue = "false",
                 description = "Skip updating PNC entities. Use only if you have all entities created properly.")
@@ -179,7 +170,6 @@ public class Pig extends AbstractCommand {
 
         @Option(
                 name = "skipBuilds",
-                overrideRequired = true,
                 hasValue = false,
                 defaultValue = "false",
                 description = "Skip PNC builds. Use when all your builds went fine, something failed later "
@@ -188,7 +178,6 @@ public class Pig extends AbstractCommand {
 
         @Option(
                 name = "skipSources",
-                overrideRequired = true,
                 hasValue = false,
                 defaultValue = "false",
                 description = "Skip sources generation.")
@@ -196,7 +185,6 @@ public class Pig extends AbstractCommand {
 
         @Option(
                 name = "skipJavadoc",
-                overrideRequired = true,
                 hasValue = false,
                 defaultValue = "false",
                 description = "Skip Javadoc generation.")
@@ -204,7 +192,6 @@ public class Pig extends AbstractCommand {
 
         @Option(
                 name = "skipLicenses",
-                overrideRequired = true,
                 hasValue = false,
                 defaultValue = "false",
                 description = "Skip Licenses generation.")
@@ -212,7 +199,6 @@ public class Pig extends AbstractCommand {
 
         @Option(
                 name = "skipSharedContent",
-                overrideRequired = true,
                 hasValue = false,
                 defaultValue = "false",
                 description = "Skip generating shared content request input.")
@@ -220,7 +206,6 @@ public class Pig extends AbstractCommand {
 
         @Option(
                 name = REMOVE_M2_DUPLICATES,
-                overrideRequired = true,
                 hasValue = false,
                 defaultValue = REMOVE_M2_DUPLICATES_DEFAULT,
                 description = REMOVE_M2_DUPLICATES_DESC)
@@ -228,7 +213,6 @@ public class Pig extends AbstractCommand {
 
         @Option(
                 name = SKIP_BRANCH_CHECK,
-                overrideRequired = true,
                 hasValue = false,
                 defaultValue = SKIP_BRANCH_CHECK_DEFAULT,
                 description = SKIP_BRANCH_CHECK_DESC)
@@ -237,7 +221,6 @@ public class Pig extends AbstractCommand {
         @Option(
                 shortName = 'r',
                 name = "repoZip",
-                overrideRequired = true,
                 description = "Repository zip. "
                         + "Might be used if you have already downloaded repository zip to speed up the process.")
         private String repoZipPath;
@@ -276,7 +259,6 @@ public class Pig extends AbstractCommand {
 
         @Option(
                 name = SKIP_BRANCH_CHECK,
-                overrideRequired = true,
                 hasValue = false,
                 defaultValue = SKIP_BRANCH_CHECK_DEFAULT,
                 description = SKIP_BRANCH_CHECK_DESC)
@@ -296,23 +278,17 @@ public class Pig extends AbstractCommand {
 
         // TODO: it is doable to do this step with build group id only, add this functionality
         // @Option(shortName = 'b',
-        // overrideRequired = true,
         // description = "id of the group to build. Exactly one of {config, build-group} has to be provided")
         // private Integer buildGroupId;
 
         @Option(
                 name = TEMP_BUILD_TIME_STAMP,
-                overrideRequired = true,
                 hasValue = false,
                 defaultValue = TEMP_BUILD_TIME_STAMP_DEFAULT,
                 description = TEMP_BUILD_TIME_STAMP_DESC)
         private boolean tempBuildTS;
 
-        @Option(
-                name = REBUILD_MODE,
-                overrideRequired = true,
-                defaultValue = REBUILD_MODE_DEFAULT,
-                description = REBUILD_MODE_DESC)
+        @Option(name = REBUILD_MODE, defaultValue = REBUILD_MODE_DEFAULT, description = REBUILD_MODE_DESC)
         private String rebuildMode;
 
         @Override
@@ -335,7 +311,6 @@ public class Pig extends AbstractCommand {
     public class GenerateRepository extends PigCommand<RepositoryData> {
         @Option(
                 name = REMOVE_M2_DUPLICATES,
-                overrideRequired = true,
                 hasValue = false,
                 defaultValue = REMOVE_M2_DUPLICATES_DEFAULT,
                 description = REMOVE_M2_DUPLICATES_DESC)


### PR DESCRIPTION
'overrideRequired' is used when you want to skip validation of required
Options or Arguments. This is typically useful for the '-h / --help' or
'-v /--version' flags, where we don't need to validate the input further
and we'll just print the help and version output respectively.

However this parameter is not useful for most other options. This commit
removes that parameter from options that shouldn't use it.

This also fixes the issue we had with 'pig run' where there were no
validation if the 'configDir' was passed in our input, which was caused
because the options had the 'overrideRequired=true' flag set.

Special thanks to @stalep for explaining to me the meaning of this
parameter in https://github.com/aeshell/aesh/issues/322