### PR TITLE
[NCL-5982] Add validation to build-config.yaml

### DIFF
--- a/config/pom.xml
+++ b/config/pom.xml
@@ -34,5 +34,10 @@
             <groupId>com.fasterxml.jackson.dataformat</groupId>
             <artifactId>jackson-dataformat-yaml</artifactId>
         </dependency>
+
+        <dependency>
+            <groupId>javax.validation</groupId>
+            <artifactId>validation-api</artifactId>
+        </dependency>
     </dependencies>
 </project>

--- a/config/src/main/java/org/jboss/pnc/bacon/config/Validate.java
+++ b/config/src/main/java/org/jboss/pnc/bacon/config/Validate.java
@@ -1,7 +1,12 @@
 package org.jboss.pnc.bacon.config;
 
+import javax.validation.ConstraintViolation;
+
 import java.net.URI;
 import java.net.URISyntaxException;
+import java.util.ArrayList;
+import java.util.List;
+import java.util.Set;
 
 public interface Validate {
 
@@ -40,6 +45,17 @@ public interface Validate {
 
     static void fail(String reason) {
         checkIfNull(null, reason);
+    }
+
+    static <T> String prettifyConstraintViolation(Set<ConstraintViolation<T>> violations) {
+
+        List<String> errorMsgs = new ArrayList<>();
+
+        for (ConstraintViolation violation : violations) {
+            errorMsgs.add("Field: " + violation.getPropertyPath() + " " + violation.getMessage());
+        }
+        return String.join("\n", errorMsgs);
+
     }
 
     class ConfigMissingException extends RuntimeException {

--- a/integration-tests/src/test/resources/config/build-config.yaml
+++ b/integration-tests/src/test/resources/config/build-config.yaml
@@ -35,3 +35,10 @@ outputPrefixes:
     releaseDir: product-a # prefix for a top level directory name inside the deliverables
     releaseFile: product-a # prefix for the deliverables. Version and milestone will be appended to it
 
+flow:
+    licensesGeneration:
+        strategy: IGNORE
+    repositoryGeneration:
+        strategy: IGNORE
+    javadocGeneration:
+        strategy: IGNORE

--- a/pig/pom.xml
+++ b/pig/pom.xml
@@ -125,6 +125,15 @@
         </dependency>
 
         <dependency>
+            <groupId>org.hibernate</groupId>
+            <artifactId>hibernate-validator</artifactId>
+        </dependency>
+        <dependency>
+            <groupId>org.glassfish</groupId>
+            <artifactId>javax.el</artifactId>
+        </dependency>
+
+        <dependency>
             <groupId>org.junit.jupiter</groupId>
             <artifactId>junit-jupiter-engine</artifactId>
             <scope>test</scope>

--- a/pig/src/main/java/org/jboss/pnc/bacon/pig/impl/config/BuildConfig.java
+++ b/pig/src/main/java/org/jboss/pnc/bacon/pig/impl/config/BuildConfig.java
@@ -32,6 +32,8 @@ import org.jboss.pnc.enums.BuildType;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
+import javax.validation.constraints.NotBlank;
+
 import java.io.UnsupportedEncodingException;
 import java.lang.reflect.Field;
 import java.net.URLDecoder;
@@ -65,12 +67,12 @@ public class BuildConfig {
     private static final Logger log = LoggerFactory.getLogger(BuildConfig.class);
     private static final ClientCreator<EnvironmentClient> CREATOR = new ClientCreator<>(EnvironmentClient::new);
 
-    private String name;
-    private String project;
-    private String buildScript;
+    private @NotBlank String name;
+    private @NotBlank String project;
+    private @NotBlank String buildScript;
     private String scmUrl;
     private String externalScmUrl;
-    private String scmRevision;
+    private @NotBlank String scmRevision;
     private String description;
     private String environmentId;
 
@@ -93,7 +95,7 @@ public class BuildConfig {
 
     private Set<String> extraRepositories = new TreeSet<>();
     private Boolean branchModified;
-    private String buildType;
+    private @NotBlank String buildType;
 
     /** deprecated: use brewBuildName instead */
     private String executionRoot;
@@ -231,10 +233,6 @@ public class BuildConfig {
         return result;
     }
 
-    public void validate(List<String> errors) {
-        // TODO!
-    }
-
     public boolean isUpgradableFrom(BuildConfiguration oldConfig) {
         String oldInternalUrl = oldConfig.getScmRepository().getInternalUrl();
         if (scmUrl != null && !StringUtils.equals(scmUrl, oldInternalUrl)) {
@@ -271,8 +269,9 @@ public class BuildConfig {
             } catch (RemoteResourceException e) {
                 throw new FatalException("Exception while talking to PNC", e);
             }
-        } else {
-            throw new FatalException("No environmentId / environmentSystemImageId defined for the build config");
         }
+
+        // if we're here, no environmentId could be found
+        return null;
     }
 }

--- a/pig/src/main/java/org/jboss/pnc/bacon/pig/impl/config/Flow.java
+++ b/pig/src/main/java/org/jboss/pnc/bacon/pig/impl/config/Flow.java
@@ -19,6 +19,7 @@ package org.jboss.pnc.bacon.pig.impl.config;
 
 import lombok.Data;
 import org.jboss.pnc.bacon.pig.impl.sources.SourcesGenerationData;
+import org.jboss.pnc.bacon.pig.impl.validation.GenerationDataCheck;
 
 /**
  *
@@ -27,9 +28,11 @@ import org.jboss.pnc.bacon.pig.impl.sources.SourcesGenerationData;
  */
 @Data
 public class Flow {
-    private LicenseGenerationData licensesGeneration;
-    private RepoGenerationData repositoryGeneration;
-    private JavadocGenerationData javadocGeneration;
+    private @GenerationDataCheck LicenseGenerationData licensesGeneration;
+
+    private @GenerationDataCheck RepoGenerationData repositoryGeneration;
+
+    private @GenerationDataCheck JavadocGenerationData javadocGeneration;
 
     /**
      * Add defaults to avoid having existing configurations having to define a sourceGeneration object in the flow

--- a/pig/src/main/java/org/jboss/pnc/bacon/pig/impl/config/Output.java
+++ b/pig/src/main/java/org/jboss/pnc/bacon/pig/impl/config/Output.java
@@ -19,6 +19,8 @@ package org.jboss.pnc.bacon.pig.impl.config;
 
 import lombok.Data;
 
+import javax.validation.constraints.NotBlank;
+
 /**
  *
  * @author Michal Szynkiewicz, michal.l.szynkiewicz@gmail.com <br>
@@ -26,6 +28,7 @@ import lombok.Data;
  */
 @Data
 public class Output {
-    private String releaseFile;
-    private String releaseDir;
+
+    private @NotBlank String releaseFile;
+    private @NotBlank String releaseDir;
 }

--- a/pig/src/main/java/org/jboss/pnc/bacon/pig/impl/config/ProductConfig.java
+++ b/pig/src/main/java/org/jboss/pnc/bacon/pig/impl/config/ProductConfig.java
@@ -19,14 +19,16 @@ package org.jboss.pnc.bacon.pig.impl.config;
 
 import lombok.Data;
 
+import javax.validation.constraints.NotBlank;
+
 /**
  * @author Michal Szynkiewicz, michal.l.szynkiewicz@gmail.com <br>
  *         Date: 11/28/17
  */
 @Data
 public class ProductConfig {
-    private String name;
-    private String abbreviation;
+    private @NotBlank String name;
+    private @NotBlank String abbreviation;
     private String stage;
     private String issueTrackerUrl;
 

--- a/pig/src/main/java/org/jboss/pnc/bacon/pig/impl/validation/GenerationDataCheck.java
+++ b/pig/src/main/java/org/jboss/pnc/bacon/pig/impl/validation/GenerationDataCheck.java
@@ -1,0 +1,28 @@
+package org.jboss.pnc.bacon.pig.impl.validation;
+
+import javax.validation.Constraint;
+import javax.validation.Payload;
+
+import java.lang.annotation.Retention;
+import java.lang.annotation.Target;
+
+import static java.lang.annotation.ElementType.ANNOTATION_TYPE;
+import static java.lang.annotation.ElementType.FIELD;
+import static java.lang.annotation.ElementType.METHOD;
+import static java.lang.annotation.ElementType.PARAMETER;
+import static java.lang.annotation.RetentionPolicy.RUNTIME;
+
+/**
+ * Validator annotation for GenerationData
+ */
+@Target({ FIELD, METHOD, PARAMETER, ANNOTATION_TYPE })
+@Retention(RUNTIME)
+@Constraint(validatedBy = GenerationDataValidator.class)
+public @interface GenerationDataCheck {
+
+    String message() default "Generation Data validation fail";
+
+    Class<?>[] groups() default {};
+
+    Class<? extends Payload>[] payload() default {};
+}

--- a/pig/src/main/java/org/jboss/pnc/bacon/pig/impl/validation/GenerationDataValidator.java
+++ b/pig/src/main/java/org/jboss/pnc/bacon/pig/impl/validation/GenerationDataValidator.java
@@ -1,0 +1,52 @@
+package org.jboss.pnc.bacon.pig.impl.validation;
+
+import org.jboss.pnc.bacon.pig.impl.config.GenerationData;
+
+import javax.validation.ConstraintValidator;
+import javax.validation.ConstraintValidatorContext;
+
+/**
+ * Validation implementation for GenerationDataCheck
+ */
+public class GenerationDataValidator implements ConstraintValidator<GenerationDataCheck, GenerationData> {
+
+    private GenerationDataCheck constraintAnnotation;
+
+    /**
+     * If the strategy is DOWNLOAD and the sourceBuild and/or sourceArtifact is null, it is not valid
+     *
+     * @param value
+     * @param context
+     * @return
+     */
+    @Override
+    public boolean isValid(GenerationData value, ConstraintValidatorContext context) {
+
+        // if error is not null, that means it's not valid!
+        String error = null;
+
+        if (value == null) {
+            // we do nothing if value is null?
+            error = null;
+        } else if (value.getStrategy().toString().equals("DOWNLOAD")
+                && (value.getSourceBuild() == null || value.getSourceArtifact() == null)) {
+            error = "strategy is 'DOWNLOAD', but 'sourceBuild' and/or 'sourceArtifact' is null!";
+        }
+
+        if (error == null) {
+            // everything is good!
+            return true;
+        } else {
+            // Set the error message for the validation violation
+            context.disableDefaultConstraintViolation();
+            context.buildConstraintViolationWithTemplate(error).addConstraintViolation();
+            return false;
+        }
+    }
+
+    @Override
+    public void initialize(GenerationDataCheck constraintAnnotation) {
+        this.constraintAnnotation = constraintAnnotation;
+
+    }
+}

--- a/pig/src/main/java/org/jboss/pnc/bacon/pig/impl/validation/ListBuildConfigCheck.java
+++ b/pig/src/main/java/org/jboss/pnc/bacon/pig/impl/validation/ListBuildConfigCheck.java
@@ -1,0 +1,28 @@
+package org.jboss.pnc.bacon.pig.impl.validation;
+
+import javax.validation.Constraint;
+import javax.validation.Payload;
+
+import java.lang.annotation.Retention;
+import java.lang.annotation.Target;
+
+import static java.lang.annotation.ElementType.ANNOTATION_TYPE;
+import static java.lang.annotation.ElementType.FIELD;
+import static java.lang.annotation.ElementType.METHOD;
+import static java.lang.annotation.ElementType.PARAMETER;
+import static java.lang.annotation.RetentionPolicy.RUNTIME;
+
+/**
+ * Validator annotation for Build config
+ */
+@Target({ FIELD, METHOD, PARAMETER, ANNOTATION_TYPE })
+@Retention(RUNTIME)
+@Constraint(validatedBy = ListBuildConfigValidator.class)
+public @interface ListBuildConfigCheck {
+
+    String message() default "Build Config validation fail";
+
+    Class<?>[] groups() default {};
+
+    Class<? extends Payload>[] payload() default {};
+}

--- a/pig/src/main/java/org/jboss/pnc/bacon/pig/impl/validation/ListBuildConfigValidator.java
+++ b/pig/src/main/java/org/jboss/pnc/bacon/pig/impl/validation/ListBuildConfigValidator.java
@@ -1,0 +1,67 @@
+package org.jboss.pnc.bacon.pig.impl.validation;
+
+import org.jboss.pnc.bacon.pig.impl.config.BuildConfig;
+import org.jboss.pnc.enums.BuildType;
+
+import javax.validation.ConstraintValidator;
+import javax.validation.ConstraintValidatorContext;
+import javax.validation.Validation;
+import javax.validation.Validator;
+import javax.validation.ValidatorFactory;
+
+import java.util.ArrayList;
+import java.util.List;
+
+/**
+ * Validation implementation for BuildConfig
+ */
+public class ListBuildConfigValidator implements ConstraintValidator<ListBuildConfigCheck, List<BuildConfig>> {
+
+    private ListBuildConfigCheck constraintAnnotation;
+    private Validator validator;
+
+    @Override
+    public boolean isValid(List<BuildConfig> values, ConstraintValidatorContext context) {
+
+        List<String> errors = new ArrayList<>();
+
+        for (BuildConfig value : values) {
+
+            if (value == null) {
+                // we do nothing if value is null?
+                errors.add("is null");
+            } else if (value.getScmUrl() == null && value.getExternalScmUrl() == null) {
+                errors.add(
+                        "Build config " + value.getName()
+                                + " has both scmUrl and externalScmUrl not specified. Specify at least one of the keys with a value");
+            } else if (value.getEnvironmentId() == null && value.getSystemImageId() == null) {
+                errors.add(
+                        "Build config " + value.getName()
+                                + " has environmentId and systemImageId not specified. Specify one of the keys with a value");
+            } else {
+                try {
+                    BuildType.valueOf(value.getBuildType());
+                } catch (IllegalArgumentException e) {
+                    errors.add("Build config " + value.getName() + " has wrong buildType");
+                }
+            }
+        }
+
+        if (errors.isEmpty()) {
+            // everything is good!
+            return true;
+        } else {
+            // Set the error message for the validation violation
+            context.disableDefaultConstraintViolation();
+            context.buildConstraintViolationWithTemplate(String.join("\n", errors)).addConstraintViolation();
+            return false;
+        }
+    }
+
+    @Override
+    public void initialize(ListBuildConfigCheck constraintAnnotation) {
+        this.constraintAnnotation = constraintAnnotation;
+        ValidatorFactory factory = Validation.buildDefaultValidatorFactory();
+        validator = factory.getValidator();
+    }
+}

--- a/pig/src/test/java/org/jboss/pnc/bacon/pig/impl/validation/GenerationDataCheckTest.java
+++ b/pig/src/test/java/org/jboss/pnc/bacon/pig/impl/validation/GenerationDataCheckTest.java
@@ -1,0 +1,98 @@
+package org.jboss.pnc.bacon.pig.impl.validation;
+
+import org.jboss.pnc.bacon.pig.impl.config.GenerationData;
+import org.jboss.pnc.bacon.pig.impl.config.JavadocGenerationData;
+import org.jboss.pnc.bacon.pig.impl.config.JavadocGenerationStrategy;
+import org.jboss.pnc.bacon.pig.impl.config.LicenseGenerationData;
+import org.jboss.pnc.bacon.pig.impl.config.LicenseGenerationStrategy;
+import org.jboss.pnc.bacon.pig.impl.config.RepoGenerationData;
+import org.jboss.pnc.bacon.pig.impl.config.RepoGenerationStrategy;
+import org.junit.jupiter.api.BeforeAll;
+import org.junit.jupiter.api.Test;
+
+import javax.validation.ConstraintViolation;
+import javax.validation.Validation;
+import javax.validation.Validator;
+import javax.validation.ValidatorFactory;
+
+import java.util.Set;
+
+import static org.assertj.core.api.Assertions.*;
+
+class GenerationDataCheckTest {
+
+    static Validator validator;
+
+    @BeforeAll
+    static void setup() {
+
+        ValidatorFactory factory = Validation.buildDefaultValidatorFactory();
+        validator = factory.getValidator();
+    }
+
+    /**
+     * Test that for when the Generation strategy is DOWNLOAD, that the sourceArtifact and the sourceBuild are also
+     * specified
+     */
+    @Test
+    void testGenerationDataValidationOnDownload() {
+
+        LicenseGenerationData licenseGenerationData = new LicenseGenerationData();
+        licenseGenerationData.setStrategy(LicenseGenerationStrategy.DOWNLOAD);
+        this.<LicenseGenerationData> testGenerationDataValidationOnDownloadHelper(licenseGenerationData);
+
+        RepoGenerationData repoGenerationData = new RepoGenerationData();
+        repoGenerationData.setStrategy(RepoGenerationStrategy.DOWNLOAD);
+        this.<RepoGenerationData> testGenerationDataValidationOnDownloadHelper(repoGenerationData);
+
+        JavadocGenerationData javadocGenerationData = new JavadocGenerationData();
+        javadocGenerationData.setStrategy(JavadocGenerationStrategy.DOWNLOAD);
+        this.<JavadocGenerationData> testGenerationDataValidationOnDownloadHelper(javadocGenerationData);
+    }
+
+    private <T extends GenerationData> void testGenerationDataValidationOnDownloadHelper(
+            GenerationData generationData) {
+        // when
+        GenerationDataWrapper generationDataWrapper = new GenerationDataWrapper<T>();
+        generationDataWrapper.generationData = generationData;
+        Set<ConstraintViolation<GenerationDataWrapper>> violations = validator.validate(generationDataWrapper);
+
+        // then
+        assertThat(violations).hasSize(1);
+        assertThat(violations.stream().findFirst().get().getMessage()).contains("sourceBuild")
+                .contains("sourceArtifact");
+
+        // when
+        generationDataWrapper.generationData.setSourceBuild("source build");
+        generationDataWrapper.generationData.setSourceArtifact(null);
+        Set<ConstraintViolation<GenerationDataWrapper>> violationsSourceBuild = validator
+                .validate(generationDataWrapper);
+
+        // then
+        assertThat(violationsSourceBuild).hasSize(1);
+        assertThat(violationsSourceBuild.stream().findFirst().get().getMessage()).contains("sourceBuild");
+
+        // when
+        generationDataWrapper.generationData.setSourceBuild(null);
+        generationDataWrapper.generationData.setSourceArtifact("source artifact");
+        Set<ConstraintViolation<GenerationDataWrapper>> violationsSourceArtifact = validator
+                .validate(generationDataWrapper);
+
+        // then
+        assertThat(violationsSourceArtifact).hasSize(1);
+        assertThat(violationsSourceArtifact.stream().findFirst().get().getMessage()).contains("sourceArtifact");
+
+        // when
+        generationDataWrapper.generationData.setSourceBuild("source build");
+        generationDataWrapper.generationData.setSourceArtifact("source artifact");
+        Set<ConstraintViolation<GenerationDataWrapper>> violationsNot = validator.validate(generationDataWrapper);
+
+        // then
+        assertThat(violationsNot).hasSize(0);
+    }
+
+    class GenerationDataWrapper<T extends GenerationData> {
+        @GenerationDataCheck
+        T generationData;
+    }
+}

--- a/pig/src/test/java/org/jboss/pnc/bacon/pig/impl/validation/ListBuildConfigCheckTest.java
+++ b/pig/src/test/java/org/jboss/pnc/bacon/pig/impl/validation/ListBuildConfigCheckTest.java
@@ -1,0 +1,127 @@
+package org.jboss.pnc.bacon.pig.impl.validation;
+
+import com.google.common.collect.Lists;
+import lombok.AllArgsConstructor;
+import org.jboss.pnc.bacon.pig.impl.config.BuildConfig;
+import org.jboss.pnc.enums.BuildType;
+import org.jeasy.random.EasyRandom;
+import org.junit.jupiter.api.BeforeAll;
+import org.junit.jupiter.api.Test;
+
+import javax.validation.ConstraintViolation;
+import javax.validation.Validation;
+import javax.validation.Validator;
+import javax.validation.ValidatorFactory;
+
+import java.util.List;
+import java.util.Set;
+
+import static org.assertj.core.api.Assertions.*;
+
+class ListBuildConfigCheckTest {
+    static Validator validator;
+    static EasyRandom easyRandom;
+
+    @BeforeAll
+    static void setupAll() {
+        ValidatorFactory factory = Validation.buildDefaultValidatorFactory();
+        validator = factory.getValidator();
+        easyRandom = new EasyRandom();
+    }
+
+    @Test
+    void checkForAtLeastOneScmUrlKeyToBeSpecified() {
+        // when both fields are null
+        BuildConfig buildConfig = easyRandom.nextObject(BuildConfig.class);
+        buildConfig.setBuildType(BuildType.MVN.toString());
+        buildConfig.setScmUrl(null);
+        buildConfig.setExternalScmUrl(null);
+
+        ListBuildConfigWrapper wrapper = new ListBuildConfigWrapper(Lists.newArrayList(buildConfig));
+        Set<ConstraintViolation<ListBuildConfigWrapper>> violations = validator.validate(wrapper);
+
+        // then
+        assertThat(violations).hasSize(1);
+        assertThat(violations.stream().findFirst().get().getMessage()).contains(buildConfig.getName());
+
+        // when only externalScmUrl null, no violation
+        buildConfig.setScmUrl("http://example.com");
+        buildConfig.setExternalScmUrl(null);
+        violations = validator.validate(wrapper);
+
+        // then
+        assertThat(violations).isEmpty();
+
+        // when only scmUrl null, no violation
+        buildConfig.setScmUrl(null);
+        buildConfig.setExternalScmUrl("http://example.com");
+        violations = validator.validate(wrapper);
+
+        // then
+        assertThat(violations).isEmpty();
+    }
+
+    /**
+     * TODO: write tests also for systemImageId. Can't really be done because 'getEnvironmentId' uses PNC Client right
+     * now
+     */
+    @Test
+    void checkForEnvironmentIdToBeSpecified() {
+
+        BuildConfig buildConfig = easyRandom.nextObject(BuildConfig.class);
+        buildConfig.setBuildType(BuildType.MVN.toString());
+        ListBuildConfigWrapper wrapper = new ListBuildConfigWrapper(Lists.newArrayList(buildConfig));
+
+        // when only environmentId is specified, no violations
+        buildConfig.setEnvironmentId("5");
+        buildConfig.setSystemImageId(null);
+        Set<ConstraintViolation<ListBuildConfigWrapper>> violations = validator.validate(wrapper);
+
+        // then
+        assertThat(violations).isEmpty();
+    }
+
+    @Test
+    void checkIfBuildTypeIsValidated() {
+        BuildConfig buildConfig = easyRandom.nextObject(BuildConfig.class);
+        buildConfig.setBuildType("garbage");
+
+        ListBuildConfigWrapper wrapper = new ListBuildConfigWrapper(Lists.newArrayList(buildConfig));
+        Set<ConstraintViolation<ListBuildConfigWrapper>> violations = validator.validate(wrapper);
+
+        // then
+        assertThat(violations).hasSize(1);
+        assertThat(violations.stream().findFirst().get().getMessage()).contains(buildConfig.getName());
+
+        // when all is good
+        buildConfig.setBuildType(BuildType.GRADLE.toString());
+        violations = validator.validate(wrapper);
+
+        // then
+        assertThat(violations).isEmpty();
+    }
+
+    @Test
+    void testIfItTestsAllBuildConfigs() {
+        // only buildConfig1 is valid, buildConfig2 should fail
+        BuildConfig buildConfig1 = easyRandom.nextObject(BuildConfig.class);
+        BuildConfig buildConfig2 = easyRandom.nextObject(BuildConfig.class);
+
+        buildConfig1.setBuildType(BuildType.NPM.toString());
+
+        ListBuildConfigWrapper wrapper = new ListBuildConfigWrapper(Lists.newArrayList(buildConfig1, buildConfig2));
+        Set<ConstraintViolation<ListBuildConfigWrapper>> violations = validator.validate(wrapper);
+
+        // then
+        assertThat(violations).hasSize(1);
+        assertThat(violations.stream().findFirst().get().getMessage()).contains(buildConfig2.getName());
+    }
+
+    @AllArgsConstructor
+    class ListBuildConfigWrapper {
+        @ListBuildConfigCheck
+        List<BuildConfig> builds;
+
+    }
+
+}

--- a/pig/src/test/java/org/jboss/pnc/bacon/pig/impl/validation/PigConfigurationValidationTest.java
+++ b/pig/src/test/java/org/jboss/pnc/bacon/pig/impl/validation/PigConfigurationValidationTest.java
@@ -1,0 +1,212 @@
+package org.jboss.pnc.bacon.pig.impl.validation;
+
+import com.google.common.collect.Lists;
+import org.jboss.pnc.bacon.pig.impl.config.BuildConfig;
+import org.jboss.pnc.bacon.pig.impl.config.JavadocGenerationStrategy;
+import org.jboss.pnc.bacon.pig.impl.config.LicenseGenerationStrategy;
+import org.jboss.pnc.bacon.pig.impl.config.PigConfiguration;
+import org.jboss.pnc.bacon.pig.impl.config.RepoGenerationStrategy;
+import org.jboss.pnc.enums.BuildType;
+import org.jeasy.random.EasyRandom;
+import org.junit.jupiter.api.BeforeAll;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+
+import javax.validation.ConstraintViolation;
+import javax.validation.Validation;
+import javax.validation.Validator;
+import javax.validation.ValidatorFactory;
+
+import java.util.Collections;
+import java.util.Set;
+
+import static org.assertj.core.api.Assertions.*;
+
+class PigConfigurationValidationTest {
+
+    static Validator validator;
+    PigConfiguration generated;
+
+    @BeforeAll
+    static void setupAll() {
+        ValidatorFactory factory = Validation.buildDefaultValidatorFactory();
+        validator = factory.getValidator();
+    }
+
+    @BeforeEach
+    void setup() {
+        EasyRandom easyRandom = new EasyRandom();
+
+        BuildConfig buildConfig = easyRandom.nextObject(BuildConfig.class);
+        buildConfig.setBuildType(BuildType.MVN.toString());
+        generated = new EasyRandom().nextObject(PigConfiguration.class);
+        generated.setBuilds(Lists.newArrayList(buildConfig));
+    }
+
+    @Test
+    void defaultGeneratedPigConfigurationIsValid() {
+        // no violations!
+        assertThat(validator.validate(generated)).isEmpty();
+    }
+
+    @Test
+    void testProductNotNull() {
+
+        // when product is null
+        generated.setProduct(null);
+        Set<ConstraintViolation<PigConfiguration>> violations = validator.validate(generated);
+
+        // then
+        assertThat(violations).hasSize(1);
+        assertThat(violations.stream().findFirst().get().getPropertyPath().toString()).isEqualTo("product");
+
+    }
+
+    @Test
+    void testProductContentIsNotBlank() {
+
+        // when name is null
+        generated.getProduct().setName(null);
+        // then
+        test(validator.validate(generated), "product.name");
+
+        // when name is empty
+        generated.getProduct().setName("");
+        // then
+        test(validator.validate(generated), "product.name");
+
+        // when abbreviation is null
+        generated.getProduct().setName("Mumbo");
+        generated.getProduct().setAbbreviation(null);
+        // then
+        test(validator.validate(generated), "product.abbreviation");
+
+        // when abbreviation is empty
+        generated.getProduct().setName("Mumbo");
+        generated.getProduct().setAbbreviation("");
+        // then
+        test(validator.validate(generated), "product.abbreviation");
+    }
+
+    @Test
+    void versionMilestoneGroupNotBlank() {
+        // when version is null
+        generated.setVersion(null);
+        // then
+        test(validator.validate(generated), "version");
+
+        // when version is empty
+        generated.setVersion("");
+        // then
+        test(validator.validate(generated), "version");
+
+        generated.setVersion("1.2.3");
+
+        // when milestone is null
+        generated.setMilestone(null);
+        // then
+        test(validator.validate(generated), "milestone");
+
+        // when milestone is empty
+        generated.setMilestone("");
+        // then
+        test(validator.validate(generated), "milestone");
+
+        generated.setMilestone("DR1");
+
+        // when group is null
+        generated.setGroup(null);
+        // then
+        test(validator.validate(generated), "group");
+
+        // when group is empty
+        generated.setGroup("");
+        // then
+        test(validator.validate(generated), "group");
+    }
+
+    @Test
+    void testBuildConfigCannotBeEmpty() {
+        // when output is empty
+        generated.setBuilds(Collections.EMPTY_LIST);
+        // then
+        test(validator.validate(generated), "builds");
+    }
+
+    @Test
+    void testOutputPrefixesNotNull() {
+        // when output is null
+        generated.setOutputPrefixes(null);
+        // then
+        test(validator.validate(generated), "outputPrefixes");
+    }
+
+    @Test
+    void testOutputPrefixesContentNotBlank() {
+        // when releaseDir is null
+        generated.getOutputPrefixes().setReleaseDir(null);
+        // then
+        test(validator.validate(generated), "outputPrefixes.releaseDir");
+
+        // when releaseDir is empty
+        generated.getOutputPrefixes().setReleaseDir("");
+        // then
+        test(validator.validate(generated), "outputPrefixes.releaseDir");
+
+        generated.getOutputPrefixes().setReleaseDir("hi");
+
+        // when releaseFile is null
+        generated.getOutputPrefixes().setReleaseFile(null);
+        // then
+        test(validator.validate(generated), "outputPrefixes.releaseFile");
+
+        // when releaseFile is empty
+        generated.getOutputPrefixes().setReleaseFile(" ");
+        // then
+        test(validator.validate(generated), "outputPrefixes.releaseFile");
+    }
+
+    @Test
+    void flowDataMustNotBeNull() {
+        // when
+        generated.setFlow(null);
+        // then
+        test(validator.validate(generated), "flow");
+    }
+
+    @Test
+    void flowDataMustBeValidIfJavadocStrategyIsDownload() {
+        // when
+        generated.getFlow().getJavadocGeneration().setStrategy(JavadocGenerationStrategy.DOWNLOAD);
+        generated.getFlow().getJavadocGeneration().setSourceBuild(null);
+
+        // then
+        test(validator.validate(generated), "flow.javadocGeneration");
+    }
+
+    @Test
+    void flowDataMustBeValidIfRepoStrategyIsDownload() {
+        // when
+        generated.getFlow().getRepositoryGeneration().setStrategy(RepoGenerationStrategy.DOWNLOAD);
+        generated.getFlow().getRepositoryGeneration().setSourceBuild(null);
+
+        // then
+        test(validator.validate(generated), "flow.repositoryGeneration");
+    }
+
+    @Test
+    void flowDataMustBeValidIfLicenseStrategyIsDownload() {
+        // when
+        generated.getFlow().getLicensesGeneration().setStrategy(LicenseGenerationStrategy.DOWNLOAD);
+        generated.getFlow().getLicensesGeneration().setSourceArtifact(null);
+
+        // then
+        test(validator.validate(generated), "flow.licensesGeneration");
+    }
+
+    private void test(Set<ConstraintViolation<PigConfiguration>> violations, String expectedPropertyPath) {
+
+        assertThat(violations).hasSize(1);
+        assertThat(violations.stream().findFirst().get().getPropertyPath()).hasToString(expectedPropertyPath);
+    }
+}

--- a/pig/src/test/resources/build-config-UnknownVar.yaml
+++ b/pig/src/test/resources/build-config-UnknownVar.yaml
@@ -32,3 +32,15 @@ builds:
       - 'versionSuffix={{redhatSuffix}}'
       - 'groovyManipulatorPrecedence=FIRST'
       - 'groovyScripts=org.jboss.vertx.component.management:vertx-component-management-aggregation:groovy:3.5.1.redhat-003'
+
+outputPrefixes:
+    releaseDir: release-dir
+    releaseFile: release-file
+flow:
+    # licensesGeneration: gen.downloadFrom 'WildFly-Swarm' matching '.*license\.zip'
+    licensesGeneration:
+        strategy: IGNORE
+    repositoryGeneration:
+        strategy: IGNORE
+    javadocGeneration:
+        strategy: IGNORE

--- a/pig/src/test/resources/build-config-VarUsage.yaml
+++ b/pig/src/test/resources/build-config-VarUsage.yaml
@@ -34,6 +34,9 @@ builds:
       - 'versionSuffix={{ redhatSuffix }}'
       - 'groovyManipulatorPrecedence=FIRST'
       - 'groovyScripts=org.jboss.vertx.component.management:vertx-component-management-aggregation:groovy:3.5.1.redhat-003'
+outputPrefixes:
+    releaseDir: release-dir
+    releaseFile: release-file
 flow:
   # licensesGeneration: gen.downloadFrom 'WildFly-Swarm' matching '.*license\.zip'
   licensesGeneration:

--- a/pom.xml
+++ b/pom.xml
@@ -342,6 +342,17 @@
                     </exclusion>
                 </exclusions>
             </dependency>
+            <!-- validation -->
+            <dependency>
+                <groupId>org.hibernate</groupId>
+                <artifactId>hibernate-validator</artifactId>
+                <version>6.1.5.Final</version>
+            </dependency>
+            <dependency>
+                <groupId>org.glassfish</groupId>
+                <artifactId>javax.el</artifactId>
+                <version>3.0.1-b11</version>
+            </dependency>
 
             <!-- jaxb -->
             <dependency>


### PR DESCRIPTION
This uses Hibernate Validator and Java EE Bean validation to accomplish
this.

Two custom bean validators are written to validate Build Configs and the
flow generation when set to 'DOWNLOAD'.

e.g
```
~/projects/work/bacon ncl-5982 ❯ java -jar cli/target/bacon.jar pig build nightly                                                           8s
[INFO ] - the configuration has been changed since the last run, using clean pig context
[INFO ] - HV000001: Hibernate Validator 2.1.2-SNAPSHOT
[ERROR] - Errors while validating the build-config.yaml:
Field: builds[0].project must not be blank
Field: product.name must not be blank
```

### Checklist:

* [ ] Have you added a note in the [CHANGELOG wiki](https://github.com/project-ncl/bacon/wiki/Changelog) for your change if user-facing?
* [ ] Have you added unit tests for your change?
