### PR TITLE
[NCLSUP-109] Stop make bacon stuck when checking branch

### DIFF
--- a/pig/src/main/java/org/jboss/pnc/bacon/pig/impl/pnc/GitRepoInspector.java
+++ b/pig/src/main/java/org/jboss/pnc/bacon/pig/impl/pnc/GitRepoInspector.java
@@ -93,6 +93,8 @@ public class GitRepoInspector {
     }
 
     private static Git cloneRepo(String internalUrl, File targetDir) throws GitAPIException, IOException {
+        log.debug("Cloning repository {} into {}", internalUrl, targetDir);
+
         Git git = Git.init().setDirectory(targetDir).call();
         StoredConfig config = git.getRepository().getConfig();
         config.setBoolean("http", null, "sslVerify", false);
@@ -122,6 +124,7 @@ public class GitRepoInspector {
      * (because we return here the tag commit and its parent)
      */
     private static Set<String> getBaseCommitPossibilities(Git git, String tagName) throws GitAPIException, IOException {
+        log.debug("Getting base commit possibilities for tag: {}", tagName);
         Set<String> result = new HashSet<>();
 
         Ref ref = git.getRepository().findRef(tagName);
@@ -138,6 +141,7 @@ public class GitRepoInspector {
     }
 
     private static String getLatestBuiltRevision(String configId, boolean temporaryBuild) {
+        log.debug("Getting latest built revision of config id {}, temporary: {}", configId, temporaryBuild);
         BuildInfoCollector.BuildSearchType searchType = temporaryBuild ? BuildInfoCollector.BuildSearchType.TEMPORARY
                 : BuildInfoCollector.BuildSearchType.PERMANENT;
         PncBuild latestBuild = buildInfoCollector.getLatestBuild(configId, searchType);


### PR DESCRIPTION
Bacon/PiG runs a check to see if the commit of the branch has already
been built in PNC.

Unfortunately during this check an InputStream may not be closed
properly which causes the app to just hang.

This commit fixes it by always closing the InputStream

### Checklist:

* [x] Have you added a note in the [CHANGELOG wiki](https://github.com/project-ncl/bacon/wiki/Changelog) for your change if user-facing?
* [ ] Have you added unit tests for your change?
