### PR TITLE
[NCL-6060] Get the build log on demand

### DIFF
--- a/pig/src/main/java/org/jboss/pnc/bacon/pig/impl/addons/quarkus/QuarkusCommunityDepAnalyzer.java
+++ b/pig/src/main/java/org/jboss/pnc/bacon/pig/impl/addons/quarkus/QuarkusCommunityDepAnalyzer.java
@@ -90,6 +90,11 @@ public class QuarkusCommunityDepAnalyzer extends AddOn {
         log.info("releasePath: {}, extrasPath: {}, deliverables: {}", releasePath, extrasPath, deliverables);
         skipped.addAll(skippedExtensions());
 
+        if (PigContext.get().getRepositoryData() == null) {
+            throw new RuntimeException(
+                    "No repository data available for document generation. Please make sure to run `pig repo` before");
+        }
+
         unpackRepository(PigContext.get().getRepositoryData().getRepositoryPath());
 
         String additionalRepository = (String) getAddOnConfiguration().get("additionalRepository");


### PR DESCRIPTION
Since the build log is not stored in the context.json due to size, that
causes some issues.

1. If a pig command depends on the build log and it is not present, this
   will stop the command from working. (e.g for `pig addons`)

It's also better to only get the build logs if necessary since they are
huge and take a lot of space. The build logs are cached within the same
pig command, but if you run multiple pig commands, the build logs will
be loaded from the PNC server again.

### Checklist:

* [ ] Have you added a note in the [CHANGELOG wiki](https://github.com/project-ncl/bacon/wiki/Changelog) for your change if user-facing?
* [ ] Have you added unit tests for your change?
