### PR TITLE
Use lombok's UtilityClass on utility classes

### DIFF
--- a/common/src/main/java/org/jboss/pnc/bacon/common/Constant.java
+++ b/common/src/main/java/org/jboss/pnc/bacon/common/Constant.java
@@ -1,20 +1,19 @@
 package org.jboss.pnc.bacon.common;
 
+import lombok.experimental.UtilityClass;
+
 import java.io.File;
 
+@UtilityClass
 public class Constant {
-
-    public static final String DEFAULT_CONFIG_FOLDER = System.getProperty("user.home") + File.separator + ".config"
+    public final String DEFAULT_CONFIG_FOLDER = System.getProperty("user.home") + File.separator + ".config"
             + File.separator + "pnc-bacon";
 
-    public static final String CONFIG_FILE_NAME = "config.yaml";
+    public final String CONFIG_FILE_NAME = "config.yaml";
 
-    public static final String CONFIG_ENV = "PNC_CONFIG_PATH";
+    public final String CONFIG_ENV = "PNC_CONFIG_PATH";
 
-    public static final String PIG_CONTEXT_DIR = "PIG_CONTEXT_DIR";
+    public final String PIG_CONTEXT_DIR = "PIG_CONTEXT_DIR";
 
-    public static final String CACHE_FILE = "saved-user.json";
-
-    private Constant() {
-    }
+    public final String CACHE_FILE = "saved-user.json";
 }

--- a/common/src/main/java/org/jboss/pnc/bacon/common/ObjectHelper.java
+++ b/common/src/main/java/org/jboss/pnc/bacon/common/ObjectHelper.java
@@ -7,29 +7,30 @@ import com.fasterxml.jackson.databind.ObjectMapper;
 import com.fasterxml.jackson.databind.SerializationFeature;
 import com.fasterxml.jackson.dataformat.yaml.YAMLFactory;
 import com.fasterxml.jackson.datatype.jsr310.JavaTimeModule;
+import lombok.experimental.UtilityClass;
 
+@UtilityClass
 public class ObjectHelper {
-
-    private static ObjectMapper getOutputMapper(boolean json) {
+    private ObjectMapper getOutputMapper(boolean json) {
         ObjectMapper om = json ? new ObjectMapper(new JsonFactory()) : new ObjectMapper(new YAMLFactory());
         om.registerModule(new JavaTimeModule());
         om.configure(SerializationFeature.WRITE_DATES_AS_TIMESTAMPS, false);
         return om;
     }
 
-    public static void print(boolean json, Object o) throws JsonProcessingException {
+    public void print(boolean json, Object o) throws JsonProcessingException {
         // FIXME: System.out.println uses system line feed, but writeValueAsString may not
         // FIXME: See <https://github.com/project-ncl/bacon/issues/349> for details
         System.out.println(getOutputMapper(json).writeValueAsString(o));
     }
 
-    public static void setRootLoggingLevel(Level level) {
+    public void setRootLoggingLevel(Level level) {
         ch.qos.logback.classic.Logger root = (ch.qos.logback.classic.Logger) org.slf4j.LoggerFactory
                 .getLogger(ch.qos.logback.classic.Logger.ROOT_LOGGER_NAME);
         root.setLevel(level);
     }
 
-    public static void setLoggingLevel(String loggerName, Level level) {
+    public void setLoggingLevel(String loggerName, Level level) {
         ch.qos.logback.classic.Logger logger = (ch.qos.logback.classic.Logger) org.slf4j.LoggerFactory
                 .getLogger(loggerName);
         logger.setLevel(level);

--- a/common/src/main/java/org/jboss/pnc/bacon/common/Utils.java
+++ b/common/src/main/java/org/jboss/pnc/bacon/common/Utils.java
@@ -17,11 +17,13 @@
  */
 package org.jboss.pnc.bacon.common;
 
+import lombok.experimental.UtilityClass;
+
 /**
  * Utils class shared among all apps
  */
+@UtilityClass
 public class Utils {
-
     /**
      * Handle picky case where sourceUrl may end with "/" in the config file, and combine it gracefully with the path
      *
@@ -29,8 +31,7 @@ public class Utils {
      * @param path remaining part of url
      * @return beautifully assembled url
      */
-    public static String generateUrlPath(String sourceUrl, String path) {
-
+    public String generateUrlPath(String sourceUrl, String path) {
         if (sourceUrl.endsWith("/")) {
             return sourceUrl.substring(0, sourceUrl.length() - 2) + path;
         } else {

--- a/integration-tests/pom.xml
+++ b/integration-tests/pom.xml
@@ -17,6 +17,7 @@
         <pnc-url>http://localhost:8080</pnc-url>
         <scm-host>example.com</scm-host>
     </properties>
+
     <dependencies>
         <!-- Project deps -->
         <dependency>
@@ -65,6 +66,11 @@
         <dependency>
             <groupId>com.github.tomakehurst</groupId>
             <artifactId>wiremock-jre8</artifactId>
+        </dependency>
+        <dependency>
+            <groupId>org.projectlombok</groupId>
+            <artifactId>lombok</artifactId>
+            <scope>test</scope>
         </dependency>
     </dependencies>
 

--- a/integration-tests/src/test/java/org/jboss/pnc/bacon/test/AbstractTest.java
+++ b/integration-tests/src/test/java/org/jboss/pnc/bacon/test/AbstractTest.java
@@ -9,6 +9,7 @@ import com.fasterxml.jackson.core.JsonProcessingException;
 import com.github.tomakehurst.wiremock.WireMockServer;
 import com.github.tomakehurst.wiremock.common.ConsoleNotifier;
 import org.junit.jupiter.api.AfterAll;
+import org.junit.jupiter.api.AfterEach;
 import org.junit.jupiter.api.BeforeAll;
 import org.junit.jupiter.api.BeforeEach;
 import org.slf4j.Logger;
@@ -29,11 +30,9 @@ public class AbstractTest {
 
     private static WireMockServer wireMockServer;
 
-    private static Random generator = new Random();
+    private static final Random generator = new Random();
 
     protected CLIExecutor executor = new CLIExecutor();
-
-    protected PNCWiremockHelper wmock = new PNCWiremockHelper();
 
     @BeforeAll
     static void startWiremockServer() {
@@ -48,11 +47,11 @@ public class AbstractTest {
 
     @BeforeEach
     void stubBanner() {
-        wmock.init();
+        PNCWiremockHelper.init();
     }
 
-    @AfterAll
-    static void clearStubs() {
+    @AfterEach
+    void clearStubs() {
         wireMockServer.resetAll();
     }
 

--- a/integration-tests/src/test/java/org/jboss/pnc/bacon/test/Endpoints.java
+++ b/integration-tests/src/test/java/org/jboss/pnc/bacon/test/Endpoints.java
@@ -1,26 +1,25 @@
 package org.jboss.pnc.bacon.test;
 
+import lombok.experimental.UtilityClass;
+
 import java.util.function.Function;
 
 /**
  *
  * @author jbrazdil
  */
+@UtilityClass
 public class Endpoints {
-
-    public static final String PRODUCT = "/products";
-    public static final Function<String, String> PRODUCT_VERSIONS = id -> PRODUCT + "/" + id + "/versions";
-    public static final String PRODUCT_MILESTONE = "/product-milestones";
-    public static final String SCM_REPOSITORY = "/scm-repositories";
-    public static final String SCM_REPOSITORY_CREATE = "/scm-repositories/create-and-sync";
-    public static final String PROJECT = "/projects";
-    public static final String BUILD_CONFIG = "/build-configs";
-    public static final Function<String, String> BUILD_CONFIG_DEPENDENCIES = id -> BUILD_CONFIG + "/" + id
-            + "/dependencies";
-    public static final String GROUP_CONFIG = "/group-configs";
-    public static final Function<String, String> GROUP_CONFIG_BUILD_CONFIGS = id -> GROUP_CONFIG + "/" + id
-            + "/build-configs";
-    public static final String PRODUCT_VERSION = "/product-versions";
-    public static final Function<String, String> PRODUCT_VERSION_MILESTONES = id -> PRODUCT_VERSION + "/" + id
-            + "/milestones";
+    public final String PRODUCT = "/products";
+    public final Function<String, String> PRODUCT_VERSIONS = id -> PRODUCT + "/" + id + "/versions";
+    public final String PRODUCT_MILESTONE = "/product-milestones";
+    public final String SCM_REPOSITORY = "/scm-repositories";
+    public final String SCM_REPOSITORY_CREATE = "/scm-repositories/create-and-sync";
+    public final String PROJECT = "/projects";
+    public final String BUILD_CONFIG = "/build-configs";
+    public final Function<String, String> BUILD_CONFIG_DEPENDENCIES = id -> BUILD_CONFIG + "/" + id + "/dependencies";
+    public final String GROUP_CONFIG = "/group-configs";
+    public final Function<String, String> GROUP_CONFIG_BUILD_CONFIGS = id -> GROUP_CONFIG + "/" + id + "/build-configs";
+    public final String PRODUCT_VERSION = "/product-versions";
+    public final Function<String, String> PRODUCT_VERSION_MILESTONES = id -> PRODUCT_VERSION + "/" + id + "/milestones";
 }

--- a/integration-tests/src/test/java/org/jboss/pnc/bacon/test/PNCWiremockHelper.java
+++ b/integration-tests/src/test/java/org/jboss/pnc/bacon/test/PNCWiremockHelper.java
@@ -26,15 +26,14 @@ import static com.github.tomakehurst.wiremock.client.WireMock.stubFor;
 import static com.github.tomakehurst.wiremock.client.WireMock.urlMatching;
 import static com.github.tomakehurst.wiremock.client.WireMock.urlPathEqualTo;
 import static com.github.tomakehurst.wiremock.stubbing.Scenario.STARTED;
-import static org.jboss.pnc.bacon.test.PNCWiremockHelper.REST;
 
 /**
  *
  * @author jbrazdil
  */
+// @UtilityClass
 public class PNCWiremockHelper {
-
-    protected static final String REST = "/pnc-rest/v2";
+    private static final String REST = "/pnc-rest/v2";
 
     private static final String TOKEN = "wiremocked-token";
 
@@ -43,30 +42,30 @@ public class PNCWiremockHelper {
             + "  \"token_type\": \"bearer\"," + "  \"not-before-policy\": 123456789,"
             + "  \"session_state\": \"002f6422-4e1b-4953-8432-e8a3472cd2dc\"," + "  \"scope\": \"profile email\"" + "}";
 
-    private ObjectMapper mapper = new ObjectMapper();
+    private static final ObjectMapper mapper = new ObjectMapper();
 
-    public PNCWiremockHelper() {
+    static {
         mapper.registerModule(new JavaTimeModule());
         mapper.configure(SerializationFeature.WRITE_DATES_AS_TIMESTAMPS, false);
     }
 
-    public void init() {
+    static void init() {
         stubAnnouncementBanner();
         stubAuthentication();
         stubUnauthenticatedAccess();
     }
 
-    private void stubAuthentication() {
+    private static void stubAuthentication() {
         stubFor(
                 WireMock.post(urlMatching("/auth/realms/.*/protocol/openid-connect/token"))
                         .willReturn(okJson(TOKEN_MESSAGE)));
     }
 
-    private void stubAnnouncementBanner() {
+    private static void stubAnnouncementBanner() {
         stubFor(_get("/generic-setting/announcement-banner").willReturn(okJson("{\"banner\":\"\"}")));
     }
 
-    private void stubUnauthenticatedAccess() {
+    private static void stubUnauthenticatedAccess() {
         stubFor(
                 WireMock.post(urlMatching(REST + "/.*"))
                         .withHeader("Authorization", absent())
@@ -97,47 +96,47 @@ public class PNCWiremockHelper {
                                         .withBody("Unauthorized")));
     }
 
-    private MappingBuilder _get(String endpoint) {
+    private static MappingBuilder _get(String endpoint) {
         return WireMock.get(urlPathEqualTo(REST + endpoint));
     }
 
-    private MappingBuilder _post(String endpoint) {
+    private static MappingBuilder _post(String endpoint) {
         return WireMock.post(urlPathEqualTo(REST + endpoint)).withHeader("Authorization", containing(TOKEN));
     }
 
-    private MappingBuilder _put(String endpoint) {
+    private static MappingBuilder _put(String endpoint) {
         return WireMock.put(urlPathEqualTo(REST + endpoint)).withHeader("Authorization", containing(TOKEN));
     }
 
-    private MappingBuilder _delete(String endpoint) {
+    private static MappingBuilder _delete(String endpoint) {
         return WireMock.delete(urlPathEqualTo(REST + endpoint)).withHeader("Authorization", containing(TOKEN));
     }
 
-    private ResponseDefinitionBuilder _jsonResponse(ResponseDefinitionBuilder builder, Object response)
+    private static ResponseDefinitionBuilder _jsonResponse(ResponseDefinitionBuilder builder, Object response)
             throws JsonProcessingException {
         return builder.withHeader("Content-Type", "application/json").withBody(mapper.writeValueAsString(response));
     }
 
-    public void creation(String endpoint, Object response) throws JsonProcessingException {
+    public static void creation(String endpoint, Object response) throws JsonProcessingException {
         stubFor(_post(endpoint).willReturn(_jsonResponse(created(), response)));
     }
 
-    public void get(String endpoint, DTOEntity response) throws JsonProcessingException {
+    public static void get(String endpoint, DTOEntity response) throws JsonProcessingException {
         String id = Objects.requireNonNull(response.getId(), "DTO id must be set");
         stubFor(_get(endpoint + "/" + id).willReturn(_jsonResponse(ok(), response)));
     }
 
-    public void get(String endpoint, String id) throws JsonProcessingException {
+    public static void get(String endpoint, String id) throws JsonProcessingException {
         stubFor(_get(endpoint + "/" + id).willReturn(notFound()));
     }
 
-    public void list(String endpoint, Page<?> responsePage) throws JsonProcessingException {
+    public static void list(String endpoint, Page<?> responsePage) throws JsonProcessingException {
         stubFor(_get(endpoint).willReturn(_jsonResponse(ok(), responsePage)));
     }
 
     private static final String SC_UPDATE = " update scenario";
 
-    public <T extends DTOEntity> void update(String endpoint, T oldResponse, T updatedResponse)
+    public static <T extends DTOEntity> void update(String endpoint, T oldResponse, T updatedResponse)
             throws JsonProcessingException {
         String id = Objects.requireNonNull(oldResponse.getId(), "DTO id must be set");
         scenario(endpoint + SC_UPDATE).getEntity(endpoint, oldResponse)
@@ -159,11 +158,11 @@ public class PNCWiremockHelper {
      * @param scenarioName Name of the scanario. Must be unique.
      * @return Scenario builder used to construct the scenario.
      */
-    public ScenarioBuilder scenario(String scenarioName) {
+    public static ScenarioBuilder scenario(String scenarioName) {
         return new ScenarioBuilder(scenarioName);
     }
 
-    public class ScenarioBuilder {
+    public static class ScenarioBuilder {
         private final String scenarioName;
         private String mockingState = STARTED;
         private Optional<String> nextState = Optional.empty();

--- a/integration-tests/src/test/java/org/jboss/pnc/bacon/test/pnc/ProductTest.java
+++ b/integration-tests/src/test/java/org/jboss/pnc/bacon/test/pnc/ProductTest.java
@@ -2,7 +2,9 @@ package org.jboss.pnc.bacon.test.pnc;
 
 import com.fasterxml.jackson.core.JsonProcessingException;
 import org.jboss.pnc.bacon.test.AbstractTest;
+import org.jboss.pnc.bacon.test.Endpoints;
 import org.jboss.pnc.bacon.test.ExecutionResult;
+import org.jboss.pnc.bacon.test.PNCWiremockHelper;
 import org.jboss.pnc.dto.Product;
 import org.jboss.pnc.dto.response.Page;
 import org.junit.jupiter.api.Assumptions;
@@ -16,7 +18,6 @@ import org.junit.jupiter.api.TestMethodOrder;
 import java.util.Collections;
 
 import static org.assertj.core.api.Assertions.assertThat;
-import static org.jboss.pnc.bacon.test.Endpoints.PRODUCT;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 
@@ -46,7 +47,7 @@ class ProductTest extends AbstractTest {
                 .abbreviation(abbreviation)
                 .description(description)
                 .build();
-        wmock.creation(PRODUCT, response);
+        PNCWiremockHelper.creation(Endpoints.PRODUCT, response);
 
         Product product = executeAndDeserialize(
                 Product.class,
@@ -72,7 +73,7 @@ class ProductTest extends AbstractTest {
 
         Product response = Product.builder().id(productId).name(PRODUCT_NAME_PREFIX + " suffix").build();
 
-        wmock.get(PRODUCT, response);
+        PNCWiremockHelper.get(Endpoints.PRODUCT, response);
 
         Product product = executeAndDeserialize(Product.class, "pnc", "product", "get", productId);
 
@@ -87,7 +88,7 @@ class ProductTest extends AbstractTest {
 
         Product response = Product.builder().id(productId).name(PRODUCT_NAME_PREFIX + "suffix").build();
         Page<Product> responsePage = new Page<>(0, 50, 1, Collections.singleton(response));
-        wmock.list(PRODUCT, responsePage);
+        PNCWiremockHelper.list(Endpoints.PRODUCT, responsePage);
 
         Product[] products = executeAndDeserialize(Product[].class, "pnc", "product", "list");
 
@@ -101,7 +102,8 @@ class ProductTest extends AbstractTest {
 
         Product response = Product.builder().id(productId).name(PRODUCT_NAME_PREFIX + "suffix").build();
         Product updatedResponse = Product.builder().id(productId).name(PRODUCT_NAME_PREFIX + "suffix updated").build();
-        wmock.update(PRODUCT, response, updatedResponse);
+
+        PNCWiremockHelper.update(Endpoints.PRODUCT, response, updatedResponse);
 
         Product originalProduct = executeAndDeserialize(Product.class, "pnc", "product", "get", productId);
 
@@ -118,11 +120,11 @@ class ProductTest extends AbstractTest {
     void shouldGetInvalidProduct() throws JsonProcessingException {
         productId = "000000";
 
-        wmock.get(PRODUCT, productId);
+        PNCWiremockHelper.get(Endpoints.PRODUCT, productId);
 
         ExecutionResult er = executeAndGetResult("pnc", "product", "get", productId);
 
-        assertEquals(er.getRetval(), 1);
+        assertEquals(1, er.getRetval());
         assertTrue(er.getError().contains("HTTP 404 Not Found"));
     }
 }

--- a/pig/src/main/java/org/jboss/pnc/bacon/pig/impl/PigContext.java
+++ b/pig/src/main/java/org/jboss/pnc/bacon/pig/impl/PigContext.java
@@ -24,11 +24,13 @@ import com.fasterxml.jackson.databind.SerializationFeature;
 import com.fasterxml.jackson.datatype.jsr310.JavaTimeModule;
 import lombok.Data;
 import lombok.extern.slf4j.Slf4j;
+import org.jboss.pnc.bacon.common.Constant;
 import org.jboss.pnc.bacon.pig.impl.config.PigConfiguration;
 import org.jboss.pnc.bacon.pig.impl.documents.Deliverables;
 import org.jboss.pnc.bacon.pig.impl.pnc.ImportResult;
 import org.jboss.pnc.bacon.pig.impl.pnc.PncBuild;
 import org.jboss.pnc.bacon.pig.impl.repo.RepositoryData;
+import org.jboss.pnc.bacon.pig.impl.utils.HashUtils;
 import org.jboss.pnc.bacon.pig.impl.utils.MilestoneNumberFinder;
 
 import java.io.File;
@@ -43,9 +45,6 @@ import java.nio.file.Paths;
 import java.util.Collection;
 import java.util.Map;
 import java.util.Optional;
-
-import static org.jboss.pnc.bacon.common.Constant.PIG_CONTEXT_DIR;
-import static org.jboss.pnc.bacon.pig.impl.utils.HashUtils.hashDirectory;
 
 /**
  * TODO: consider saving the latest reached state to not repeat the steps already performed
@@ -187,10 +186,10 @@ public class PigContext {
     }
 
     private static PigContext readContext(boolean clean, Path configDir) {
-        String sha = hashDirectory(configDir);
+        String sha = HashUtils.hashDirectory(configDir);
 
         PigContext result;
-        String ctxLocationEnv = System.getenv(PIG_CONTEXT_DIR);
+        String ctxLocationEnv = System.getenv(Constant.PIG_CONTEXT_DIR);
         Path contextDir = ctxLocationEnv == null ? Paths.get(".bacon") : Paths.get(ctxLocationEnv);
         Path contextJson = contextDir.resolve("pig-context.json");
         if (!clean && Files.exists(contextJson)) {

--- a/pig/src/main/java/org/jboss/pnc/bacon/pig/impl/addons/AddOnFactory.java
+++ b/pig/src/main/java/org/jboss/pnc/bacon/pig/impl/addons/AddOnFactory.java
@@ -17,6 +17,7 @@
  */
 package org.jboss.pnc.bacon.pig.impl.addons;
 
+import lombok.experimental.UtilityClass;
 import org.jboss.pnc.bacon.pig.impl.addons.microprofile.MicroProfileSmallRyeCommunityDepAnalyzer;
 import org.jboss.pnc.bacon.pig.impl.addons.quarkus.QuarkusCommunityDepAnalyzer;
 import org.jboss.pnc.bacon.pig.impl.addons.quarkus.QuarkusPostBuildAnalyzer;
@@ -35,9 +36,9 @@ import java.util.Map;
  * @author Michal Szynkiewicz, michal.l.szynkiewicz@gmail.com <br>
  *         Date: 12/11/17
  */
+@UtilityClass
 public class AddOnFactory {
-
-    public static List<AddOn> listAddOns(
+    public List<AddOn> listAddOns(
             PigConfiguration pigConfiguration,
             Map<String, PncBuild> builds,
             String releasePath,
@@ -54,8 +55,5 @@ public class AddOnFactory {
         resultList.add(new MicroProfileSmallRyeCommunityDepAnalyzer(pigConfiguration, builds, releasePath, extrasPath));
         resultList.add(new QuarkusPostBuildAnalyzer(pigConfiguration, builds, releasePath, extrasPath));
         return resultList;
-    }
-
-    private AddOnFactory() {
     }
 }

--- a/pig/src/main/java/org/jboss/pnc/bacon/pig/impl/addons/quarkus/QuarkusCommunityDepAnalyzer.java
+++ b/pig/src/main/java/org/jboss/pnc/bacon/pig/impl/addons/quarkus/QuarkusCommunityDepAnalyzer.java
@@ -42,8 +42,6 @@ import java.util.TreeSet;
 import java.util.function.Predicate;
 import java.util.stream.Collectors;
 
-import static org.jboss.pnc.bacon.pig.impl.utils.FileUtils.mkTempDir;
-
 /**
  * @author Michal Szynkiewicz, michal.l.szynkiewicz@gmail.com <br>
  *         Date: 12/08/2019
@@ -153,7 +151,7 @@ public class QuarkusCommunityDepAnalyzer extends AddOn {
     }
 
     private void unpackRepository(Path repoZipPath) {
-        File unzippedRepo = mkTempDir("repoZipForDepAnalysis");
+        File unzippedRepo = FileUtils.mkTempDir("repoZipForDepAnalysis");
         repoZipContents = FileUtils.unzip(repoZipPath.toFile(), unzippedRepo);
 
         Optional<String> quarkusCore = repoZipContents.stream()
@@ -213,7 +211,7 @@ public class QuarkusCommunityDepAnalyzer extends AddOn {
     }
 
     private Path generateQuarkusProject(Predicate<String> artifactIdSelector, String settingsSelector) {
-        Path tempProjectLocation = mkTempDir("q-dep-analysis-generated-project").toPath();
+        Path tempProjectLocation = FileUtils.mkTempDir("q-dep-analysis-generated-project").toPath();
         List<String> extensionArtifactIds = findProductizedExtensions().stream()
                 .filter(artifactIdSelector)
                 .collect(Collectors.toList());

--- a/pig/src/main/java/org/jboss/pnc/bacon/pig/impl/addons/spring/BomVerifierAddon.java
+++ b/pig/src/main/java/org/jboss/pnc/bacon/pig/impl/addons/spring/BomVerifierAddon.java
@@ -34,7 +34,6 @@ import java.util.stream.Collectors;
 import java.util.stream.Stream;
 
 import static java.util.Collections.emptyList;
-import static org.jboss.pnc.bacon.pig.impl.utils.XmlUtils.listNodes;
 
 /**
  * @author Michal Szynkiewicz, michal.l.szynkiewicz@gmail.com <br>
@@ -122,7 +121,7 @@ public class BomVerifierAddon extends AddOn {
         build.findArtifactByFileName(pigConfiguration.getFlow().getRepositoryGeneration().getSourceArtifact())
                 .downloadTo(bom);
 
-        List<Node> nodeList = listNodes(bom, "//dependencies/dependency");
+        List<Node> nodeList = XmlUtils.listNodes(bom, "//dependencies/dependency");
         Map<String, String> properties = XmlUtils.getProperties(bom);
         return nodeList.stream().map(node -> GAV.fromXml((Element) node, properties));
     }

--- a/pig/src/main/java/org/jboss/pnc/bacon/pig/impl/documents/sharedcontent/BrewSearcher.java
+++ b/pig/src/main/java/org/jboss/pnc/bacon/pig/impl/documents/sharedcontent/BrewSearcher.java
@@ -19,6 +19,7 @@
 package org.jboss.pnc.bacon.pig.impl.documents.sharedcontent;
 
 import com.redhat.red.build.koji.model.xmlrpc.KojiTagInfo;
+import lombok.experimental.UtilityClass;
 import org.jboss.pnc.bacon.pig.impl.utils.BuildFinderUtils;
 import org.jboss.pnc.build.finder.koji.KojiBuild;
 import org.slf4j.Logger;
@@ -34,10 +35,11 @@ import java.util.stream.Collectors;
  * @author Michal Szynkiewicz, michal.l.szynkiewicz@gmail.com <br>
  *         Date: 6/19/17
  */
+@UtilityClass
 public class BrewSearcher {
-    private static final Logger log = LoggerFactory.getLogger(BrewSearcher.class);
+    private final Logger log = LoggerFactory.getLogger(BrewSearcher.class);
 
-    public static void fillBrewData(SharedContentReportRow row) {
+    public void fillBrewData(SharedContentReportRow row) {
         log.debug("Asking for {}\n", row.toGapv());
         List<KojiBuild> builds = getBuilds(row);
         builds.forEach(build -> {
@@ -55,16 +57,16 @@ public class BrewSearcher {
         });
     }
 
-    private static List<KojiBuild> getBuilds(SharedContentReportRow row) {
+    private List<KojiBuild> getBuilds(SharedContentReportRow row) {
         Path filePath = row.getFilePath();
         return getBuilds(filePath);
     }
 
-    public static List<KojiBuild> getBuilds(final Path filePath) {
+    public List<KojiBuild> getBuilds(final Path filePath) {
         return BuildFinderUtils.findBuilds(filePath, false);
     }
 
-    private static void fillBuiltBy(SharedContentReportRow row, KojiBuild build) {
+    private void fillBuiltBy(SharedContentReportRow row, KojiBuild build) {
         if (build.getBuildInfo() == null || build.getBuildInfo().getOwnerName() == null) {
             return;
         }
@@ -78,7 +80,7 @@ public class BrewSearcher {
         row.setBuildAuthor(value);
     }
 
-    private static void fillTags(SharedContentReportRow row, KojiBuild build) {
+    private void fillTags(SharedContentReportRow row, KojiBuild build) {
         if (build.getTags() == null) {
             return;
         }
@@ -90,8 +92,5 @@ public class BrewSearcher {
         } else {
             row.setBuildTags(tags);
         }
-    }
-
-    private BrewSearcher() {
     }
 }

--- a/pig/src/main/java/org/jboss/pnc/bacon/pig/impl/license/LicenseGenerator.java
+++ b/pig/src/main/java/org/jboss/pnc/bacon/pig/impl/license/LicenseGenerator.java
@@ -18,6 +18,7 @@
 
 package org.jboss.pnc.bacon.pig.impl.license;
 
+import lombok.experimental.UtilityClass;
 import me.snowdrop.licenses.LicensesGenerator;
 import me.snowdrop.licenses.LicensesGeneratorException;
 import me.snowdrop.licenses.properties.GeneratorProperties;
@@ -48,13 +49,11 @@ import java.util.stream.Stream;
  * @author Michal Szynkiewicz, michal.l.szynkiewicz@gmail.com <br>
  *         Date: 8/24/17
  */
+@UtilityClass
 public class LicenseGenerator {
-    private static final Logger log = LoggerFactory.getLogger(LicenseGenerator.class);
+    private final Logger log = LoggerFactory.getLogger(LicenseGenerator.class);
 
-    private LicenseGenerator() {
-    }
-
-    public static void generateLicenses(Collection<GAV> gavs, File archiveFile, String topLevelDirectoryName) {
+    public void generateLicenses(Collection<GAV> gavs, File archiveFile, String topLevelDirectoryName) {
         File temporaryDestination = FileUtils.mkTempDir("licenses");
         File topLevelDirectory = new File(temporaryDestination, topLevelDirectoryName);
 
@@ -63,7 +62,7 @@ public class LicenseGenerator {
         log.debug("Generated zip archive {}", archiveFile);
     }
 
-    public static void generateLicenses(Collection<GAV> gavs, File licensesDirectory, boolean useTempBuilds) {
+    public void generateLicenses(Collection<GAV> gavs, File licensesDirectory, boolean useTempBuilds) {
         try {
             LicensesGenerator generator = new LicensesGenerator(prepareGeneratorProperties(useTempBuilds));
 
@@ -93,7 +92,7 @@ public class LicenseGenerator {
         }
     }
 
-    public static void extractLicenses(File repoZip, File archiveFile, String topLevelDirectoryName) {
+    public void extractLicenses(File repoZip, File archiveFile, String topLevelDirectoryName) {
         File temporaryDestination = FileUtils.mkTempDir("licenses");
         File topLevelDirectory = new File(temporaryDestination, topLevelDirectoryName);
 
@@ -112,13 +111,13 @@ public class LicenseGenerator {
 
     }
 
-    private static List<Gav> gavsToLicenseGeneratorGavs(Collection<GAV> gavs) {
+    private List<Gav> gavsToLicenseGeneratorGavs(Collection<GAV> gavs) {
         return gavs.stream()
                 .map(gav -> new Gav(gav.getGroupId(), gav.getArtifactId(), gav.getVersion(), gav.getPackaging()))
                 .collect(Collectors.toList());
     }
 
-    private static GeneratorProperties prepareGeneratorProperties(boolean useTempBuilds) {
+    private GeneratorProperties prepareGeneratorProperties(boolean useTempBuilds) {
         Properties props = new Properties();
         PigConfig pig = Config.instance().getActiveProfile().getPig();
         String licenseServiceUrl = pig.getLicenseServiceUrl();

--- a/pig/src/main/java/org/jboss/pnc/bacon/pig/impl/nvr/NvrListGenerator.java
+++ b/pig/src/main/java/org/jboss/pnc/bacon/pig/impl/nvr/NvrListGenerator.java
@@ -17,6 +17,7 @@
  */
 package org.jboss.pnc.bacon.pig.impl.nvr;
 
+import lombok.experimental.UtilityClass;
 import org.jboss.pnc.bacon.pig.impl.utils.BuildFinderUtils;
 import org.jboss.pnc.build.finder.koji.KojiBuild;
 import org.jboss.pnc.build.finder.report.NVRReport;
@@ -31,13 +32,11 @@ import java.util.Collection;
 import java.util.List;
 import java.util.Map;
 
-public final class NvrListGenerator {
-    private static final Logger log = LoggerFactory.getLogger(NvrListGenerator.class);
+@UtilityClass
+public class NvrListGenerator {
+    private final Logger log = LoggerFactory.getLogger(NvrListGenerator.class);
 
-    private NvrListGenerator() {
-    }
-
-    public static boolean generateNvrList(Map<String, Collection<String>> checksums, Path targetPath) {
+    public boolean generateNvrList(Map<String, Collection<String>> checksums, Path targetPath) {
         log.info("Generating NVR list for {} checksums and saving result to {}", checksums.size(), targetPath);
 
         List<KojiBuild> builds = BuildFinderUtils.findBuilds(checksums, true);

--- a/pig/src/main/java/org/jboss/pnc/bacon/pig/impl/pnc/GitRepoInspector.java
+++ b/pig/src/main/java/org/jboss/pnc/bacon/pig/impl/pnc/GitRepoInspector.java
@@ -17,6 +17,7 @@
  */
 package org.jboss.pnc.bacon.pig.impl.pnc;
 
+import lombok.experimental.UtilityClass;
 import org.eclipse.jgit.api.Git;
 import org.eclipse.jgit.api.errors.GitAPIException;
 import org.eclipse.jgit.lib.ObjectId;
@@ -44,12 +45,13 @@ import java.util.Set;
  * @author Michal Szynkiewicz, michal.l.szynkiewicz@gmail.com <br>
  *         Date: 3/4/19
  */
+@UtilityClass
 public class GitRepoInspector {
+    private final Logger log = LoggerFactory.getLogger(GitRepoInspector.class);
 
-    private static final Logger log = LoggerFactory.getLogger(GitRepoInspector.class);
-    private static final String GIT_REMOTE_NAME = "prod";
+    private final String GIT_REMOTE_NAME = "prod";
 
-    private static final BuildInfoCollector buildInfoCollector = new BuildInfoCollector();
+    private final BuildInfoCollector buildInfoCollector = new BuildInfoCollector();
 
     /**
      * Check if branch 'refSpec' is different from the branch used in the last successful build (either temporary or
@@ -61,11 +63,7 @@ public class GitRepoInspector {
      * @param temporaryBuild
      * @return
      */
-    public static boolean isModifiedBranch(
-            String configId,
-            String internalUrl,
-            String refSpec,
-            boolean temporaryBuild) {
+    public boolean isModifiedBranch(String configId, String internalUrl, String refSpec, boolean temporaryBuild) {
 
         log.info(
                 "Trying to check if branch '{}' in '{}' has been modified, compared to latest build of build config '{}'",
@@ -94,9 +92,7 @@ public class GitRepoInspector {
         return false;
     }
 
-    private static Git cloneRepo(String internalUrl, File targetDir) throws GitAPIException, IOException {
-        log.debug("Cloning repository {} into {}", internalUrl, targetDir);
-
+    private Git cloneRepo(String internalUrl, File targetDir) throws GitAPIException, IOException {
         Git git = Git.init().setDirectory(targetDir).call();
 
         try (Repository repository = git.getRepository()) {
@@ -111,7 +107,7 @@ public class GitRepoInspector {
         return git;
     }
 
-    private static String headRevision(Git git, String branch) throws GitAPIException, IOException {
+    private String headRevision(Git git, String branch) throws GitAPIException, IOException {
         try (Repository repository = git.getRepository()) {
             Ref ref = getRef(branch, repository);
             ObjectId id = ref.getPeeledObjectId();
@@ -127,7 +123,7 @@ public class GitRepoInspector {
      * TODO: smarter check is required, here if a repour tag is on an "upstream" commit TODO: we may miss modifications
      * (because we return here the tag commit and its parent)
      */
-    private static Set<String> getBaseCommitPossibilities(Git git, String tagName) throws GitAPIException, IOException {
+    private Set<String> getBaseCommitPossibilities(Git git, String tagName) throws GitAPIException, IOException {
         log.debug("Getting base commit possibilities for tag: {}", tagName);
         Set<String> result = new HashSet<>();
 
@@ -146,7 +142,7 @@ public class GitRepoInspector {
         }
     }
 
-    private static String getLatestBuiltRevision(String configId, boolean temporaryBuild) {
+    private String getLatestBuiltRevision(String configId, boolean temporaryBuild) {
         log.debug("Getting latest built revision of config id {}, temporary: {}", configId, temporaryBuild);
         BuildInfoCollector.BuildSearchType searchType = temporaryBuild ? BuildInfoCollector.BuildSearchType.TEMPORARY
                 : BuildInfoCollector.BuildSearchType.PERMANENT;
@@ -154,7 +150,7 @@ public class GitRepoInspector {
         return latestBuild.getScmRevision();
     }
 
-    private static URIish toAnonymous(String internalUrl) throws MalformedURLException {
+    private URIish toAnonymous(String internalUrl) throws MalformedURLException {
         String uriAsString;
         if (internalUrl.startsWith("git+ssh")) {
             uriAsString = internalUrl.replace("git+ssh", "https").replace(".redhat.com/", ".redhat.com/gerrit/");
@@ -172,7 +168,7 @@ public class GitRepoInspector {
      * @return the ref if found
      * @throws IOException
      */
-    private static Ref getRef(String reference, Repository repository) throws IOException {
+    private Ref getRef(String reference, Repository repository) throws IOException {
 
         Ref ref = repository.findRef(GIT_REMOTE_NAME + "/" + reference);
 
@@ -180,8 +176,5 @@ public class GitRepoInspector {
             ref = repository.findRef(reference);
         }
         return ref;
-    }
-
-    private GitRepoInspector() {
     }
 }

--- a/pig/src/main/java/org/jboss/pnc/bacon/pig/impl/pnc/PncBuilder.java
+++ b/pig/src/main/java/org/jboss/pnc/bacon/pig/impl/pnc/PncBuilder.java
@@ -18,6 +18,7 @@
 package org.jboss.pnc.bacon.pig.impl.pnc;
 
 import org.jboss.pnc.bacon.pig.impl.utils.SleepUtils;
+import org.jboss.pnc.bacon.pnc.client.PncClientHelper;
 import org.jboss.pnc.client.ClientException;
 import org.jboss.pnc.client.GroupBuildClient;
 import org.jboss.pnc.client.GroupConfigurationClient;
@@ -29,8 +30,6 @@ import org.jboss.pnc.rest.api.parameters.GroupBuildParameters;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
-import static org.jboss.pnc.bacon.pnc.client.PncClientHelper.getPncConfiguration;
-
 /**
  * @author Michal Szynkiewicz, michal.l.szynkiewicz@gmail.com <br>
  *         Date: 11/14/17
@@ -41,8 +40,8 @@ public class PncBuilder {
     private final GroupConfigurationClient groupConfigClient;
 
     public PncBuilder() {
-        groupBuildClient = new GroupBuildClient(getPncConfiguration());
-        groupConfigClient = new GroupConfigurationClient(getPncConfiguration());
+        groupBuildClient = new GroupBuildClient(PncClientHelper.getPncConfiguration());
+        groupConfigClient = new GroupConfigurationClient(PncClientHelper.getPncConfiguration());
     }
 
     public GroupBuild buildAndWait(

--- a/pig/src/main/java/org/jboss/pnc/bacon/pig/impl/pnc/PncConfigurator.java
+++ b/pig/src/main/java/org/jboss/pnc/bacon/pig/impl/pnc/PncConfigurator.java
@@ -17,6 +17,7 @@
  */
 package org.jboss.pnc.bacon.pig.impl.pnc;
 
+import org.jboss.pnc.bacon.pig.impl.utils.PncClientUtils;
 import org.jboss.pnc.bacon.pnc.client.PncClientHelper;
 import org.jboss.pnc.client.ClientException;
 import org.jboss.pnc.client.ProductMilestoneClient;
@@ -34,8 +35,6 @@ import java.time.Instant;
 import java.time.LocalDate;
 import java.time.ZoneOffset;
 import java.util.Optional;
-
-import static org.jboss.pnc.bacon.pig.impl.utils.PncClientUtils.toStream;
 
 /**
  * @author Michal Szynkiewicz, michal.l.szynkiewicz@gmail.com <br>
@@ -83,7 +82,7 @@ public class PncConfigurator {
             throw new RuntimeException("Error getting milestone for milestoneName: " + milestoneName, e);
         }
 
-        return toStream(milestones).findAny();
+        return PncClientUtils.toStream(milestones).findAny();
     }
 
     private ProductMilestone createMilestone(ProductVersionRef version, String milestoneName) {

--- a/pig/src/main/java/org/jboss/pnc/bacon/pig/impl/repo/ArtifactVersion.java
+++ b/pig/src/main/java/org/jboss/pnc/bacon/pig/impl/repo/ArtifactVersion.java
@@ -1,5 +1,6 @@
 package org.jboss.pnc.bacon.pig.impl.repo;
 
+import lombok.experimental.UtilityClass;
 import org.jboss.pnc.bacon.pig.impl.pnc.ArtifactWrapper;
 import org.jboss.pnc.bacon.pig.impl.pnc.PncBuild;
 import org.jboss.pnc.bacon.pig.impl.utils.GAV;
@@ -10,17 +11,15 @@ import java.util.Optional;
 /**
  * @author Michal Szynkiewicz, michal.l.szynkiewicz@gmail.com 2020-06-05
  */
+@UtilityClass
 public class ArtifactVersion {
-    public static String prefix = "artifactVersion://";
-
-    private ArtifactVersion() {
-    }
+    public String prefix = "artifactVersion://";
 
     /*
      * gets artifact coordinates from a location of a form artifactVersion://groupId:artifactId[@buildName] and gets a
      * version of the artifact from the build
      */
-    public static String get(String location, String defaultBuildName, Map<String, PncBuild> builds) {
+    public String get(String location, String defaultBuildName, Map<String, PncBuild> builds) {
         if (!location.startsWith(ArtifactVersion.prefix)) {
             throw new RuntimeException("location: " + location + " is not a proper artifactVersion location");
         }

--- a/pig/src/main/java/org/jboss/pnc/bacon/pig/impl/repo/ExternalArtifactDownloader.java
+++ b/pig/src/main/java/org/jboss/pnc/bacon/pig/impl/repo/ExternalArtifactDownloader.java
@@ -17,6 +17,7 @@
  */
 package org.jboss.pnc.bacon.pig.impl.repo;
 
+import lombok.experimental.UtilityClass;
 import org.jboss.pnc.bacon.pig.impl.utils.FileDownloadUtils;
 import org.jboss.pnc.bacon.pig.impl.utils.GAV;
 import org.jboss.pnc.bacon.pig.impl.utils.indy.Indy;
@@ -31,20 +32,17 @@ import java.nio.file.Path;
  * @author Michal Szynkiewicz, michal.l.szynkiewicz@gmail.com <br>
  *         Date: 5/10/18
  */
+@UtilityClass
 public class ExternalArtifactDownloader {
+    private final Logger log = LoggerFactory.getLogger(ExternalArtifactDownloader.class);
 
-    private static final Logger log = LoggerFactory.getLogger(ExternalArtifactDownloader.class);
-
-    private ExternalArtifactDownloader() {
-    }
-
-    public static File downloadExternalArtifact(GAV gav, Path targetRepoContents, boolean sourcesOptional) {
+    public File downloadExternalArtifact(GAV gav, Path targetRepoContents, boolean sourcesOptional) {
         File targetPath = targetPath(gav, targetRepoContents);
 
         return downloadExternalArtifact(gav, targetPath, sourcesOptional);
     }
 
-    public static File downloadExternalArtifact(GAV gav, File targetPath, boolean sourcesOptional) {
+    public File downloadExternalArtifact(GAV gav, File targetPath, boolean sourcesOptional) {
         targetPath.toPath().getParent().toFile().mkdirs();
 
         String indyUrl = gav.isTemporary() ? Indy.getIndyTempUrl() : Indy.getIndyUrl();
@@ -63,7 +61,7 @@ public class ExternalArtifactDownloader {
         return targetPath;
     }
 
-    public static File targetPath(GAV gav, Path targetRepoContents) {
+    public File targetPath(GAV gav, Path targetRepoContents) {
         Path versionPath = targetRepoContents.resolve(gav.toVersionPath());
         return versionPath.resolve(gav.toFileName()).toFile();
     }

--- a/pig/src/main/java/org/jboss/pnc/bacon/pig/impl/repo/RepoBuilder.java
+++ b/pig/src/main/java/org/jboss/pnc/bacon/pig/impl/repo/RepoBuilder.java
@@ -63,8 +63,8 @@ public class RepoBuilder {
     private final RepoGenerationData repoGeneration;
     private final Map<String, PncBuild> builds;
     private final String additionalRepo;
-    String topLevelDirectoryName;
-    Path configurationDirectory;
+    private String topLevelDirectoryName;
+    private Path configurationDirectory;
 
     public RepoBuilder(
             PigConfiguration pigConfiguration,
@@ -117,7 +117,7 @@ public class RepoBuilder {
         buildProjectWithOverriddenM2(projectLocation, repoDir, settingsXml);
     }
 
-    private Properties settingsProps(boolean tempBuild, String additionalRepo) {
+    private static Properties settingsProps(boolean tempBuild, String additionalRepo) {
         Properties result = new Properties();
         if (tempBuild) {
             String repoDef = "--> <repository>\n" + "          <id>additional</id>\n" + "          <url>"
@@ -175,10 +175,10 @@ public class RepoBuilder {
     protected File createProject(File bomFile, Predicate<GAV> artifactSelector) throws IOException {
         log.debug("Generating a project with all libraries from BOM as dependencies");
         String dependencies = extractRedhatDependencies(bomFile, artifactSelector);
-        String bomVersion = XmlUtils.extract(bomFile, "/project/version").getContent();
+        String bomVersion = XmlUtils.extract(bomFile, "/project/version");
 
         if (bomVersion == null) {
-            bomVersion = XmlUtils.extract(bomFile, "/project/parent/version").getContent();
+            bomVersion = XmlUtils.extract(bomFile, "/project/parent/version");
         }
 
         if (bomVersion == null) {
@@ -219,7 +219,7 @@ public class RepoBuilder {
             return value;
         }
 
-        if (ArtifactVersion.prefix.startsWith(ArtifactVersion.prefix)) {
+        if (value.startsWith(ArtifactVersion.prefix)) {
             return ArtifactVersion.get(value, repoGeneration.getSourceBuild(), builds);
         }
 

--- a/pig/src/main/java/org/jboss/pnc/bacon/pig/impl/repo/RepoDescriptor.java
+++ b/pig/src/main/java/org/jboss/pnc/bacon/pig/impl/repo/RepoDescriptor.java
@@ -17,6 +17,7 @@
  */
 package org.jboss.pnc.bacon.pig.impl.repo;
 
+import lombok.experimental.UtilityClass;
 import org.jboss.pnc.bacon.pig.impl.utils.GAV;
 
 import java.io.File;
@@ -32,12 +33,13 @@ import java.util.stream.Stream;
  * @author Michal Szynkiewicz, michal.l.szynkiewicz@gmail.com <br>
  *         Date: 11/14/17
  */
+@UtilityClass
 public class RepoDescriptor {
 
-    public static final String[] CHECKSUM_EXTENSIONS = { ".md5", ".sha1", "maven-metadata.xml" };
-    public static final String MAVEN_REPOSITORY = "maven-repository/";
+    public final String[] CHECKSUM_EXTENSIONS = { ".md5", ".sha1", "maven-metadata.xml" };
+    public final String MAVEN_REPOSITORY = "maven-repository/";
 
-    public static Collection<GAV> listGavs(File m2RepoDirectory) {
+    public Collection<GAV> listGavs(File m2RepoDirectory) {
         List<GAV> allGavs = listFiles(m2RepoDirectory).stream()
                 .filter(f -> Stream.of(CHECKSUM_EXTENSIONS).noneMatch(ext -> f.getName().endsWith(ext)))
                 .map(f -> GAV.fromFileName(f.getAbsolutePath(), MAVEN_REPOSITORY))
@@ -47,10 +49,7 @@ public class RepoDescriptor {
         return resultSet;
     }
 
-    public static Collection<File> listFiles(File m2RepoDirectory) {
+    public Collection<File> listFiles(File m2RepoDirectory) {
         return org.apache.commons.io.FileUtils.listFiles(m2RepoDirectory, null, true);
-    }
-
-    private RepoDescriptor() {
     }
 }

--- a/pig/src/main/java/org/jboss/pnc/bacon/pig/impl/repo/RepoManager.java
+++ b/pig/src/main/java/org/jboss/pnc/bacon/pig/impl/repo/RepoManager.java
@@ -183,21 +183,21 @@ public class RepoManager extends DeliverableManager<RepoGenerationData, Reposito
         return repackage(sourceDir);
     }
 
-    private RepositoryData milestone() {
+    private static RepositoryData milestone() {
         log.info("Generating maven repo for milestone [{}]", PigContext.get().getFullVersion());
         // TODO
         throw new FatalException("Not yet implemented");
     }
 
-    private boolean areSourcesMissing(Set<GAV> list, GAV gav) {
+    private static boolean areSourcesMissing(Set<GAV> list, GAV gav) {
         return list.stream().noneMatch(a -> a.equals(gav) && "sources".equals(a.getClassifier()));
     }
 
-    private boolean isPomMissing(Set<GAV> list, GAV gav) {
+    private static boolean isPomMissing(Set<GAV> list, GAV gav) {
         return list.stream().noneMatch(a -> a.equals(gav) && "pom".equals(a.getPackaging()));
     }
 
-    private boolean areJavadocsMissing(Set<GAV> list, GAV gav) {
+    private static boolean areJavadocsMissing(Set<GAV> list, GAV gav) {
         return list.stream().noneMatch(a -> a.equals(gav) && "javadoc".equals(a.getClassifier()));
     }
 
@@ -211,6 +211,7 @@ public class RepoManager extends DeliverableManager<RepoGenerationData, Reposito
         return false;
     }
 
+    @Override
     protected RepositoryData downloadAndRepackage() {
         log.info("downloading and repackaging maven repository");
         File sourceTopLevelDirectory = download();
@@ -320,7 +321,7 @@ public class RepoManager extends DeliverableManager<RepoGenerationData, Reposito
         return repackage(new File(repoParentDir, "maven-repository"));
     }
 
-    private Predicate<GAV> predicate(Map<String, String> stage) {
+    private static Predicate<GAV> predicate(Map<String, String> stage) {
         String matching = stage.getOrDefault("matching", ".*");
         String notMatching = stage.getOrDefault("not-matching", "^$");
         return gav -> {
@@ -337,7 +338,7 @@ public class RepoManager extends DeliverableManager<RepoGenerationData, Reposito
         return pigConfiguration.getTopLevelDirectoryPrefix() + "maven-repository";
     }
 
-    private RepositoryData result(File targetTopLevelDirectory, Path targetZipPath) {
+    private static RepositoryData result(File targetTopLevelDirectory, Path targetZipPath) {
         RepositoryData result = new RepositoryData();
         File contentsDirectory = new File(targetTopLevelDirectory, "maven-repository");
         result.setFiles(RepoDescriptor.listFiles(contentsDirectory));

--- a/pig/src/main/java/org/jboss/pnc/bacon/pig/impl/repo/RepositoryUtils.java
+++ b/pig/src/main/java/org/jboss/pnc/bacon/pig/impl/repo/RepositoryUtils.java
@@ -61,14 +61,15 @@ import static java.util.Comparator.comparingInt;
  * @author Michal Szynkiewicz, michal.l.szynkiewicz@gmail.com <br>
  *         Date: 1/18/18
  */
+// @UtilityClass
 public class RepositoryUtils {
     private static final Logger log = LoggerFactory.getLogger(RepositoryUtils.class);
 
     public static void generateMavenMetadata(File mavenRepositoryDirectory) {
         log.debug("Generating maven-metadata.xml files");
         Set<String> pomPaths = new HashSet<>();
-        RepositoryUtils.searchForPomPaths(mavenRepositoryDirectory, mavenRepositoryDirectory, pomPaths);
-        RepositoryUtils.generateMetadata(mavenRepositoryDirectory, pomPaths);
+        searchForPomPaths(mavenRepositoryDirectory, mavenRepositoryDirectory, pomPaths);
+        generateMetadata(mavenRepositoryDirectory, pomPaths);
     }
 
     private static void searchForPomPaths(File root, File mavenRepositoryDirectory, Set<String> pomPaths) {
@@ -197,7 +198,7 @@ public class RepositoryUtils {
         removeMatchingCondition(element, RepositoryUtils::isCommunity);
     }
 
-    private static boolean isCommunity(File f) {
+    static boolean isCommunity(File f) {
         String absolutePath = f.getAbsolutePath();
         return !absolutePath.contains("redhat-") && !absolutePath.contains("eap-runtime-artifacts");
     }
@@ -223,7 +224,7 @@ public class RepositoryUtils {
                 }
 
                 final List<File> redHatFiles = Stream.of(children)
-                        .filter(f -> !isCommunity(f))
+                        .filter(RepositoryUtils::isCommunity)
                         .collect(Collectors.toList());
 
                 if (redHatFiles.isEmpty()) {
@@ -241,7 +242,7 @@ public class RepositoryUtils {
                             matchingRHArtifactVersions.sort(comparingInt(e -> e.getValue().getRedhatBuildNumber()));
                             Collections.reverse(matchingRHArtifactVersions);
 
-                            matchingRHArtifactVersions.stream().skip(1).forEach(e -> {
+                            matchingRHArtifactVersions.stream().skip(1L).forEach(e -> {
                                 final File directoryToBeDeleted = e.getKey();
 
                                 log.info(
@@ -261,7 +262,7 @@ public class RepositoryUtils {
         });
     }
 
-    private static class RedHatArtifactVersion {
+    private static final class RedHatArtifactVersion {
         private final String upstreamVersion;
         private final int redhatBuildNumber;
 
@@ -309,8 +310,5 @@ public class RepositoryUtils {
         public int hashCode() {
             return Objects.hash(upstreamVersion, redhatBuildNumber);
         }
-    }
-
-    private RepositoryUtils() {
     }
 }

--- a/pig/src/main/java/org/jboss/pnc/bacon/pig/impl/sources/SourcesGenerator.java
+++ b/pig/src/main/java/org/jboss/pnc/bacon/pig/impl/sources/SourcesGenerator.java
@@ -33,8 +33,6 @@ import java.util.function.Predicate;
 import java.util.stream.Collectors;
 import java.util.stream.Stream;
 
-import static org.jboss.pnc.bacon.pig.impl.utils.GerritUtils.gerritSnapshotDownloadUrl;
-
 public class SourcesGenerator {
     private static final Logger log = LoggerFactory.getLogger(SourcesGenerator.class);
 
@@ -88,8 +86,6 @@ public class SourcesGenerator {
 
     private void downloadSourcesFromBuilds(Map<String, PncBuild> builds, File workDir, File contentsDir) {
         builds.values().forEach(build -> {
-            URI url = gerritSnapshotDownloadUrl(build.getInternalScmUrl(), build.getScmRevision());
-
             File targetPath = new File(workDir, build.getName() + ".tar.gz");
             try (BuildClient client = CREATOR.newClient();
                     Response response = client.getInternalScmArchiveLink(build.getId())) {

--- a/pig/src/main/java/org/jboss/pnc/bacon/pig/impl/utils/BuildFinderUtils.java
+++ b/pig/src/main/java/org/jboss/pnc/bacon/pig/impl/utils/BuildFinderUtils.java
@@ -1,6 +1,7 @@
 package org.jboss.pnc.bacon.pig.impl.utils;
 
 import com.redhat.red.build.koji.KojiClientException;
+import lombok.experimental.UtilityClass;
 import org.apache.commons.collections4.MultiValuedMap;
 import org.apache.commons.collections4.multimap.ArrayListValuedHashMap;
 import org.jboss.pnc.bacon.config.Config;
@@ -30,20 +31,17 @@ import java.util.concurrent.ExecutorService;
 import java.util.concurrent.Executors;
 import java.util.concurrent.Future;
 
-public final class BuildFinderUtils {
-    private static final Logger log = LoggerFactory.getLogger(BuildFinderUtils.class);
+@UtilityClass
+public class BuildFinderUtils {
+    private final Logger log = LoggerFactory.getLogger(BuildFinderUtils.class);
 
-    private BuildFinderUtils() {
+    private final String KOJI_BUILD_FINDER_CONFIG_ENV = "KOJI_BUILD_FINDER_CONFIG";
 
-    }
+    private final String KOJI_BUILD_FINDER_CONFIG_PROP = "koji.build.finder.config";
 
-    private static final String KOJI_BUILD_FINDER_CONFIG_ENV = "KOJI_BUILD_FINDER_CONFIG";
+    private final String KOJI_BUILD_FINDER_CONFIG_TEMPLATE = "/koji-build-finder/config.json";
 
-    private static final String KOJI_BUILD_FINDER_CONFIG_PROP = "koji.build.finder.config";
-
-    private static final String KOJI_BUILD_FINDER_CONFIG_TEMPLATE = "/koji-build-finder/config.json";
-
-    private static Map<Checksum, Collection<String>> mapToMultiMap(Map<String, Collection<String>> checksums) {
+    private Map<Checksum, Collection<String>> mapToMultiMap(Map<String, Collection<String>> checksums) {
         Set<Map.Entry<String, Collection<String>>> entries = checksums.entrySet();
         MultiValuedMap<Checksum, String> multiMap = new ArrayListValuedHashMap<>(entries.size());
 
@@ -60,7 +58,7 @@ public final class BuildFinderUtils {
         return Collections.unmodifiableMap(multiMap.asMap());
     }
 
-    public static BuildConfig getKojiBuildFinderConfigFromFile(File file) {
+    public BuildConfig getKojiBuildFinderConfigFromFile(File file) {
         try {
             return BuildConfig.load(file);
         } catch (IOException e) {
@@ -70,11 +68,11 @@ public final class BuildFinderUtils {
         }
     }
 
-    public static BuildConfig getKojiBuildFinderConfigFromFile(String filename) {
+    public BuildConfig getKojiBuildFinderConfigFromFile(String filename) {
         return getKojiBuildFinderConfigFromFile(new File(filename));
     }
 
-    public static BuildConfig getKojiBuildFinderConfigFromResource(String resourceName) {
+    public BuildConfig getKojiBuildFinderConfigFromResource(String resourceName) {
         Properties props = new Properties();
         props.setProperty("KOJI_URL", Config.instance().getActiveProfile().getPig().getKojiHubUrl());
 
@@ -83,7 +81,7 @@ public final class BuildFinderUtils {
         return getKojiBuildFinderConfigFromJson(json);
     }
 
-    public static BuildConfig getKojiBuildFinderConfigFromJson(String json) {
+    public BuildConfig getKojiBuildFinderConfigFromJson(String json) {
         try {
             return BuildConfig.load(json);
         } catch (IOException e) {
@@ -91,7 +89,7 @@ public final class BuildFinderUtils {
         }
     }
 
-    public static BuildConfig getKojiBuildFinderConfig() {
+    public BuildConfig getKojiBuildFinderConfig() {
         String propFilename = System.getProperty(KOJI_BUILD_FINDER_CONFIG_PROP);
 
         if (propFilename != null) {
@@ -113,7 +111,7 @@ public final class BuildFinderUtils {
      * @param file the file
      * @return the checksums
      */
-    public static Map<String, Collection<String>> findChecksums(File file) {
+    public Map<String, Collection<String>> findChecksums(File file) {
         BuildConfig config = getKojiBuildFinderConfig();
         List<String> inputs = Collections.singletonList(file.getPath());
         ExecutorService pool = Executors.newSingleThreadExecutor();
@@ -144,7 +142,7 @@ public final class BuildFinderUtils {
      * @param includeNotFound whether or not to include not found files as build index 0
      * @return the builds, including not found files if includeNotFound is true, or the found builds otherwise
      */
-    public static List<KojiBuild> findBuilds(Map<String, Collection<String>> checksums, boolean includeNotFound) {
+    public List<KojiBuild> findBuilds(Map<String, Collection<String>> checksums, boolean includeNotFound) {
         BuildConfig config = getKojiBuildFinderConfig();
 
         try (KojiClientSession session = new KojiClientSession(config.getKojiHubURL())) {
@@ -168,7 +166,7 @@ public final class BuildFinderUtils {
      * @param includeNotFound whether or not to include not found files as build index 0
      * @return the builds, including not found files if includeNotFound is true, or the found builds otherwise
      */
-    public static List<KojiBuild> findBuilds(File file, boolean includeNotFound) {
+    public List<KojiBuild> findBuilds(File file, boolean includeNotFound) {
         BuildConfig config = getKojiBuildFinderConfig();
         List<String> inputs = Collections.singletonList(file.getPath());
         ExecutorService pool = Executors.newFixedThreadPool(2);
@@ -217,7 +215,7 @@ public final class BuildFinderUtils {
      * @param includeNotFound whether or not to include not found files as build index 0
      * @return the builds, including not found files if includeNotFound is true, or the found builds otherwise
      */
-    public static List<KojiBuild> findBuilds(Path path, boolean includeNotFound) {
+    public List<KojiBuild> findBuilds(Path path, boolean includeNotFound) {
         return findBuilds(path.toFile(), includeNotFound);
     }
 
@@ -228,7 +226,7 @@ public final class BuildFinderUtils {
      * @param includeNotFound whether or not to include not found files as build index 0
      * @return the builds, including not found files if includeNotFound is true, or the found builds otherwise
      */
-    public static List<KojiBuild> findBuilds(String filename, boolean includeNotFound) {
+    public List<KojiBuild> findBuilds(String filename, boolean includeNotFound) {
         return findBuilds(new File(filename), includeNotFound);
     }
 }

--- a/pig/src/main/java/org/jboss/pnc/bacon/pig/impl/utils/CSVUtils.java
+++ b/pig/src/main/java/org/jboss/pnc/bacon/pig/impl/utils/CSVUtils.java
@@ -1,5 +1,6 @@
 package org.jboss.pnc.bacon.pig.impl.utils;
 
+import lombok.experimental.UtilityClass;
 import org.apache.commons.csv.CSVFormat;
 import org.apache.commons.csv.CSVParser;
 
@@ -14,8 +15,9 @@ import java.util.stream.Collectors;
 /**
  * @author Harsh Madhani<harshmadhani@gmail.com> Date: 06-August-2020
  */
+@UtilityClass
 public class CSVUtils {
-    public static Set<String> columnValues(String columnName, String filePath, char delimiter) throws IOException {
+    public Set<String> columnValues(String columnName, String filePath, char delimiter) throws IOException {
         try (Reader in = Files.newBufferedReader(Paths.get(filePath), StandardCharsets.UTF_8);
                 CSVParser parser = CSVFormat.EXCEL.withDelimiter(delimiter).withFirstRecordAsHeader().parse(in)) {
             return parser.getRecords().stream().map(record -> record.get(columnName)).collect(Collectors.toSet());

--- a/pig/src/main/java/org/jboss/pnc/bacon/pig/impl/utils/CollectionUtils.java
+++ b/pig/src/main/java/org/jboss/pnc/bacon/pig/impl/utils/CollectionUtils.java
@@ -18,6 +18,8 @@
 
 package org.jboss.pnc.bacon.pig.impl.utils;
 
+import lombok.experimental.UtilityClass;
+
 import java.util.HashSet;
 import java.util.Set;
 
@@ -25,12 +27,9 @@ import java.util.Set;
  * @author Michal Szynkiewicz, michal.l.szynkiewicz@gmail.com <br>
  *         Date: 7/7/17
  */
+@UtilityClass
 public class CollectionUtils {
-
-    private CollectionUtils() {
-    }
-
-    public static <T> Set<T> subtractSet(Set<T> minuend, Set<T> subtrahend) {
+    public <T> Set<T> subtractSet(Set<T> minuend, Set<T> subtrahend) {
         Set<T> resultSet = new HashSet<>(minuend);
         resultSet.removeAll(subtrahend);
         return resultSet;

--- a/pig/src/main/java/org/jboss/pnc/bacon/pig/impl/utils/FileDownloadUtils.java
+++ b/pig/src/main/java/org/jboss/pnc/bacon/pig/impl/utils/FileDownloadUtils.java
@@ -17,6 +17,7 @@
  */
 package org.jboss.pnc.bacon.pig.impl.utils;
 
+import lombok.experimental.UtilityClass;
 import org.apache.commons.io.IOUtils;
 import org.apache.http.client.config.RequestConfig;
 import org.apache.http.client.methods.CloseableHttpResponse;
@@ -38,24 +39,20 @@ import java.net.URI;
  * @author Michal Szynkiewicz, michal.l.szynkiewicz@gmail.com <br>
  *         Date: 4/16/18
  */
+@UtilityClass
 public class FileDownloadUtils {
-    private FileDownloadUtils() {
-    }
+    private final Logger log = LoggerFactory.getLogger(FileDownloadUtils.class);
 
-    private static final Logger log = LoggerFactory.getLogger(FileDownloadUtils.class);
+    private final int CONNECTION_TIMEOUT = 300000;
 
-    private static final int CONNECTION_TIMEOUT = 300000;
-
-    private static final int READ_TIMEOUT = 900000;
-
-    private static final int MAX_RETRIES = 5;
+    private final int READ_TIMEOUT = 900000;
 
     private static final RequestConfig requestConfig = RequestConfig.copy(RequestConfig.DEFAULT)
             .setConnectTimeout(CONNECTION_TIMEOUT)
             .setSocketTimeout(READ_TIMEOUT)
             .build();
 
-    public static void downloadTo(URI downloadUrl, File targetPath) {
+    public void downloadTo(URI downloadUrl, File targetPath) {
         log.info("Downloading {} to {}", downloadUrl, targetPath);
 
         try (CloseableHttpClient httpClient = HttpClients.custom().setDefaultRequestConfig(requestConfig).build()) {
@@ -78,8 +75,7 @@ public class FileDownloadUtils {
         log.info("Downloaded {} to {}", downloadUrl, targetPath);
     }
 
-    private static void downloadWithClient(CloseableHttpClient httpClient, URI downloadUrl, File targetPath)
-            throws Exception {
+    private void downloadWithClient(CloseableHttpClient httpClient, URI downloadUrl, File targetPath) throws Exception {
         try (CloseableHttpResponse response = httpClient.execute(new HttpGet(downloadUrl))) {
             int statusCode = response.getStatusLine().getStatusCode();
             if (statusCode < 200 || statusCode > 299) {

--- a/pig/src/main/java/org/jboss/pnc/bacon/pig/impl/utils/FileUtils.java
+++ b/pig/src/main/java/org/jboss/pnc/bacon/pig/impl/utils/FileUtils.java
@@ -18,6 +18,7 @@
 
 package org.jboss.pnc.bacon.pig.impl.utils;
 
+import lombok.experimental.UtilityClass;
 import org.apache.commons.compress.archivers.ArchiveEntry;
 import org.apache.commons.compress.archivers.ArchiveException;
 import org.apache.commons.compress.archivers.ArchiveInputStream;
@@ -73,14 +74,11 @@ import static java.nio.file.Files.createTempDirectory;
  * @author Michal Szynkiewicz, michal.l.szynkiewicz@gmail.com <br>
  *         Date: 7/28/17
  */
-public final class FileUtils {
-    private static final Logger log = LoggerFactory.getLogger(FileUtils.class);
+@UtilityClass
+public class FileUtils {
+    private final Logger log = LoggerFactory.getLogger(FileUtils.class);
 
-    private FileUtils() {
-
-    }
-
-    public static File mkTempDir(final String prefix) {
+    public File mkTempDir(final String prefix) {
         try {
             return createTempDirectory(prefix).toFile();
         } catch (IOException e) {
@@ -88,7 +86,7 @@ public final class FileUtils {
         }
     }
 
-    public static String getCompressorType(final File file) {
+    public String getCompressorType(final File file) {
         try (final InputStream is = Files.newInputStream(file.toPath());
                 final BufferedInputStream bis = new BufferedInputStream(is)) {
             return CompressorStreamFactory.detect(bis);
@@ -97,7 +95,7 @@ public final class FileUtils {
         }
     }
 
-    public static String getCompressorType(final String filename) {
+    public String getCompressorType(final String filename) {
         if (BZip2Utils.isCompressedFilename(filename)) {
             return CompressorStreamFactory.BZIP2;
         } else if (GzipUtils.isCompressedFilename(filename)) {
@@ -111,7 +109,7 @@ public final class FileUtils {
         }
     }
 
-    public static void setModeAndLastModifiedTime(Path path, ArchiveEntry entry) throws IOException {
+    public void setModeAndLastModifiedTime(Path path, ArchiveEntry entry) throws IOException {
         final FileSystem fileSystem = path.getFileSystem();
         final Set<String> attributeViews = fileSystem.supportedFileAttributeViews();
 
@@ -162,8 +160,7 @@ public final class FileUtils {
     // FIXME: Setting the mode on a directory before extracting its files can cause problems
     // FIXME: We should not set the mode until all files in that directory are extracted
     // FIXME: See <https://www.gnu.org/software/tar/manual/tar.html#SEC85>.
-    public static void setModeAndLastModifiedTime(final Path path, final int mode, final FileTime time)
-            throws IOException {
+    public void setModeAndLastModifiedTime(final Path path, final int mode, final FileTime time) throws IOException {
         final FileSystem fileSystem = path.getFileSystem();
         final Set<String> attributeViews = fileSystem.supportedFileAttributeViews();
 
@@ -200,7 +197,7 @@ public final class FileUtils {
         }
     }
 
-    public static Collection<String> untar(final File input, final File directory) {
+    public Collection<String> untar(final File input, final File directory) {
         log.debug("tar -xf {} -C {}", input, directory);
 
         final String compressorType = getCompressorType(input);
@@ -273,7 +270,7 @@ public final class FileUtils {
         return Collections.unmodifiableCollection(entries);
     }
 
-    public static Collection<String> tar(final File output, final File workingDirectory, final File directoryToTar) {
+    public Collection<String> tar(final File output, final File workingDirectory, final File directoryToTar) {
         final Path directory = directoryToTar.toPath();
 
         log.debug("tar -cf {} {}", output, directory);
@@ -340,7 +337,7 @@ public final class FileUtils {
         return Collections.unmodifiableCollection(entries);
     }
 
-    public static Collection<String> listZipContents(final File input) {
+    public Collection<String> listZipContents(final File input) {
         log.debug("Listing contents of {}", input);
 
         try (final InputStream is = Files.newInputStream(input.toPath());
@@ -359,11 +356,11 @@ public final class FileUtils {
         }
     }
 
-    public static Collection<String> unzip(final File input, final File directory) {
+    public Collection<String> unzip(final File input, final File directory) {
         return unzip(input, directory, null);
     }
 
-    public static Collection<String> unzip(final File input, final File directory, final String extraction) {
+    public Collection<String> unzip(final File input, final File directory, final String extraction) {
         log.debug("unzip -o {} -d {}", input, directory);
 
         Pattern extractionPattern = null;
@@ -440,7 +437,7 @@ public final class FileUtils {
         return Collections.unmodifiableCollection(entries);
     }
 
-    public static Collection<String> zip(final File output, final File workingDirectory, final File directoryToZip) {
+    public Collection<String> zip(final File output, final File workingDirectory, final File directoryToZip) {
         final Path directory = directoryToZip.toPath();
 
         log.debug("zip -r {} {}", output, directory);
@@ -497,7 +494,7 @@ public final class FileUtils {
         return Collections.unmodifiableCollection(entries);
     }
 
-    public static void copy(final File srcFile, final File destFile) {
+    public void copy(final File srcFile, final File destFile) {
         try {
             if (srcFile.isFile()) {
                 if (destFile.isFile()) {
@@ -524,7 +521,7 @@ public final class FileUtils {
      * @param srcDir the path to the directory to move
      * @param destDir the path to the target directory
      */
-    public static boolean moveDirectoryContents(final File srcDir, final File destDir) throws IOException {
+    public boolean moveDirectoryContents(final File srcDir, final File destDir) throws IOException {
         if (!srcDir.isDirectory() || !destDir.isDirectory()) {
             return false;
         }

--- a/pig/src/main/java/org/jboss/pnc/bacon/pig/impl/utils/GerritUtils.java
+++ b/pig/src/main/java/org/jboss/pnc/bacon/pig/impl/utils/GerritUtils.java
@@ -17,20 +17,19 @@
  */
 package org.jboss.pnc.bacon.pig.impl.utils;
 
+import lombok.experimental.UtilityClass;
+
 import java.net.URI;
 
 /**
  * @author Michal Szynkiewicz, michal.l.szynkiewicz@gmail.com <br>
  *         Date: 8/31/18
  */
+@UtilityClass
 public class GerritUtils {
+    public final String GERRIT = "gerrit";
 
-    private GerritUtils() {
-    }
-
-    public static final String GERRIT = "gerrit";
-
-    public static URI gerritSnapshotDownloadUrl(String scmUrl, String scmRevision) {
+    public URI gerritSnapshotDownloadUrl(String scmUrl, String scmRevision) {
         String uriString = String.format(
                 "https://%s/gitweb?p=%s;a=snapshot;h=%s;sf=tgz",
                 gerritUrl(scmUrl),
@@ -39,11 +38,11 @@ public class GerritUtils {
         return URI.create(uriString);
     }
 
-    public static String repository(String scmUrl) {
+    public String repository(String scmUrl) {
         return scmUrl.substring(scmUrl.indexOf(GERRIT) + GERRIT.length() + 1);
     }
 
-    public static String gerritUrl(String scmUrl) {
+    public String gerritUrl(String scmUrl) {
         String result = scmUrl.replaceAll("^.*://", "");
         result = result.substring(0, result.indexOf(GERRIT) + GERRIT.length());
         return result;

--- a/pig/src/main/java/org/jboss/pnc/bacon/pig/impl/utils/HashUtils.java
+++ b/pig/src/main/java/org/jboss/pnc/bacon/pig/impl/utils/HashUtils.java
@@ -1,5 +1,6 @@
 package org.jboss.pnc.bacon.pig.impl.utils;
 
+import lombok.experimental.UtilityClass;
 import org.apache.commons.codec.digest.DigestUtils;
 import org.jboss.resteasy.util.Hex;
 
@@ -9,11 +10,9 @@ import java.nio.file.Path;
 import java.security.MessageDigest;
 import java.util.stream.Stream;
 
+@UtilityClass
 public class HashUtils {
-    private HashUtils() {
-    }
-
-    public static String hashDirectory(Path directory) {
+    public String hashDirectory(Path directory) {
         MessageDigest sha = DigestUtils.getSha512Digest();
         try (Stream<Path> stream = Files.walk(directory)) {
             stream.filter(Files::isRegularFile).sorted().forEach(path -> {
@@ -29,5 +28,4 @@ public class HashUtils {
         }
         return Hex.encodeHex(sha.digest());
     }
-
 }

--- a/pig/src/main/java/org/jboss/pnc/bacon/pig/impl/utils/MavenRepositoryUtils.java
+++ b/pig/src/main/java/org/jboss/pnc/bacon/pig/impl/utils/MavenRepositoryUtils.java
@@ -1,5 +1,8 @@
 package org.jboss.pnc.bacon.pig.impl.utils;
 
+import lombok.experimental.UtilityClass;
+import org.jboss.pnc.bacon.pig.impl.repo.RepoDescriptor;
+
 import java.io.IOException;
 import java.nio.file.Files;
 import java.nio.file.Path;
@@ -8,15 +11,13 @@ import java.util.Optional;
 import java.util.stream.Collectors;
 import java.util.stream.Stream;
 
-import static org.jboss.pnc.bacon.pig.impl.repo.RepoDescriptor.MAVEN_REPOSITORY;
-
 /**
  * @author Michal Szynkiewicz, michal.l.szynkiewicz@gmail.com <br>
  *         Date: 13/08/2019
  */
+@UtilityClass
 public class MavenRepositoryUtils {
-
-    public static Path getContentsDirPath(Path unzippedRepoPath) {
+    public Path getContentsDirPath(Path unzippedRepoPath) {
         try (Stream<Path> unzippedRepoStream = Files.list(unzippedRepoPath)) {
             List<Path> topLevelDirs = unzippedRepoStream.filter(Files::isDirectory).collect(Collectors.toList());
             if (topLevelDirs.size() != 1) {
@@ -25,8 +26,8 @@ public class MavenRepositoryUtils {
             }
 
             try (Stream<Path> topLevelDirsStream = Files.list(topLevelDirs.get(0))) {
-                Optional<Path> maybeContentsDir = topLevelDirsStream
-                        .filter(p -> p.getFileName().toString().equals(MAVEN_REPOSITORY.replace("/", "")))
+                Optional<Path> maybeContentsDir = topLevelDirsStream.filter(
+                        p -> p.getFileName().toString().equals(RepoDescriptor.MAVEN_REPOSITORY.replace("/", "")))
                         .findAny();
 
                 return maybeContentsDir.orElseThrow(
@@ -39,8 +40,5 @@ public class MavenRepositoryUtils {
                     "Failed to get the contents directory for maven repo unzipped to: " + unzippedRepoPath,
                     e);
         }
-    }
-
-    private MavenRepositoryUtils() {
     }
 }

--- a/pig/src/main/java/org/jboss/pnc/bacon/pig/impl/utils/MilestoneNumberFinder.java
+++ b/pig/src/main/java/org/jboss/pnc/bacon/pig/impl/utils/MilestoneNumberFinder.java
@@ -17,6 +17,7 @@
  */
 package org.jboss.pnc.bacon.pig.impl.utils;
 
+import lombok.experimental.UtilityClass;
 import org.apache.commons.io.FileUtils;
 
 import java.io.File;
@@ -33,8 +34,9 @@ import java.util.regex.Pattern;
  * @author Michal Szynkiewicz, michal.l.szynkiewicz@gmail.com <br>
  *         Date: 3/5/18
  */
+@UtilityClass
 public class MilestoneNumberFinder {
-    public static String getFirstUnused(String url, String version, String milestoneBase) {
+    public String getFirstUnused(String url, String version, String milestoneBase) {
         if (!milestoneBase.contains("*")) {
             return milestoneBase;
         }
@@ -50,11 +52,11 @@ public class MilestoneNumberFinder {
         return milestonePrefix + getOneAbove(used);
     }
 
-    private static Integer getOneAbove(List<Integer> used) {
+    private Integer getOneAbove(List<Integer> used) {
         return used.stream().max(Integer::compareTo).orElse(0) + 1;
     }
 
-    private static List<Integer> findUsedNumbers(String version, String milestonePrefix, String indexFile) {
+    private List<Integer> findUsedNumbers(String version, String milestonePrefix, String indexFile) {
         List<Integer> resultList = new ArrayList<>();
         String prefix = version + "." + milestonePrefix;
 
@@ -70,7 +72,7 @@ public class MilestoneNumberFinder {
         return resultList;
     }
 
-    private static String readIndexFile(String url) {
+    private String readIndexFile(String url) {
         try {
             File tempFile = File.createTempFile("uploadAreaIndex", "html");
             FileUtils.copyURLToFile(new URL(url), tempFile);
@@ -80,8 +82,5 @@ public class MilestoneNumberFinder {
         } catch (IOException e) {
             throw new RuntimeException("Failed to download index file from the upload location " + url, e);
         }
-    }
-
-    private MilestoneNumberFinder() {
     }
 }

--- a/pig/src/main/java/org/jboss/pnc/bacon/pig/impl/utils/OSCommandExecutor.java
+++ b/pig/src/main/java/org/jboss/pnc/bacon/pig/impl/utils/OSCommandExecutor.java
@@ -46,10 +46,11 @@ import static org.apache.commons.lang3.StringUtils.join;
  * @author Michal Szynkiewicz, michal.l.szynkiewicz@gmail.com <br>
  *         Date: 6/2/17
  */
+// @UtilityClass
 public class OSCommandExecutor {
     private static final Logger log = LoggerFactory.getLogger(OSCommandExecutor.class);
 
-    public static List<String> runCommand(String s) {
+    public List<String> runCommand(String s) {
         return runCommandIn(s, null);
     }
 
@@ -222,8 +223,8 @@ public class OSCommandExecutor {
             }
         }
 
-        private static String[] unescape(String[] input) {
-            return (String[]) Stream.of(input).map(CommandExecutor::stripQuoteMarks).toArray(String[]::new);
+        private String[] unescape(String[] input) {
+            return Stream.of(input).map(CommandExecutor::stripQuoteMarks).toArray(String[]::new);
         }
 
         private static String stripQuoteMarks(String s) {
@@ -239,7 +240,7 @@ public class OSCommandExecutor {
             return s;
         }
 
-        private static void consumeInputStream(InputStream inputStream, Consumer<String> consumer) throws IOException {
+        private void consumeInputStream(InputStream inputStream, Consumer<String> consumer) throws IOException {
             try (InputStreamReader streamReader = new InputStreamReader(inputStream);
                     BufferedReader reader = new BufferedReader(streamReader)) {
                 String line;
@@ -249,11 +250,11 @@ public class OSCommandExecutor {
             }
         }
 
-        private static void writeToStdoutInOneLine(InputStream inputStream) throws IOException {
+        private void writeToStdoutInOneLine(InputStream inputStream) throws IOException {
             consumeInputStream(inputStream, l -> System.out.print(l + "\r"));
         }
 
-        private static void read(InputStream inputStream, List<String> out) throws IOException {
+        private void read(InputStream inputStream, List<String> out) throws IOException {
             consumeInputStream(inputStream, out::add);
         }
 
@@ -284,8 +285,5 @@ public class OSCommandExecutor {
         protected String prepareCommand(String command) {
             return command;
         }
-    }
-
-    private OSCommandExecutor() {
     }
 }

--- a/pig/src/main/java/org/jboss/pnc/bacon/pig/impl/utils/PncClientUtils.java
+++ b/pig/src/main/java/org/jboss/pnc/bacon/pig/impl/utils/PncClientUtils.java
@@ -17,6 +17,7 @@
  */
 package org.jboss.pnc.bacon.pig.impl.utils;
 
+import lombok.experimental.UtilityClass;
 import org.jboss.pnc.client.RemoteCollection;
 
 import java.util.List;
@@ -29,24 +30,25 @@ import java.util.stream.StreamSupport;
  * @author Michal Szynkiewicz, michal.l.szynkiewicz@gmail.com <br>
  *         Date: 28/06/2019
  */
+@UtilityClass
 public class PncClientUtils {
-    public static <T> List<T> toList(RemoteCollection<T> collection) {
+    public <T> List<T> toList(RemoteCollection<T> collection) {
         return toStream(collection).collect(Collectors.toList());
     }
 
-    public static <T> Stream<T> toStream(RemoteCollection<T> collection) {
+    public <T> Stream<T> toStream(RemoteCollection<T> collection) {
         return StreamSupport.stream(collection.spliterator(), false);
     }
 
-    public static Optional<String> findByNameQuery(String name) {
+    public Optional<String> findByNameQuery(String name) {
         return query("name=='%s'", name);
     }
 
-    public static Optional<String> query(String format, Object... values) {
+    public Optional<String> query(String format, Object... values) {
         return Optional.of(String.format(format, values));
     }
 
-    public static <T> Optional<T> maybeSingle(RemoteCollection<T> collection) {
+    public <T> Optional<T> maybeSingle(RemoteCollection<T> collection) {
         List<T> list = toList(collection);
         switch (list.size()) {
             case 0:
@@ -56,8 +58,5 @@ public class PncClientUtils {
             default:
                 throw new RuntimeException("Expecting single result got " + list.size());
         }
-    }
-
-    private PncClientUtils() {
     }
 }

--- a/pig/src/main/java/org/jboss/pnc/bacon/pig/impl/utils/PropertyUtils.java
+++ b/pig/src/main/java/org/jboss/pnc/bacon/pig/impl/utils/PropertyUtils.java
@@ -17,6 +17,8 @@
  */
 package org.jboss.pnc.bacon.pig.impl.utils;
 
+import lombok.experimental.UtilityClass;
+
 import java.util.Map;
 import java.util.Properties;
 import java.util.regex.Pattern;
@@ -25,13 +27,15 @@ import java.util.regex.Pattern;
  * @author Michal Szynkiewicz, michal.l.szynkiewicz@gmail.com <br>
  *         Date: 9/29/17
  */
+@UtilityClass
 public class PropertyUtils {
-    public static String replaceProperties(String text, Properties properties) {
+    public String replaceProperties(String text, Properties properties) {
+        String theText = text;
         for (Map.Entry<Object, Object> property : properties.entrySet()) {
             String key = String.format("${%s}", property.getKey());
             key = Pattern.quote(key);
-            text = text.replaceAll(key, String.valueOf(property.getValue()));
+            theText = theText.replaceAll(key, String.valueOf(property.getValue()));
         }
-        return text;
+        return theText;
     }
 }

--- a/pig/src/main/java/org/jboss/pnc/bacon/pig/impl/utils/ResourceUtils.java
+++ b/pig/src/main/java/org/jboss/pnc/bacon/pig/impl/utils/ResourceUtils.java
@@ -18,6 +18,7 @@
 
 package org.jboss.pnc.bacon.pig.impl.utils;
 
+import lombok.experimental.UtilityClass;
 import org.apache.commons.io.FileUtils;
 import org.apache.commons.io.IOUtils;
 import org.slf4j.Logger;
@@ -26,6 +27,8 @@ import org.slf4j.LoggerFactory;
 import java.io.File;
 import java.io.IOException;
 import java.io.InputStream;
+import java.nio.charset.Charset;
+import java.nio.charset.StandardCharsets;
 import java.nio.file.Path;
 import java.util.Optional;
 import java.util.Properties;
@@ -36,21 +39,17 @@ import static org.apache.commons.io.FileUtils.writeStringToFile;
  * @author Michal Szynkiewicz, michal.l.szynkiewicz@gmail.com <br>
  *         Date: 7/14/17
  */
+@UtilityClass
 public class ResourceUtils {
+    private final Logger log = LoggerFactory.getLogger(ResourceUtils.class);
 
-    private static final Logger log = LoggerFactory.getLogger(ResourceUtils.class);
+    public final Charset ENCODING = StandardCharsets.UTF_8;
 
-    public static final String ENCODING = "UTF-8";
-
-    public static File extractToTmpFile(String resource, String prefix, String suffix) {
+    public File extractToTmpFile(String resource, String prefix, String suffix) {
         return extractToTmpFileWithFiltering(resource, prefix, suffix, null);
     }
 
-    public static File extractToTmpFileWithFiltering(
-            String resource,
-            String prefix,
-            String suffix,
-            Properties properties) {
+    public File extractToTmpFileWithFiltering(String resource, String prefix, String suffix, Properties properties) {
         try {
             File tempFile = File.createTempFile(prefix, suffix);
             return extractToFileWithFiltering(resource, tempFile, properties);
@@ -59,11 +58,11 @@ public class ResourceUtils {
         }
     }
 
-    public static File extractToFile(String resource, File targetFile) {
+    public File extractToFile(String resource, File targetFile) {
         return extractToFileWithFiltering(resource, targetFile, null);
     }
 
-    public static File extractToFileWithFiltering(String resource, File targetFile, Properties properties) {
+    public File extractToFileWithFiltering(String resource, File targetFile, Properties properties) {
         try {
             String resourceAsString = extractToStringWithFiltering(resource, properties);
             FileUtils.write(targetFile, resourceAsString, ENCODING);
@@ -73,7 +72,7 @@ public class ResourceUtils {
         }
     }
 
-    public static String extractToStringWithFiltering(String resource, Properties properties) {
+    public String extractToStringWithFiltering(String resource, Properties properties) {
         String resourceAsString = getResourceAsString(resource);
         if (properties != null) {
             resourceAsString = PropertyUtils.replaceProperties(resourceAsString, properties);
@@ -81,7 +80,7 @@ public class ResourceUtils {
         return resourceAsString;
     }
 
-    public static void copyResourceWithFiltering(
+    public void copyResourceWithFiltering(
             String sourceFileName,
             String targetFileName,
             File targetDirectory,
@@ -98,7 +97,7 @@ public class ResourceUtils {
         }
     }
 
-    public static void copyOverridableResource(
+    public void copyOverridableResource(
             String sourceFileName,
             String targetFileName,
             File targetDirectory,
@@ -122,12 +121,12 @@ public class ResourceUtils {
      * @param configurationDirectory directory to check for the files
      * @return file content read to string
      */
-    public static String getOverridableResource(String fileName, Path configurationDirectory) {
+    public String getOverridableResource(String fileName, Path configurationDirectory) {
         Optional<String> maybeResult = getResourceFromDirectory(fileName, configurationDirectory);
         return maybeResult.orElseGet(() -> getResourceAsString(fileName));
     }
 
-    public static Optional<String> getResourceFromDirectory(String fileName, Path configurationDirectory) {
+    public Optional<String> getResourceFromDirectory(String fileName, Path configurationDirectory) {
         File file = new File(configurationDirectory.toFile(), fileName);
         if (file.exists()) {
             try {
@@ -139,7 +138,7 @@ public class ResourceUtils {
         return Optional.empty();
     }
 
-    public static String getResourceAsString(String resource) {
+    public String getResourceAsString(String resource) {
         InputStream resourceStream = ResourceUtils.class.getResourceAsStream(resource);
         if (resourceStream == null) {
             throw new IllegalArgumentException("Resource " + resource + " not found");
@@ -149,8 +148,5 @@ public class ResourceUtils {
         } catch (IOException e) {
             throw new IllegalArgumentException("Unable to read resource: " + resource);
         }
-    }
-
-    private ResourceUtils() {
     }
 }

--- a/pig/src/main/java/org/jboss/pnc/bacon/pig/impl/utils/SleepUtils.java
+++ b/pig/src/main/java/org/jboss/pnc/bacon/pig/impl/utils/SleepUtils.java
@@ -18,6 +18,7 @@
 
 package org.jboss.pnc.bacon.pig.impl.utils;
 
+import lombok.experimental.UtilityClass;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
@@ -27,11 +28,11 @@ import java.util.function.Supplier;
  * @author Michal Szynkiewicz, michal.l.szynkiewicz@gmail.com <br>
  *         Date: 7/7/17
  */
+@UtilityClass
 public class SleepUtils {
+    private final Logger log = LoggerFactory.getLogger(SleepUtils.class);
 
-    private static final Logger log = LoggerFactory.getLogger(SleepUtils.class);
-
-    public static void sleep(int seconds) {
+    public void sleep(int seconds) {
         try {
             Thread.sleep(seconds * 1000L);
         } catch (InterruptedException e) {
@@ -39,7 +40,7 @@ public class SleepUtils {
         }
     }
 
-    public static void waitFor(Supplier<Boolean> condition, int checkInterval, boolean printDot) {
+    public void waitFor(Supplier<Boolean> condition, int checkInterval, boolean printDot) {
         if (condition.get()) {
             return;
         }
@@ -65,7 +66,7 @@ public class SleepUtils {
      *
      * @throws RuntimeException if the timeout is reached
      */
-    public static <T> T waitFor(
+    public <T> T waitFor(
             Supplier<T> condition,
             int checkInterval,
             long timeout,
@@ -89,7 +90,7 @@ public class SleepUtils {
         }
     }
 
-    private static <T> T tryGet(Supplier<T> condition, boolean ignoreException) {
+    private <T> T tryGet(Supplier<T> condition, boolean ignoreException) {
         try {
             return condition.get();
         } catch (RuntimeException e) {
@@ -100,8 +101,5 @@ public class SleepUtils {
                 throw e;
             }
         }
-    }
-
-    private SleepUtils() {
     }
 }

--- a/pig/src/main/java/org/jboss/pnc/bacon/pig/impl/utils/indy/Indy.java
+++ b/pig/src/main/java/org/jboss/pnc/bacon/pig/impl/utils/indy/Indy.java
@@ -1,16 +1,16 @@
 package org.jboss.pnc.bacon.pig.impl.utils.indy;
 
+import lombok.experimental.UtilityClass;
 import org.jboss.pnc.bacon.config.Config;
 import org.jboss.pnc.bacon.config.PigConfig;
 
+@UtilityClass
 public class Indy {
-    private static volatile String indyRepoUrl;
-    private static volatile String indyTempRepoUrl;
+    private volatile String indyRepoUrl;
 
-    private Indy() {
-    }
+    private volatile String indyTempRepoUrl;
 
-    public static String getIndyUrl() {
+    public String getIndyUrl() {
         if (indyRepoUrl == null) {
             indyRepoUrl = pigUrl() + "api/content/maven/group/static";
         }
@@ -18,7 +18,7 @@ public class Indy {
         return indyRepoUrl;
     }
 
-    public static String getIndyTempUrl() {
+    public String getIndyTempUrl() {
         if (indyTempRepoUrl == null) {
             indyTempRepoUrl = pigUrl() + "api/content/maven/group/temporary-builds";
         }
@@ -26,7 +26,7 @@ public class Indy {
         return indyTempRepoUrl;
     }
 
-    private static String pigUrl() {
+    private String pigUrl() {
         PigConfig pig = Config.instance().getActiveProfile().getPig();
         String indyUrl = pig.getIndyUrl();
         if (!indyUrl.endsWith("/")) {

--- a/pnc/src/main/java/org/jboss/pnc/bacon/pnc/ProductMilestoneCli.java
+++ b/pnc/src/main/java/org/jboss/pnc/bacon/pnc/ProductMilestoneCli.java
@@ -47,7 +47,6 @@ import java.time.Instant;
 import java.util.Optional;
 
 import static org.apache.commons.lang.StringUtils.isNotEmpty;
-import static org.jboss.pnc.bacon.pnc.client.PncClientHelper.parseDateFormat;
 
 @Slf4j
 @GroupCommandDefinition(
@@ -99,10 +98,9 @@ public class ProductMilestoneCli extends AbstractCommand {
                     startDate = PncClientHelper.getTodayDayInYYYYMMDDFormat();
                 }
 
-                Instant startDateInstant = parseDateFormat(startDate);
-                Instant endDateInstant = parseDateFormat(endDate);
-
                 ProductVersionRef productVersionRef = ProductVersionRef.refBuilder().id(productVersionId).build();
+                Instant startDateInstant = PncClientHelper.parseDateFormat(startDate);
+                Instant endDateInstant = PncClientHelper.parseDateFormat(endDate);
 
                 ProductMilestone milestone = ProductMilestone.builder()
                         .version(productMilestoneVersion)
@@ -167,11 +165,11 @@ public class ProductMilestoneCli extends AbstractCommand {
                         }
                     }
                     if (isNotEmpty(startDate)) {
-                        Instant startDateInstant = parseDateFormat(startDate);
+                        Instant startDateInstant = PncClientHelper.parseDateFormat(startDate);
                         updated.startingDate(startDateInstant);
                     }
                     if (isNotEmpty(endDate)) {
-                        Instant endDateInstant = parseDateFormat(endDate);
+                        Instant endDateInstant = PncClientHelper.parseDateFormat(endDate);
                         updated.plannedEndDate(endDateInstant);
                     }
 
@@ -254,8 +252,8 @@ public class ProductMilestoneCli extends AbstractCommand {
     }
 
     /**
-     * Product Milestone version format is: <d>.<d>.<d>.<word> The first 2 digits must match the digit for the product
-     * version
+     * Product Milestone version format is: {@literal <d>.<d>.<d>.<word>} The first 2 digits must match the digit for
+     * the product version.
      *
      * @param productVersionId
      * @param milestoneVersion

--- a/pnc/src/main/java/org/jboss/pnc/bacon/pnc/client/PncClientHelper.java
+++ b/pnc/src/main/java/org/jboss/pnc/bacon/pnc/client/PncClientHelper.java
@@ -17,6 +17,7 @@
  */
 package org.jboss.pnc.bacon.pnc.client;
 
+import lombok.experimental.UtilityClass;
 import lombok.extern.slf4j.Slf4j;
 import org.jboss.pnc.bacon.auth.DirectKeycloakClientImpl;
 import org.jboss.pnc.bacon.auth.KeycloakClientException;
@@ -37,21 +38,21 @@ import java.time.Instant;
 import java.util.Date;
 
 @Slf4j
+@UtilityClass
 public class PncClientHelper {
+    private final SimpleDateFormat sdf = new SimpleDateFormat("yyyy-MM-dd");
 
-    private static final SimpleDateFormat sdf = new SimpleDateFormat("yyyy-MM-dd");
+    private boolean bannerChecked = false;
 
-    private static boolean bannerChecked = false;
-
-    public static Configuration getPncConfiguration(boolean authenticationNeeded) {
+    public Configuration getPncConfiguration(boolean authenticationNeeded) {
         return setup(authenticationNeeded);
     }
 
-    public static Configuration getPncConfiguration() {
+    public Configuration getPncConfiguration() {
         return getPncConfiguration(true);
     }
 
-    public static Configuration setup(boolean authenticationNeeded) {
+    public Configuration setup(boolean authenticationNeeded) {
         Config config = Config.instance();
 
         KeycloakConfig keycloakConfig = config.getActiveProfile().getKeycloak();
@@ -103,7 +104,7 @@ public class PncClientHelper {
      * @param keycloakConfig the keycloak config
      * @return the token, or null if we couldn't get it
      */
-    private static String getBearerToken(KeycloakConfig keycloakConfig) {
+    private String getBearerToken(KeycloakConfig keycloakConfig) {
 
         log.debug("Authenticating to keycloak");
 
@@ -134,7 +135,7 @@ public class PncClientHelper {
         }
     }
 
-    private static void printBannerIfNecessary(Configuration configuration) {
+    private void printBannerIfNecessary(Configuration configuration) {
 
         if (!bannerChecked) {
             try (GenericSettingClient genericSettingClient = new GenericSettingClient(configuration)) {
@@ -157,8 +158,7 @@ public class PncClientHelper {
      *
      * @param date the date format
      */
-    public static Instant parseDateFormat(String date) {
-
+    public Instant parseDateFormat(String date) {
         try {
             Date ret = sdf.parse(date);
             return ret.toInstant();
@@ -167,7 +167,7 @@ public class PncClientHelper {
         }
     }
 
-    public static String getTodayDayInYYYYMMDDFormat() {
+    public String getTodayDayInYYYYMMDDFormat() {
         return sdf.format(new Date());
     }
 }

--- a/pnc/src/main/java/org/jboss/pnc/bacon/pnc/common/ParameterChecker.java
+++ b/pnc/src/main/java/org/jboss/pnc/bacon/pnc/common/ParameterChecker.java
@@ -17,6 +17,7 @@
  */
 package org.jboss.pnc.bacon.pnc.common;
 
+import lombok.experimental.UtilityClass;
 import lombok.extern.slf4j.Slf4j;
 import org.jboss.pnc.bacon.common.exception.FatalException;
 import org.jboss.pnc.enums.RebuildMode;
@@ -25,13 +26,12 @@ import org.jboss.pnc.enums.RebuildMode;
  * Helper class to check for parameter validity
  */
 @Slf4j
+@UtilityClass
 public class ParameterChecker {
-
     /**
      * Check that the rebuild mode provided by the user is valid or not
      */
-    public static void checkRebuildModeOption(String rebuildMode) throws FatalException {
-
+    public void checkRebuildModeOption(String rebuildMode) throws FatalException {
         try {
             RebuildMode.valueOf(rebuildMode);
         } catch (IllegalArgumentException | NullPointerException e) {


### PR DESCRIPTION
### For

* Class marked `static final` and all fields automatically marked `static`
* Private constructor created which throws `IllegalArgumentException`

### Against

* Can't be used in cases where we have an inner class that uses a public constructor, but maybe this isn't a great design to begin with
* Can't be used with `import static`. Once you use `@UtilityClass`, the compiler does not know that these fields are `static`.
