### PR TITLE
[NCLSUP-171] Set vars in PiG from command line

### DIFF
--- a/integration-tests/src/test/java/org/jboss/pnc/bacon/test/pig/PigFunctionalTest.java
+++ b/integration-tests/src/test/java/org/jboss/pnc/bacon/test/pig/PigFunctionalTest.java
@@ -13,6 +13,7 @@ import org.junit.jupiter.api.BeforeAll;
 import org.junit.jupiter.api.Tag;
 
 import java.nio.file.Path;
+import java.util.Collections;
 import java.util.Optional;
 
 @Tag(TestType.REAL_SERVICE_ONLY)
@@ -38,7 +39,12 @@ public abstract class PigFunctionalTest {
         }
         pig.validate();
 
-        PigContext.init(clean, configDir, targetDirectory.toAbsolutePath().toString(), releaseStorageUrl);
+        PigContext.init(
+                clean,
+                configDir,
+                targetDirectory.toAbsolutePath().toString(),
+                releaseStorageUrl,
+                Collections.emptyMap());
         return suffix;
     }
 

--- a/pig/src/main/java/org/jboss/pnc/bacon/pig/Pig.java
+++ b/pig/src/main/java/org/jboss/pnc/bacon/pig/Pig.java
@@ -39,6 +39,8 @@ import picocli.CommandLine.Parameters;
 
 import java.nio.file.Path;
 import java.nio.file.Paths;
+import java.util.Collections;
+import java.util.Map;
 import java.util.Optional;
 import java.util.concurrent.Callable;
 
@@ -115,6 +117,11 @@ public class Pig {
                 description = "The directory where the deliverables will be put")
         private String targetPath;
 
+        @Option(
+                names = { "-e", "--env" },
+                description = "Override the variables in the build-config.yaml. e.g -eVariable1=value1 -e Variable2=value2 --env=Variable3=value3")
+        private Map<String, String> overrides = Collections.emptyMap();
+
         /**
          * Computes a result, or throws an exception if unable to do so.
          *
@@ -136,7 +143,7 @@ public class Pig {
             FileDownloadUtils.setAttempts(downloadAttempts);
 
             Optional<String> releaseStorageUrl = Optional.ofNullable(this.releaseStorageUrl);
-            PigContext.init(clean || isStartingPoint(), Paths.get(configDir), targetPath, releaseStorageUrl);
+            PigContext.init(clean || isStartingPoint(), Paths.get(configDir), targetPath, releaseStorageUrl, overrides);
             PigContext.get().setTempBuild(tempBuild);
             ObjectHelper.print(getJsonOutput(), doExecute());
             return 0;

--- a/pig/src/main/java/org/jboss/pnc/bacon/pig/impl/PigContext.java
+++ b/pig/src/main/java/org/jboss/pnc/bacon/pig/impl/PigContext.java
@@ -87,11 +87,15 @@ public class PigContext {
 
     private Map<String, Collection<String>> checksums;
 
-    public void initConfig(Path configDir, String targetPath, Optional<String> releaseStorageUrl) {
+    public void initConfig(
+            Path configDir,
+            String targetPath,
+            Optional<String> releaseStorageUrl,
+            Map<String, String> overrides) {
         File configFile = configDir.resolve("build-config.yaml").toFile();
         if (configFile.exists()) {
             try (FileInputStream configStream = new FileInputStream(configFile)) {
-                PigConfiguration loadedConfig = PigConfiguration.load(configStream);
+                PigConfiguration loadedConfig = PigConfiguration.load(configStream, overrides);
                 setPigConfiguration(loadedConfig, targetPath, releaseStorageUrl);
             } catch (IOException e) {
                 throw new RuntimeException("Failed to read config file: " + configFile.getAbsolutePath(), e);
@@ -186,9 +190,10 @@ public class PigContext {
             boolean clean,
             Path configDir,
             String targetPath,
-            Optional<String> releaseStorageUrl) {
+            Optional<String> releaseStorageUrl,
+            Map<String, String> overrides) {
         instance = readContext(clean, configDir);
-        instance.initConfig(configDir, targetPath, releaseStorageUrl);
+        instance.initConfig(configDir, targetPath, releaseStorageUrl, overrides);
         return instance;
     }
 

--- a/pig/src/test/java/org/jboss/pnc/bacon/config/ConfigReaderTest.java
+++ b/pig/src/test/java/org/jboss/pnc/bacon/config/ConfigReaderTest.java
@@ -17,11 +17,14 @@
  */
 package org.jboss.pnc.bacon.config;
 
+import com.google.common.collect.ImmutableMap;
 import org.jboss.pnc.bacon.pig.impl.config.JavadocGenerationStrategy;
 import org.jboss.pnc.bacon.pig.impl.config.PigConfiguration;
 import org.junit.jupiter.api.Test;
 
 import java.io.InputStream;
+import java.util.Collections;
+import java.util.Map;
 
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.junit.jupiter.api.Assertions.assertNotNull;
@@ -42,10 +45,10 @@ class ConfigReaderTest {
     }
 
     private PigConfiguration loadBuildConfig(String buildConfig) {
-        return loadBuildConfig(buildConfig, "");
+        return loadBuildConfig(buildConfig, Collections.emptyMap());
     }
 
-    private PigConfiguration loadBuildConfig(String buildConfig, String buildVarOverrides) {
+    private PigConfiguration loadBuildConfig(String buildConfig, Map<String, String> buildVarOverrides) {
         InputStream configStream = PigConfiguration.class.getResourceAsStream(buildConfig);
         return PigConfiguration.load(configStream, buildVarOverrides);
     }
@@ -61,7 +64,8 @@ class ConfigReaderTest {
 
     @Test
     void shouldExpandAndOverrideVariables() {
-        PigConfiguration config = loadBuildConfig("/build-config-VarUsage.yaml", "productName=vertx, milestone=ER2");
+        Map<String, String> overrides = ImmutableMap.of("productName", "vertx", "milestone", "ER2");
+        PigConfiguration config = loadBuildConfig("/build-config-VarUsage.yaml", overrides);
         assertNotNull(config);
         if (!config.getVersion().equals("3.5.1")) {
             fail("Version does not match predefined variable");


### PR DESCRIPTION
This is done by passing the parameter:
```
bacon pig run .. \
    -eVariable1=Value1 \
    -e variable2=value2 \
    --env=variable3=value3
```

### Checklist:

* [ ] Have you added a note in the [CHANGELOG wiki](https://github.com/project-ncl/bacon/wiki/Changelog) for your change if user-facing?
* [ ] Have you added unit tests for your change?
