### PR TITLE
Enable tailtip widget by default by explicitly overriding picicli jline3

### DIFF
--- a/cli/pom.xml
+++ b/cli/pom.xml
@@ -43,6 +43,14 @@
             <artifactId>picocli-shell-jline3</artifactId>
         </dependency>
         <dependency>
+            <groupId>org.jline</groupId>
+            <artifactId>jline</artifactId>
+        </dependency>
+        <dependency>
+            <groupId>org.jline</groupId>
+            <artifactId>jline-console</artifactId>
+        </dependency>
+        <dependency>
             <groupId>org.assertj</groupId>
             <artifactId>assertj-core</artifactId>
             <scope>test</scope>

--- a/cli/src/main/java/org/jboss/pnc/bacon/cli/App.java
+++ b/cli/src/main/java/org/jboss/pnc/bacon/cli/App.java
@@ -148,7 +148,12 @@ public class App {
                         .variable(LineReader.LIST_MAX, 50) // max tab completion candidates
                         .build();
                 builtins.setLineReader(reader);
-                new TailTipWidgets(reader, systemRegistry::commandDescription, 5, TailTipWidgets.TipType.COMPLETER);
+                TailTipWidgets tailTipWidgets = new TailTipWidgets(
+                        reader,
+                        systemRegistry::commandDescription,
+                        5,
+                        TailTipWidgets.TipType.COMPLETER);
+                tailTipWidgets.enable();
                 KeyMap<Binding> keyMap = reader.getKeyMaps().get("main");
                 keyMap.bind(new Reference("tailtip-toggle"), KeyMap.alt("s"));
 

--- a/cli/src/main/java/org/jboss/pnc/bacon/cli/App.java
+++ b/cli/src/main/java/org/jboss/pnc/bacon/cli/App.java
@@ -28,31 +28,47 @@ import org.jboss.pnc.bacon.common.exception.FatalException;
 import org.jboss.pnc.bacon.config.Config;
 import org.jboss.pnc.bacon.pig.Pig;
 import org.jboss.pnc.bacon.pnc.Pnc;
-import org.jline.builtins.Builtins;
-import org.jline.builtins.SystemRegistry;
-import org.jline.builtins.SystemRegistryImpl;
-import org.jline.builtins.Widgets.TailTipWidgets;
+import org.jline.builtins.Options;
+import org.jline.console.ArgDesc;
+import org.jline.console.CmdDesc;
+import org.jline.console.CommandRegistry;
+import org.jline.console.SystemRegistry;
+import org.jline.console.impl.Builtins;
+import org.jline.console.impl.SystemRegistryImpl;
 import org.jline.keymap.KeyMap;
 import org.jline.reader.Binding;
+import org.jline.reader.Candidate;
+import org.jline.reader.Completer;
 import org.jline.reader.EndOfFileException;
 import org.jline.reader.LineReader;
 import org.jline.reader.LineReaderBuilder;
 import org.jline.reader.MaskingCallback;
+import org.jline.reader.ParsedLine;
 import org.jline.reader.Parser;
 import org.jline.reader.Reference;
 import org.jline.reader.UserInterruptException;
 import org.jline.reader.impl.DefaultParser;
+import org.jline.reader.impl.completer.SystemCompleter;
 import org.jline.terminal.Terminal;
 import org.jline.terminal.TerminalBuilder;
+import org.jline.utils.AttributedString;
+import org.jline.widget.TailTipWidgets;
 import picocli.CommandLine;
 import picocli.CommandLine.Command;
 import picocli.CommandLine.IExecutionExceptionHandler;
 import picocli.CommandLine.Option;
-import picocli.shell.jline3.PicocliCommands;
 
 import java.io.IOException;
 import java.nio.file.Path;
 import java.nio.file.Paths;
+import java.util.ArrayList;
+import java.util.Arrays;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+import java.util.Set;
+import java.util.function.Supplier;
+import java.util.stream.Collectors;
 
 import static picocli.CommandLine.ScopeType.INHERIT;
 
@@ -126,7 +142,7 @@ public class App {
             AnsiConsole.systemInstall();
             // set up JLine built-in commands
             Builtins builtins = new Builtins(App::workDir, null, null);
-            builtins.rename(org.jline.builtins.Builtins.Command.TTOP, "top");
+            builtins.rename(Builtins.Command.TTOP, "top");
             builtins.alias("zle", "widget");
             builtins.alias("bindkey", "keymap");
 
@@ -144,7 +160,7 @@ public class App {
                         .completer(systemRegistry.completer())
                         .parser(parser)
                         .variable(LineReader.HISTORY_FILE, Constant.HISTORY)
-                        .variable(LineReader.HISTORY_FILE_SIZE, 50)
+                        .variable(LineReader.HISTORY_FILE_SIZE, 100)
                         .variable(LineReader.LIST_MAX, 50) // max tab completion candidates
                         .build();
                 builtins.setLineReader(reader);
@@ -157,7 +173,7 @@ public class App {
                 KeyMap<Binding> keyMap = reader.getKeyMaps().get("main");
                 keyMap.bind(new Reference("tailtip-toggle"), KeyMap.alt("s"));
 
-                log.info("Tooltips disabled ; press Alt-s to enable");
+                log.info("Tooltips enabled ; press Alt-s to disable");
                 String prompt = "prompt> ";
 
                 // start the shell and process input until the user quits with Ctrl-D
@@ -227,6 +243,217 @@ public class App {
 
             return cmd.getExitCodeExceptionMapper() != null ? cmd.getExitCodeExceptionMapper().getExitCode(ex)
                     : cmd.getCommandSpec().exitCodeOnExecutionException();
+        }
+    }
+
+    // Explicit inline override of picocli jline3 until picocli 4.6 is released fixing
+    // https://github.com/remkop/picocli/issues/1175
+
+    /**
+     * Compiles SystemCompleter for command completion and implements a method commandDescription() that provides
+     * command descriptions for JLine TailTipWidgets to be displayed in terminal status bar. SystemCompleter implements
+     * the JLine 3 {@link Completer} interface. SystemCompleter generates completion candidates for the specified
+     * command line based on the {@link CommandLine.Model.CommandSpec} that this {@code PicocliCommands} was constructed
+     * with.
+     *
+     * @since 4.1.2
+     */
+    static class PicocliCommands implements CommandRegistry {
+        private final Supplier<Path> workDir;
+        private final CommandLine cmd;
+        private final Set<String> commands;
+        private final Map<String, String> aliasCommand = new HashMap<>();
+
+        public PicocliCommands(Path workDir, CommandLine cmd) {
+            this(() -> workDir, cmd);
+        }
+
+        public PicocliCommands(Supplier<Path> workDir, CommandLine cmd) {
+            this.workDir = workDir;
+            this.cmd = cmd;
+            commands = cmd.getCommandSpec().subcommands().keySet();
+            for (String c : commands) {
+                for (String a : cmd.getSubcommands().get(c).getCommandSpec().aliases()) {
+                    aliasCommand.put(a, c);
+                }
+            }
+        }
+
+        /**
+         *
+         * @param command
+         * @return true if PicocliCommands contains command
+         */
+        public boolean hasCommand(String command) {
+            return commands.contains(command) || aliasCommand.containsKey(command);
+        }
+
+        public SystemCompleter compileCompleters() {
+            SystemCompleter out = new SystemCompleter();
+            List<String> all = new ArrayList<>();
+            all.addAll(commands);
+            all.addAll(aliasCommand.keySet());
+            out.add(all, new PicocliCompleter());
+            return out;
+        }
+
+        private class PicocliCompleter implements Completer {
+
+            public PicocliCompleter() {
+            }
+
+            @Override
+            public void complete(LineReader reader, ParsedLine commandLine, List<Candidate> candidates) {
+                assert commandLine != null;
+                assert candidates != null;
+                String word = commandLine.word();
+                List<String> words = commandLine.words();
+                CommandLine sub = findSubcommandLine(words, commandLine.wordIndex());
+                if (sub == null) {
+                    return;
+                }
+                if (word.startsWith("-")) {
+                    String buffer = word.substring(0, commandLine.wordCursor());
+                    int eq = buffer.indexOf('=');
+                    for (CommandLine.Model.OptionSpec option : sub.getCommandSpec().options()) {
+                        if (option.arity().max() == 0 && eq < 0) {
+                            addCandidates(candidates, Arrays.asList(option.names()));
+                        } else {
+                            if (eq > 0) {
+                                String opt = buffer.substring(0, eq);
+                                if (Arrays.asList(option.names()).contains(opt)
+                                        && option.completionCandidates() != null) {
+                                    addCandidates(
+                                            candidates,
+                                            option.completionCandidates(),
+                                            buffer.substring(0, eq + 1),
+                                            "",
+                                            true);
+                                }
+                            } else {
+                                addCandidates(candidates, Arrays.asList(option.names()), "", "=", false);
+                            }
+                        }
+                    }
+                } else {
+                    addCandidates(candidates, sub.getSubcommands().keySet());
+                    for (CommandLine s : sub.getSubcommands().values()) {
+                        addCandidates(candidates, Arrays.asList(s.getCommandSpec().aliases()));
+                    }
+                }
+            }
+
+            private void addCandidates(List<Candidate> candidates, Iterable<String> cands) {
+                addCandidates(candidates, cands, "", "", true);
+            }
+
+            private void addCandidates(
+                    List<Candidate> candidates,
+                    Iterable<String> cands,
+                    String preFix,
+                    String postFix,
+                    boolean complete) {
+                for (String s : cands) {
+                    candidates.add(
+                            new Candidate(
+                                    AttributedString.stripAnsi(preFix + s + postFix),
+                                    s,
+                                    null,
+                                    null,
+                                    null,
+                                    null,
+                                    complete));
+                }
+            }
+
+        }
+
+        private CommandLine findSubcommandLine(List<String> args, int lastIdx) {
+            CommandLine out = cmd;
+            for (int i = 0; i < lastIdx; i++) {
+                if (!args.get(i).startsWith("-")) {
+                    out = findSubcommandLine(out, args.get(i));
+                    if (out == null) {
+                        break;
+                    }
+                }
+            }
+            return out;
+        }
+
+        private CommandLine findSubcommandLine(CommandLine cmdline, String command) {
+            for (CommandLine s : cmdline.getSubcommands().values()) {
+                if (s.getCommandName().equals(command)
+                        || Arrays.asList(s.getCommandSpec().aliases()).contains(command)) {
+                    return s;
+                }
+            }
+            return null;
+        }
+
+        /**
+         *
+         * @param args
+         * @return command description for JLine TailTipWidgets to be displayed in terminal status bar.
+         */
+        @Override
+        public CmdDesc commandDescription(List<String> args) {
+            CommandLine sub = findSubcommandLine(args, args.size());
+            if (sub == null) {
+                return null;
+            }
+            CommandLine.Model.CommandSpec spec = sub.getCommandSpec();
+            CommandLine.Help cmdhelp = new picocli.CommandLine.Help(spec);
+            List<AttributedString> main = new ArrayList<>();
+            Map<String, List<AttributedString>> options = new HashMap<>();
+            String synopsis = AttributedString
+                    .stripAnsi(spec.usageMessage().sectionMap().get("synopsis").render(cmdhelp).toString());
+            main.add(Options.HelpException.highlightSyntax(synopsis.trim(), Options.HelpException.defaultStyle()));
+            // using JLine help highlight because the statement below does not work well...
+            // main.add(new
+            // AttributedString(spec.usageMessage().sectionMap().get("synopsis").render(cmdhelp).toString()));
+            for (CommandLine.Model.OptionSpec o : spec.options()) {
+                String key = Arrays.stream(o.names()).collect(Collectors.joining(" "));
+                List<AttributedString> val = new ArrayList<>();
+                for (String d : o.description()) {
+                    val.add(new AttributedString(d));
+                }
+                if (o.arity().max() > 0) {
+                    key += "=" + o.paramLabel();
+                }
+                options.put(key, val);
+            }
+            return new CmdDesc(main, ArgDesc.doArgNames(Arrays.asList("")), options);
+        }
+
+        @Override
+        public List<String> commandInfo(String command) {
+            List<String> out = new ArrayList<>();
+            CommandLine.Model.CommandSpec spec = cmd.getSubcommands().get(command).getCommandSpec();
+            CommandLine.Help cmdhelp = new picocli.CommandLine.Help(spec);
+            String description = AttributedString
+                    .stripAnsi(spec.usageMessage().sectionMap().get("description").render(cmdhelp).toString());
+            out.addAll(Arrays.asList(description.split("\\r?\\n")));
+            return out;
+        }
+
+        @Override
+        public Object invoke(CommandRegistry.CommandSession session, String command, Object[] args) throws Exception {
+            List<String> arguments = new ArrayList<>();
+            arguments.add(command);
+            arguments.addAll(Arrays.stream(args).map(Object::toString).collect(Collectors.toList()));
+            cmd.execute(arguments.toArray(new String[0]));
+            return null;
+        }
+
+        @Override
+        public Set<String> commandNames() {
+            return commands;
+        }
+
+        @Override
+        public Map<String, String> commandAliases() {
+            return aliasCommand;
         }
     }
 }

--- a/pom.xml
+++ b/pom.xml
@@ -158,6 +158,16 @@
                 <artifactId>picocli-shell-jline3</artifactId>
                 <version>${picocli.version}</version>
             </dependency>
+            <dependency>
+                <groupId>org.jline</groupId>
+                <artifactId>jline</artifactId>
+                <version>3.16.0</version>
+            </dependency>
+            <dependency>
+                <groupId>org.jline</groupId>
+                <artifactId>jline-console</artifactId>
+                <version>3.16.0</version>
+            </dependency>
             <!-- I need this, otherwise the snowdrop dependency overrides the version and it messes things up -->
             <dependency>
                 <groupId>org.jboss.resteasy</groupId>


### PR DESCRIPTION
This explicitly enables tailtip support for the console interface. To do that I have had to inline a lot of picocli-jline3 support until https://github.com/remkop/picocli/issues/1175 is fixed (found during discussions on https://github.com/jline/jline3/issues/571 ).

If this is ok , I'll add a separate internal tracker to remove the override code (the second commit) once picocli 4.6 is out.