### PR TITLE
[NCL-6044] Check if all builds in final state when group build done 

### DIFF
--- a/pig/pom.xml
+++ b/pig/pom.xml
@@ -139,6 +139,11 @@
             <artifactId>mockito-inline</artifactId>
             <scope>test</scope>
         </dependency>
+        <dependency>
+            <groupId>org.jeasy</groupId>
+            <artifactId>easy-random-core</artifactId>
+            <scope>test</scope>
+        </dependency>
     </dependencies>
 
     <build>

--- a/pig/src/main/java/org/jboss/pnc/bacon/pig/impl/pnc/PncBuilder.java
+++ b/pig/src/main/java/org/jboss/pnc/bacon/pig/impl/pnc/PncBuilder.java
@@ -49,6 +49,17 @@ public class PncBuilder {
         groupConfigClient = new GroupConfigurationClient(getPncConfiguration());
     }
 
+    /**
+     * Created to inject mocks for testing
+     *
+     * @param gb
+     * @param gc
+     */
+    PncBuilder(GroupBuildClient gb, GroupConfigurationClient gc) {
+        groupBuildClient = gb;
+        groupConfigClient = gc;
+    }
+
     public GroupBuild buildAndWait(
             GroupConfigurationRef group,
             boolean tempBuild,
@@ -78,13 +89,13 @@ public class PncBuilder {
         }
     }
 
-    private void waitForSuccessfulFinish(String groupBuildId) {
+    void waitForSuccessfulFinish(String groupBuildId) {
         log.info("Waiting for finish of group build {}", groupBuildId);
         SleepUtils.waitFor(() -> isSuccessfullyFinished(groupBuildId), 30, true);
         log.info("Group build finished successfully");
     }
 
-    private boolean isSuccessfullyFinished(String groupBuildId) {
+    boolean isSuccessfullyFinished(String groupBuildId) {
 
         log.debug("Checking if group build {} is successfully finished", groupBuildId);
         try {
@@ -121,7 +132,7 @@ public class PncBuilder {
      * @param groupBuildId the group build id
      * @return whether all the builds have a final status or not
      */
-    private boolean verifyAllBuildsInGroupBuildInFinalStateWithProperCount(String groupBuildId) {
+    boolean verifyAllBuildsInGroupBuildInFinalStateWithProperCount(String groupBuildId) {
 
         log.debug(
                 "Checking if all builds in group build {} are in final state with proper count of builds",
@@ -149,7 +160,7 @@ public class PncBuilder {
      * @param groupBuildId
      * @return count, -1 if an error happened
      */
-    private int getCountOfBuildConfigsForGroupBuild(String groupBuildId) {
+    int getCountOfBuildConfigsForGroupBuild(String groupBuildId) {
 
         try {
             GroupBuild gb = groupBuildClient.getSpecific(groupBuildId);

--- a/pig/src/test/java/org/jboss/pnc/bacon/pig/impl/pnc/PncBuilderTest.java
+++ b/pig/src/test/java/org/jboss/pnc/bacon/pig/impl/pnc/PncBuilderTest.java
@@ -1,0 +1,78 @@
+package org.jboss.pnc.bacon.pig.impl.pnc;
+
+import org.jboss.pnc.client.GroupBuildClient;
+import org.jboss.pnc.client.GroupConfigurationClient;
+import org.jboss.pnc.client.RemoteCollection;
+import org.jboss.pnc.dto.BuildConfiguration;
+import org.jboss.pnc.dto.BuildConfigurationRef;
+import org.jboss.pnc.dto.GroupBuild;
+import org.jboss.pnc.dto.GroupConfiguration;
+import org.jeasy.random.EasyRandom;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+
+import java.util.Collection;
+import java.util.HashMap;
+import java.util.Iterator;
+import java.util.Map;
+
+import static org.junit.jupiter.api.Assertions.*;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.when;
+
+class PncBuilderTest {
+
+    private GroupBuildClient groupBuildClient;
+    private GroupConfigurationClient groupConfigurationClient;
+
+    private EasyRandom easyRandom = new EasyRandom();
+
+    @BeforeEach
+    void setup() {
+        groupBuildClient = mock(GroupBuildClient.class);
+        groupConfigurationClient = mock(GroupConfigurationClient.class);
+    }
+
+    @Test
+    void getCountOfBuildConfigsForGroupBuild() throws Exception {
+
+        Map<String, BuildConfigurationRef> buildConfigurations = new HashMap<>();
+        BuildConfigurationRef bc1 = easyRandom.nextObject(BuildConfigurationRef.class);
+        BuildConfigurationRef bc2 = easyRandom.nextObject(BuildConfigurationRef.class);
+        BuildConfigurationRef bc3 = easyRandom.nextObject(BuildConfigurationRef.class);
+        buildConfigurations.put(bc1.getName(), bc1);
+        buildConfigurations.put(bc2.getName(), bc2);
+        buildConfigurations.put(bc3.getName(), bc3);
+
+        String groupConfigurationId = "5";
+        String groupBuildId = "1";
+
+        GroupConfiguration gc = GroupConfiguration.builder()
+                .id(groupConfigurationId)
+                .buildConfigs(buildConfigurations)
+                .build();
+        GroupBuild gb = GroupBuild.builder().id(groupBuildId).groupConfig(gc).build();
+
+        when(groupBuildClient.getSpecific(groupBuildId)).thenReturn(gb);
+        when(groupConfigurationClient.getBuildConfigs(groupConfigurationId))
+                .thenReturn(new RemoteCollection<BuildConfiguration>() {
+                    @Override
+                    public int size() {
+                        return buildConfigurations.size();
+                    }
+
+                    @Override
+                    public Collection<BuildConfiguration> getAll() {
+                        return null;
+                    }
+
+                    @Override
+                    public Iterator<BuildConfiguration> iterator() {
+                        return null;
+                    }
+                });
+
+        PncBuilder builder = new PncBuilder(groupBuildClient, groupConfigurationClient);
+        assertEquals(buildConfigurations.size(), builder.getCountOfBuildConfigsForGroupBuild(groupBuildId));
+    }
+}

--- a/pom.xml
+++ b/pom.xml
@@ -409,6 +409,12 @@
                 <version>1.1.0</version>
                 <scope>test</scope>
             </dependency>
+            <dependency>
+                <groupId>org.jeasy</groupId>
+                <artifactId>easy-random-core</artifactId>
+                <version>4.2.0</version>
+                <scope>test</scope>
+            </dependency>
         </dependencies>
     </dependencyManagement>
 


### PR DESCRIPTION
Due to internal logic in PNC-Orch, a group build gets updated in the
database just before the final build in the group build is done. This
may cause the scenario where during a time window, the group build state
is successful, but there's still 1 build in the group build still in
running state.

The situation is even worse if the group build ends in state
'NO_REBUILD_REQUIRED'. Before the builds even have a chance to be
scheduled, the group build is already marked as 'NO_REBUILD_REQUIRED'
beforehand. Then when we get the list of builds, they may still be in
status RUNNING. This is dangerous because then the final artifact list
may be empty, and in the case of NO_REBUILD_REQUIRED, we'll never get
the original successul build.

To avoid these scenarios, we also check if all the builds in a group
build are in a final state once the group build is marked as successful.

### Checklist:

* [ ] Have you added a note in the [CHANGELOG wiki](https://github.com/project-ncl/bacon/wiki/Changelog) for your change if user-facing?
* [ ] Have you added unit tests for your change?
