### PR TITLE
[NCL-6018] Download logs even when build successful

### DIFF
--- a/pig/src/main/java/org/jboss/pnc/bacon/pig/impl/pnc/BuildInfoCollector.java
+++ b/pig/src/main/java/org/jboss/pnc/bacon/pig/impl/pnc/BuildInfoCollector.java
@@ -105,17 +105,15 @@ public class BuildInfoCollector {
 
             PncBuild result = new PncBuild(build);
 
-            if (!build.getStatus().completedSuccessfully()) {
-                Optional<InputStream> maybeBuildLogs = buildClient.getBuildLogs(build.getId());
+            Optional<InputStream> maybeBuildLogs = buildClient.getBuildLogs(build.getId());
 
-                // only store logs if present and build failed: log not that useful if build successful
-                if (maybeBuildLogs.isPresent()) {
-                    try (InputStream inputStream = maybeBuildLogs.get()) {
-                        String log = readLog(inputStream);
-                        result.addBuildLog(log);
-                    }
+            if (maybeBuildLogs.isPresent()) {
+                try (InputStream inputStream = maybeBuildLogs.get()) {
+                    String log = readLog(inputStream);
+                    result.addBuildLog(log);
                 }
             }
+
             result.addBuiltArtifacts(toList(buildClient.getBuiltArtifacts(build.getId())));
             return result;
         } catch (ClientException | IOException e) {
@@ -203,16 +201,14 @@ public class BuildInfoCollector {
                     pncBuild = new PncBuild(build);
                 }
 
-                // only get logs when build fail. Is that a good logic?
-                if (!pncBuild.getBuildStatus().completedSuccessfully()) {
-                    Optional<InputStream> maybeBuildLogs = buildClient.getBuildLogs(pncBuild.getId());
-                    if (maybeBuildLogs.isPresent()) {
-                        try (InputStream inputStream = maybeBuildLogs.get()) {
-                            String log = readLog(inputStream);
-                            pncBuild.addBuildLog(log);
-                        }
+                Optional<InputStream> maybeBuildLogs = buildClient.getBuildLogs(pncBuild.getId());
+                if (maybeBuildLogs.isPresent()) {
+                    try (InputStream inputStream = maybeBuildLogs.get()) {
+                        String log = readLog(inputStream);
+                        pncBuild.addBuildLog(log);
                     }
                 }
+
                 pncBuild.addBuiltArtifacts(toList(buildClient.getBuiltArtifacts(pncBuild.getId())));
                 result.put(pncBuild.getName(), pncBuild);
             }

--- a/pig/src/main/java/org/jboss/pnc/bacon/pig/impl/pnc/PncBuild.java
+++ b/pig/src/main/java/org/jboss/pnc/bacon/pig/impl/pnc/PncBuild.java
@@ -18,6 +18,7 @@
 
 package org.jboss.pnc.bacon.pig.impl.pnc;
 
+import com.fasterxml.jackson.annotation.JsonIgnore;
 import com.fasterxml.jackson.annotation.JsonIgnoreProperties;
 import lombok.AllArgsConstructor;
 import lombok.Getter;
@@ -58,6 +59,9 @@ public class PncBuild {
     private String name;
     private Map<String, String> attributes;
     private BuildStatus buildStatus;
+
+    // Don't print huge build logs in the user's output. It's usually not that useful
+    @JsonIgnore
     private List<String> buildLog;
     private List<ArtifactWrapper> builtArtifacts;
     private List<ArtifactWrapper> dependencyArtifacts;


### PR DESCRIPTION
In a previous commit, we didn't download logs if the builds were
successful because the logs would be printed in the stdout and would be
way too long.

However this broke addons that rely on the logs. This commit reverts the
changes of the previous commit, and also doesn't print the logs
(successful or not) to the stdout.

The addons broken are: MicroProfileSmallRyeCommunityDepAnalyzer.java and
RuntimeDependenciesAnalyzer.java

### Checklist:

* [ ] Have you added a note in the [CHANGELOG wiki](https://github.com/project-ncl/bacon/wiki/Changelog) for your change if user-facing?
* [ ] Have you added unit tests for your change?
