### PR TITLE
Add support for quarkus-bom.json devtools for parent build only in Quarkus Community dep analyser

### DIFF
--- a/pig/src/main/java/org/jboss/pnc/bacon/pig/impl/addons/quarkus/QuarkusCommunityDepAnalyzer.java
+++ b/pig/src/main/java/org/jboss/pnc/bacon/pig/impl/addons/quarkus/QuarkusCommunityDepAnalyzer.java
@@ -261,7 +261,8 @@ public class QuarkusCommunityDepAnalyzer extends AddOn {
     }
 
     private String devtoolsJarName() {
-        return "quarkus-product-bom-" + quarkusVersion + ".json";
+        return PigContext.get().getPigConfiguration().getFlow().getRepositoryGeneration().getBomArtifactId() + "-"
+                + quarkusVersion + ".json";
     }
 
     private Set<String> unpackArtifactIdsFrom(Path extensionsPath) {


### PR DESCRIPTION

cc @michalszynkiewicz 
this much change only should also work for `quarkus-bom`