### PR TITLE
Add retries when downloading links on bacon_install.py

### DIFF
--- a/bacon_install.py
+++ b/bacon_install.py
@@ -121,9 +121,12 @@ def download_maven_metadata_xml(url, folder):
     download_link(link, folder, "maven-metadata.xml")
 
 
-def download_link(link, folder, filename):
+def download_link(link, folder, filename, retries=7):
     """
     Download the link into the folder with name 'filename'
+
+    Add retries in case the download fails due to stale server content issue on
+    repositories.jboss.org
     """
 
     print("Downloading: " + link)
@@ -138,7 +141,11 @@ def download_link(link, folder, filename):
         with open(folder + "/" + filename, "wb") as f:
             f.write(r)
     except Exception as error:
-        raise Exception("Something wrong happened while downloading the link: " + link + " :: " + str(error))
+        if retries > 0:
+            print("Something went wrong while downloading the link. Retrying...")
+            download_link(link, folder, filename, retries=retries - 1)
+        else:
+            raise Exception("Something wrong happened while downloading the link: " + link + " :: " + str(error))
 
 
 def create_folder_if_absent(folder):


### PR DESCRIPTION
When downloading artifacts from repositories.jboss.org, it sometimes
fails because the specific server we are hitting on
repositories.jboss.org does not have the content yet, and returns 404.
The retries is an attempt to workaround this by retrying to download the
artifact up to 7 times until we give up.

### Checklist:

* [ ] Have you added a note in the [CHANGELOG wiki](https://github.com/project-ncl/bacon/wiki/Changelog) for your change if user-facing?
* [ ] Have you added unit tests for your change?
