### PR TITLE
Remove the 'password' field in the configuration doc

### DIFF
--- a/guide/configuration.md
+++ b/guide/configuration.md
@@ -33,7 +33,6 @@ keycloak:
 
     # if regular user
     clientId: ""
-    password: ""
 
     # if service account
     # clientSecret: ""


### PR DESCRIPTION
Thanks to @riprasad for pointing out this mistake in our docs.

### Checklist:

* [ ] Have you added a note in the [CHANGELOG wiki](https://github.com/project-ncl/bacon/wiki/Changelog) for your change if user-facing?
* [ ] Have you added unit tests for your change?
