### PR TITLE
[NCL-6037] Only generate nvr list when possible

### DIFF
--- a/pig/src/main/java/org/jboss/pnc/bacon/pig/PigFacade.java
+++ b/pig/src/main/java/org/jboss/pnc/bacon/pig/PigFacade.java
@@ -215,13 +215,23 @@ public final class PigFacade {
                 context.getDeliverables().getNvrListName());
     }
 
+    /**
+     * Generate the nvr list from the information gathered during repository generation. If the latter was ignored, then
+     * nothing happens
+     */
     private static void generateNvrList() {
         PigContext context = PigContext.get();
         Map<String, Collection<String>> checksums = context.getChecksums();
-        Path targetPath = Paths.get(context.getReleasePath())
-                .resolve(context.getDeliverables().getNvrListName())
-                .toAbsolutePath();
-        NvrListGenerator.generateNvrList(checksums, targetPath);
+
+        if (checksums == null) {
+            // checksums populated only when repository generation is switched on
+            log.warn("No nvr list generated since repository generation may have been ignored");
+        } else {
+            Path targetPath = Paths.get(context.getReleasePath())
+                    .resolve(context.getDeliverables().getNvrListName())
+                    .toAbsolutePath();
+            NvrListGenerator.generateNvrList(checksums, targetPath);
+        }
     }
 
     private static void pushToBrew(boolean reimport) {


### PR DESCRIPTION
If the repository generation is ignored, the checksum data is never
populated. In that scenario, we shouldn't generate the nvr list during
the release phase since we don't have the required information.

### Checklist:

* [ ] Have you added a note in the [CHANGELOG wiki](https://github.com/project-ncl/bacon/wiki/Changelog) for your change if user-facing?
* [ ] Have you added unit tests for your change?
