### PR TITLE
[NCLSUP-119] Fix check for isBranchModified

### DIFF
--- a/pig/src/main/java/org/jboss/pnc/bacon/pig/impl/pnc/PncBuild.java
+++ b/pig/src/main/java/org/jboss/pnc/bacon/pig/impl/pnc/PncBuild.java
@@ -55,6 +55,7 @@ public class PncBuild {
 
     private String internalScmUrl;
     private String scmRevision;
+    private String scmTag;
     private String id;
     private String name;
     private Map<String, String> attributes;
@@ -76,6 +77,7 @@ public class PncBuild {
         id = build.getId();
         internalScmUrl = build.getScmRepository().getInternalUrl();
         scmRevision = build.getScmRevision();
+        scmTag = build.getScmTag();
         buildStatus = build.getStatus();
         attributes = build.getAttributes();
     }


### PR DESCRIPTION
The check assumed that the 'scmRevision' in the build information would
be a tag name. Instead it is the commit id.

This commit fixes it by grabbing the scmTag information instead which
contains the real tag name.

It also treats the 'branch' as either a ref (pointer to a commit), or
the commit itself. This should handle the corner case where the full commit
id is specified in the build-config.yaml

Optionals are also now used to better handle the case where the
information is not available

### Checklist:

* [ ] Have you added a note in the [CHANGELOG wiki](https://github.com/project-ncl/bacon/wiki/Changelog) for your change if user-facing?
* [ ] Have you added unit tests for your change?
