### PR TITLE
Revert "Bump httpclient from 4.5.12 to 4.5.13"

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -213,7 +213,7 @@
             <dependency>
                 <groupId>org.apache.httpcomponents</groupId>
                 <artifactId>httpclient</artifactId>
-                <version>4.5.13</version>
+                <version>4.5.12</version>
             </dependency>
             <dependency>
                 <groupId>org.apache.httpcomponents</groupId>


### PR DESCRIPTION
This reverts commit fe35147bd512fef004b586e5e159aec29236f532.

It breaks stuff with our port set to 'null' from the PNC Client

### Checklist:

* [ ] Have you added a note in the [CHANGELOG wiki](https://github.com/project-ncl/bacon/wiki/Changelog) for your change if user-facing?
* [ ] Have you added unit tests for your change?
