### PR TITLE
Set default javadoc generation to IGNORE

### DIFF
--- a/pig/src/main/java/org/jboss/pnc/bacon/pig/impl/javadoc/JavadocManager.java
+++ b/pig/src/main/java/org/jboss/pnc/bacon/pig/impl/javadoc/JavadocManager.java
@@ -94,7 +94,8 @@ public class JavadocManager extends DeliverableManager<GenerationData<?>, Void> 
     }
 
     public void prepare() {
-        JavadocGenerationStrategy strategy = generationData.getStrategy();
+        JavadocGenerationStrategy strategy = generationData == null ? JavadocGenerationStrategy.IGNORE
+                : generationData.getStrategy();
         switch (strategy) {
             case DOWNLOAD:
                 downloadAndRepackage();


### PR DESCRIPTION
This matches the same logic as for license generation

### Checklist:

* [ ] Have you added a note in the [CHANGELOG wiki](https://github.com/project-ncl/bacon/wiki/Changelog) for your change if user-facing?
* [ ] Have you added unit tests for your change?
