### PR TITLE
[NCLSUP-100] Bacon/pig throws nullpointer when downloading build repo…

### DIFF
--- a/pig/src/main/java/org/jboss/pnc/bacon/pig/impl/config/RepoGenerationData.java
+++ b/pig/src/main/java/org/jboss/pnc/bacon/pig/impl/config/RepoGenerationData.java
@@ -20,6 +20,7 @@ package org.jboss.pnc.bacon.pig.impl.config;
 import lombok.Data;
 
 import java.util.ArrayList;
+import java.util.HashSet;
 import java.util.List;
 import java.util.Map;
 import java.util.Set;
@@ -44,7 +45,7 @@ public class RepoGenerationData extends GenerationData<RepoGenerationStrategy> {
     private boolean includeLicenses;
     private boolean includeMavenMetadata;
     private String buildScript;
-    private Set<String> ignored;
+    private Set<String> ignored = new HashSet<>();
     private String additionalRepo;
     private List<Map<String, String>> stages;
     private Map<String, String> parameters;


### PR DESCRIPTION
when user doesn't specify field in config file field is not initialized causing deep in repo generation nullpointer when checking if artifacts extracted from bom are contained in ignored set