### PR TITLE
Remove hardcoded line separator from Shell.writeln

### DIFF
--- a/common/src/main/java/org/jboss/pnc/bacon/common/cli/AbstractCommand.java
+++ b/common/src/main/java/org/jboss/pnc/bacon/common/cli/AbstractCommand.java
@@ -79,7 +79,8 @@ public class AbstractCommand implements Command {
             shell.writeln(commandInvocation.getHelpInfo());
             String exampleText = exampleText();
             if (exampleText != null) {
-                shell.writeln("Examples:\n");
+                shell.writeln("Examples:");
+                shell.writeln("");
                 shell.writeln(exampleText);
             }
             activated = true;


### PR DESCRIPTION
I am not sure if you wanted an extra newline there to begin with, but try letting shell handle `writeln()` in case it is system-dependent. If we want another newline, we can try `shell.writeln("").`
