### PR TITLE
NCL-5986: Configure YAML to use system line feeds to match println()

### DIFF
--- a/common/pom.xml
+++ b/common/pom.xml
@@ -50,5 +50,10 @@
             <groupId>org.commonjava.maven.ext</groupId>
             <artifactId>pom-manipulation-common</artifactId>
         </dependency>
+        <dependency>
+            <groupId>com.github.stefanbirkner</groupId>
+            <artifactId>system-lambda</artifactId>
+            <scope>test</scope>
+        </dependency>
     </dependencies>
 </project>

--- a/common/src/main/java/org/jboss/pnc/bacon/common/ObjectHelper.java
+++ b/common/src/main/java/org/jboss/pnc/bacon/common/ObjectHelper.java
@@ -6,20 +6,20 @@ import com.fasterxml.jackson.core.JsonProcessingException;
 import com.fasterxml.jackson.databind.ObjectMapper;
 import com.fasterxml.jackson.databind.SerializationFeature;
 import com.fasterxml.jackson.dataformat.yaml.YAMLFactory;
+import com.fasterxml.jackson.dataformat.yaml.YAMLGenerator;
 import com.fasterxml.jackson.datatype.jsr310.JavaTimeModule;
 
 public class ObjectHelper {
 
     private static ObjectMapper getOutputMapper(boolean json) {
-        ObjectMapper om = json ? new ObjectMapper(new JsonFactory()) : new ObjectMapper(new YAMLFactory());
+        ObjectMapper om = json ? new ObjectMapper(new JsonFactory())
+                : new ObjectMapper(new YAMLFactory().configure(YAMLGenerator.Feature.USE_PLATFORM_LINE_BREAKS, true));
         om.registerModule(new JavaTimeModule());
         om.configure(SerializationFeature.WRITE_DATES_AS_TIMESTAMPS, false);
         return om;
     }
 
     public static void print(boolean json, Object o) throws JsonProcessingException {
-        // FIXME: System.out.println uses system line feed, but writeValueAsString may not
-        // FIXME: See <https://github.com/project-ncl/bacon/issues/349> for details
         System.out.println(getOutputMapper(json).writeValueAsString(o));
     }
 

--- a/common/src/test/java/org/jboss/pnc/bacon/common/ObjectHelperTest.java
+++ b/common/src/test/java/org/jboss/pnc/bacon/common/ObjectHelperTest.java
@@ -4,54 +4,41 @@ import ch.qos.logback.classic.Level;
 import com.google.common.collect.Maps;
 import org.junit.jupiter.api.Test;
 
-import java.io.ByteArrayOutputStream;
-import java.io.PrintStream;
-import java.nio.charset.StandardCharsets;
 import java.util.Map;
 
+import static com.github.stefanbirkner.systemlambda.SystemLambda.tapSystemOut;
 import static org.junit.jupiter.api.Assertions.*;
 
 class ObjectHelperTest {
 
     @Test
     void printJson() throws Exception {
-        PrintStream old = System.out;
+        String actual = tapSystemOut(() -> {
+            Map<String, String> testSubject = Maps.newHashMap();
 
-        ByteArrayOutputStream stream = new ByteArrayOutputStream();
-        PrintStream ps = new PrintStream(stream, false, StandardCharsets.UTF_8.name());
-        System.setOut(ps);
-        Map<String, String> testSubject = Maps.newHashMap();
-        testSubject.put("test", "subject");
+            testSubject.put("test", "subject");
 
-        ObjectHelper.print(true, testSubject);
-        System.out.flush();
-        System.setOut(old);
+            ObjectHelper.print(true, testSubject);
+        });
 
-        // FIXME: Ideally, we wouldn't need to trim, but we may get a different final newline
-        // FIXME: See <https://github.com/project-ncl/bacon/issues/349> for details
-        String output = stream.toString().trim();
-        assertEquals("{\"test\":\"subject\"}", output);
+        String expected = String.format("{\"test\":\"subject\"}%n");
+
+        assertEquals(expected, actual);
     }
 
     @Test
     void printYaml() throws Exception {
-        PrintStream old = System.out;
+        String actual = tapSystemOut(() -> {
+            Map<String, String> testSubject = Maps.newHashMap();
 
-        ByteArrayOutputStream stream = new ByteArrayOutputStream();
-        PrintStream ps = new PrintStream(stream, false, StandardCharsets.UTF_8.name());
-        System.setOut(ps);
-        Map<String, String> testSubject = Maps.newHashMap();
-        testSubject.put("test", "subject");
+            testSubject.put("test", "subject");
 
-        ObjectHelper.print(false, testSubject);
+            ObjectHelper.print(false, testSubject);
+        });
 
-        System.out.flush();
-        System.setOut(old);
+        String expected = String.format("---%ntest: \"subject\"%n%n");
 
-        // FIXME: Ideally, we wouldn't need to trim, but we may get a different final newline
-        // FIXME: See <https://github.com/project-ncl/bacon/issues/349> for details
-        String output = stream.toString().trim();
-        assertEquals("---\ntest: \"subject\"", output);
+        assertEquals(expected, actual);
     }
 
     @Test


### PR DESCRIPTION
Replace manual tapping of System.out with tapSystemOut() in test

### Checklist:

* [ ] Have you added a note in the [CHANGELOG wiki](https://github.com/project-ncl/bacon/wiki/Changelog) for your change if user-facing?
* [ ] Have you added unit tests for your change?
