### PR TITLE
[NCLSUP-174] Ignore pig-context and target folder

### DIFF
--- a/pig/src/main/java/org/jboss/pnc/bacon/pig/impl/PigContext.java
+++ b/pig/src/main/java/org/jboss/pnc/bacon/pig/impl/PigContext.java
@@ -193,7 +193,21 @@ public class PigContext {
     }
 
     private static PigContext readContext(boolean clean, Path configDir) {
-        String sha = hashDirectory(configDir);
+        String sha = hashDirectory(
+                configDir,
+                path -> {
+                    // normalize to remove any redundancies (unnecessary './' or '../' in the path)
+                    Path tempPath = path.normalize();
+                    // we ignore the top-level .bacon/pig-context.json and the content from the top-level target folder
+                    // if
+                    // present
+                    // They shouldn't be part of the hash generation since their content will change constantly but
+                    // shouldn't
+                    // contribute to the hash of the directory since their content doesn't affect the integrity of the
+                    // context
+                    return tempPath.startsWith(Paths.get(".bacon", "pig-context.json"))
+                            || tempPath.startsWith(Paths.get("target"));
+                });
 
         PigContext result;
         String ctxLocationEnv = System.getenv(PIG_CONTEXT_DIR);

--- a/pig/src/main/java/org/jboss/pnc/bacon/pig/impl/utils/HashUtils.java
+++ b/pig/src/main/java/org/jboss/pnc/bacon/pig/impl/utils/HashUtils.java
@@ -7,6 +7,7 @@ import java.io.IOException;
 import java.nio.file.Files;
 import java.nio.file.Path;
 import java.security.MessageDigest;
+import java.util.function.Predicate;
 import java.util.stream.Stream;
 
 public class HashUtils {
@@ -14,9 +15,22 @@ public class HashUtils {
     }
 
     public static String hashDirectory(Path directory) {
+        // don't ignore any file
+        return hashDirectory(directory, path -> false);
+    }
+
+    /**
+     * Hash the content of a directory and specify files to ignore in the hash
+     *
+     * @param directory path of the directory
+     * @param ignorePredicate predicate that get the list of files, and decides whether to ignore them or not. returns
+     *        true to ignore
+     * @return the hash of the directory content
+     */
+    public static String hashDirectory(Path directory, Predicate<Path> ignorePredicate) {
         MessageDigest sha = DigestUtils.getSha512Digest();
         try (Stream<Path> stream = Files.walk(directory)) {
-            stream.filter(Files::isRegularFile).sorted().forEach(path -> {
+            stream.filter(Files::isRegularFile).filter(ignorePredicate.negate()).sorted().forEach(path -> {
                 try {
                     DigestUtils.updateDigest(sha, directory.relativize(path).toString());
                     DigestUtils.updateDigest(sha, path.toFile());

--- a/pig/src/test/java/org/jboss/pnc/bacon/pig/impl/utils/HashUtilsTest.java
+++ b/pig/src/test/java/org/jboss/pnc/bacon/pig/impl/utils/HashUtilsTest.java
@@ -59,4 +59,13 @@ class HashUtilsTest {
         assertThat(originalHash).isNotEqualTo(exactCopyHash);
     }
 
+    @Test
+    void shouldIgnoreSomePaths() {
+
+        String originalHash = HashUtils.hashDirectory(testDirs.resolve("original"));
+        String copyIgnoreFileHash = HashUtils.hashDirectory(testDirs.resolve("copy-with-file-to-be-ignored"), path -> {
+            return path.normalize().endsWith("ignore-me");
+        });
+    }
+
 }

--- a/pig/src/test/resources/hash/copy-with-file-to-be-ignored/file1.txt
+++ b/pig/src/test/resources/hash/copy-with-file-to-be-ignored/file1.txt
@@ -1,0 +1,5 @@
+some file
+with    some content
+
+
+the original file for the HashUtilsTest

--- a/pig/src/test/resources/hash/copy-with-file-to-be-ignored/file2.txt
+++ b/pig/src/test/resources/hash/copy-with-file-to-be-ignored/file2.txt
@@ -1,0 +1,1 @@
+another file

--- a/pig/src/test/resources/hash/copy-with-file-to-be-ignored/ignore-me
+++ b/pig/src/test/resources/hash/copy-with-file-to-be-ignored/ignore-me
@@ -1,0 +1,1 @@
+This file should be skipped from the hash directory


### PR DESCRIPTION
When generating the hash of the directory config to determine whether
the pig-context.json should be invalidated or not, the hash should
ignore the files 'bacon/pig-context.json' and the contents inside the
'target' folder.

This is to handle a special case where the user may run the `bacon pig`
command using path '.', in which case the 2 files mentioned above will
be created inside the directory config.

Since those 2 files change content all the time, it causes the hash of
the directory to be always different between `bacon pig` runs and
wrongly invalidates the existing pig-context.json because it wrongly
assumes that the *real* content of the directory config has changed.

### Checklist:

* [ ] Have you added a note in the [CHANGELOG wiki](https://github.com/project-ncl/bacon/wiki/Changelog) for your change if user-facing?
* [x] Have you added unit tests for your change?
