### PR TITLE
Make test classes and methods package-private as per JUnit 5

### DIFF
--- a/cli/src/test/java/org/jboss/pnc/bacon/cli/AppTest.java
+++ b/cli/src/test/java/org/jboss/pnc/bacon/cli/AppTest.java
@@ -9,7 +9,7 @@ import org.junit.jupiter.api.Test;
 class AppTest {
 
     @Test
-    public void testHelp() throws Exception {
+    void testHelp() throws Exception {
         App app = new App();
         String text = tapSystemOut(() -> assertEquals(0, app.run(new String[] { "-h" })));
         assertTrue(text.contains("Usage: bacon [<options>]"));

--- a/integration-tests/src/test/java/org/jboss/pnc/bacon/test/AbstractTest.java
+++ b/integration-tests/src/test/java/org/jboss/pnc/bacon/test/AbstractTest.java
@@ -34,27 +34,27 @@ public class AbstractTest {
     protected PNCWiremockHelper wmock = new PNCWiremockHelper();
 
     @BeforeAll
-    public static void startWiremockServer() {
+    static void startWiremockServer() {
         wireMockServer = new WireMockServer(options().port(8080).notifier(new ConsoleNotifier(false)));
         wireMockServer.start();
     }
 
     @AfterAll
-    public static void stopWiremockServer() {
+    static void stopWiremockServer() {
         wireMockServer.stop();
     }
 
     @BeforeEach
-    public void stubBabnner() {
+    void stubBanner() {
         wmock.init();
     }
 
     @AfterAll
-    public void clearStubs() {
+    static void clearStubs() {
         wireMockServer.resetAll();
     }
 
-    public static String getRandomString() {
+    protected static String getRandomString() {
         byte[] bytes = new byte[6];
         generator.nextBytes(bytes);
         final String randomString = Base64.getEncoder().encodeToString(bytes);

--- a/integration-tests/src/test/java/org/jboss/pnc/bacon/test/pig/PigTest.java
+++ b/integration-tests/src/test/java/org/jboss/pnc/bacon/test/pig/PigTest.java
@@ -47,7 +47,7 @@ import static org.jboss.pnc.bacon.test.Endpoints.SCM_REPOSITORY_CREATE;
  */
 @TestInstance(TestInstance.Lifecycle.PER_CLASS)
 @TestMethodOrder(MethodOrderer.OrderAnnotation.class)
-public class PigTest extends AbstractTest {
+class PigTest extends AbstractTest {
 
     private static final String UNIVERSAL_ID = "42";
     private static final String SUFFIX = getRandomString();
@@ -64,7 +64,7 @@ public class PigTest extends AbstractTest {
 
     @Test
     @Order(1)
-    public void shouldCreateProduct() throws IOException {
+    void shouldCreateProduct() throws IOException {
         final Path configFile = CONFIG_LOCATION;
         replaceSuffixInConfigFile(configFile.resolve("build-config.yaml"));
 

--- a/integration-tests/src/test/java/org/jboss/pnc/bacon/test/pnc/ProductTest.java
+++ b/integration-tests/src/test/java/org/jboss/pnc/bacon/test/pnc/ProductTest.java
@@ -28,14 +28,14 @@ import com.fasterxml.jackson.core.JsonProcessingException;
  */
 @TestInstance(Lifecycle.PER_CLASS)
 @TestMethodOrder(MethodOrderer.OrderAnnotation.class)
-public class ProductTest extends AbstractTest {
+class ProductTest extends AbstractTest {
     private static final String PRODUCT_NAME_PREFIX = "BT New Product Name ";
 
     private String productId;
 
     @Test
     @Order(1)
-    public void shouldCreateProduct() throws JsonProcessingException {
+    void shouldCreateProduct() throws JsonProcessingException {
 
         final String suffix = getRandomString();
         final String productName = PRODUCT_NAME_PREFIX + suffix;
@@ -69,7 +69,7 @@ public class ProductTest extends AbstractTest {
 
     @Test
     @Order(2)
-    public void shouldGetProduct() throws JsonProcessingException {
+    void shouldGetProduct() throws JsonProcessingException {
         Assumptions.assumeTrue(productId != null);
 
         Product response = Product.builder().id(productId).name(PRODUCT_NAME_PREFIX + " suffix").build();
@@ -84,7 +84,7 @@ public class ProductTest extends AbstractTest {
 
     @Test
     @Order(2)
-    public void shouldListProducts() throws JsonProcessingException {
+    void shouldListProducts() throws JsonProcessingException {
         Assumptions.assumeTrue(productId != null);
 
         Product response = Product.builder().id(productId).name(PRODUCT_NAME_PREFIX + "suffix").build();
@@ -98,7 +98,7 @@ public class ProductTest extends AbstractTest {
 
     @Test
     @Order(3)
-    public void shouldUpdateProduct() throws JsonProcessingException {
+    void shouldUpdateProduct() throws JsonProcessingException {
         Assumptions.assumeTrue(productId != null);
 
         Product response = Product.builder().id(productId).name(PRODUCT_NAME_PREFIX + "suffix").build();
@@ -117,7 +117,7 @@ public class ProductTest extends AbstractTest {
     }
 
     @Test
-    public void shouldGetInvalidProduct() throws JsonProcessingException {
+    void shouldGetInvalidProduct() throws JsonProcessingException {
         productId = "000000";
 
         wmock.get(PRODUCT, productId);

--- a/pig/src/test/java/org/jboss/pnc/bacon/config/ConfigReaderTest.java
+++ b/pig/src/test/java/org/jboss/pnc/bacon/config/ConfigReaderTest.java
@@ -32,9 +32,9 @@ import static org.junit.jupiter.api.Assertions.fail;
  * @author Michal Szynkiewicz, michal.l.szynkiewicz@gmail.com <br>
  *         Date: 11/28/17
  */
-public class ConfigReaderTest {
+class ConfigReaderTest {
     @Test
-    public void shouldDeserializeJavadocGenerationStrategy() {
+    void shouldDeserializeJavadocGenerationStrategy() {
         PigConfiguration config = loadBuildConfig("/build-config-VarUsage.yaml");
         assertNotNull(config);
         JavadocGenerationStrategy strategy = config.getFlow().getJavadocGeneration().getStrategy();
@@ -51,7 +51,7 @@ public class ConfigReaderTest {
     }
 
     @Test
-    public void shouldExpandVariables() {
+    void shouldExpandVariables() {
         PigConfiguration config = loadBuildConfig("/build-config-VarUsage.yaml");
         assertNotNull(config);
         if (!config.getVersion().equals("3.5.1")) {
@@ -60,7 +60,7 @@ public class ConfigReaderTest {
     }
 
     @Test
-    public void shouldExpandAndOverrideVariables() {
+    void shouldExpandAndOverrideVariables() {
         PigConfiguration config = loadBuildConfig("/build-config-VarUsage.yaml", "productName=vertx, milestone=ER2");
         assertNotNull(config);
         if (!config.getVersion().equals("3.5.1")) {
@@ -77,7 +77,7 @@ public class ConfigReaderTest {
     }
 
     @Test
-    public void shouldFailOnUnkownVariable() {
+    void shouldFailOnUnkownVariable() {
         boolean thrown = false;
         try {
             loadBuildConfig("/build-config-UnknownVar.yaml");

--- a/pig/src/test/java/org/jboss/pnc/bacon/pig/impl/documents/sharedcontent/da/DADaoTest.java
+++ b/pig/src/test/java/org/jboss/pnc/bacon/pig/impl/documents/sharedcontent/da/DADaoTest.java
@@ -52,7 +52,7 @@ class DADaoTest {
     }
 
     @Test
-    public void shouldLookupJunit412() {
+    void shouldLookupJunit412() {
         CommunityDependency dependency = new CommunityDependency("junit", "junit", "4.12", "jar");
         daDao.fillDaData(dependency);
         assertThat(dependency.getRecommendation()).isEqualTo("4.12.0.redhat-003");
@@ -60,7 +60,7 @@ class DADaoTest {
     }
 
     @Test
-    public void shouldLookupJunit456() {
+    void shouldLookupJunit456() {
         CommunityDependency dependency = new CommunityDependency("junit", "junit", "4.56", "jar");
         daDao.fillDaData(dependency);
         assertThat(dependency.getRecommendation()).isNull();
@@ -68,7 +68,7 @@ class DADaoTest {
     }
 
     @Test
-    public void shouldLookupJunity456() {
+    void shouldLookupJunity456() {
         CommunityDependency dependency = new CommunityDependency("junit", "junity", "4.56", "jar");
         daDao.fillDaData(dependency);
         assertThat(dependency.getRecommendation()).isNull();

--- a/pig/src/test/java/org/jboss/pnc/bacon/pig/impl/utils/indy/IndyTest.java
+++ b/pig/src/test/java/org/jboss/pnc/bacon/pig/impl/utils/indy/IndyTest.java
@@ -12,7 +12,7 @@ import static org.junit.jupiter.api.Assertions.*;
 class IndyTest {
 
     @BeforeAll
-    public static void setup() throws IOException {
+    static void setup() throws IOException {
         File file = new File(IndyTest.class.getClassLoader().getResource("config.yaml").getFile());
         Config.configure(file.getParent(), "config.yaml", "default");
         Config.initialize();

--- a/pnc/src/test/java/org/jboss/pnc/bacon/pnc/ProductReleaseCliTest.java
+++ b/pnc/src/test/java/org/jboss/pnc/bacon/pnc/ProductReleaseCliTest.java
@@ -19,8 +19,7 @@ import org.mockito.Mockito;
 
 class ProductReleaseCliTest {
     @Test
-    public void testCreateException()
-            throws CommandException, InterruptedException, IOException, IllegalAccessException {
+    void testCreateException() throws CommandException, InterruptedException, IOException, IllegalAccessException {
         ProductReleaseCli.Create create = spy((new ProductReleaseCli()).new Create());
         CommandInvocation commandInvocation = mock(CommandInvocation.class);
         File file = new File(ProductReleaseCliTest.class.getClassLoader().getResource("config.yaml").getFile());

--- a/pnc/src/test/java/org/jboss/pnc/bacon/pnc/common/ParameterCheckerTest.java
+++ b/pnc/src/test/java/org/jboss/pnc/bacon/pnc/common/ParameterCheckerTest.java
@@ -7,7 +7,7 @@ import static org.junit.jupiter.api.Assertions.*;
 
 class ParameterCheckerTest {
     @Test
-    public void verifyRebuildOption() {
+    void verifyRebuildOption() {
         try {
             ParameterChecker.checkRebuildModeOption("FOOBAR");
             fail("No exception thrown");


### PR DESCRIPTION
JUnit 4 forced test classes and methods to be public. JUnit 5 changed this. See also <https://github.com/junit-team/junit5/issues/679> where they made the change to their own codebase. This is a minor PR, but it adds some consistency (some tests were using this and some weren't).