### PR TITLE
[NCL-6080] Cleanup with picocli 4.6 changes

### DIFF
--- a/cli/pom.xml
+++ b/cli/pom.xml
@@ -51,6 +51,14 @@
             <artifactId>jline-console</artifactId>
         </dependency>
         <dependency>
+            <groupId>ch.qos.logback</groupId>
+            <artifactId>logback-classic</artifactId>
+        </dependency>
+        <dependency>
+            <groupId>org.fusesource.jansi</groupId>
+            <artifactId>jansi</artifactId>
+        </dependency>
+        <dependency>
             <groupId>org.assertj</groupId>
             <artifactId>assertj-core</artifactId>
             <scope>test</scope>

--- a/cli/src/main/java/org/jboss/pnc/bacon/cli/App.java
+++ b/cli/src/main/java/org/jboss/pnc/bacon/cli/App.java
@@ -62,7 +62,12 @@ import static picocli.CommandLine.ScopeType.INHERIT;
  */
 
 @Slf4j
-@Command(name = "bacon", versionProvider = VersionProvider.class, subcommands = { Da.class, Pig.class, Pnc.class })
+@Command(
+        name = "bacon",
+        scope = INHERIT,
+        mixinStandardHelpOptions = true,
+        versionProvider = VersionProvider.class,
+        subcommands = { Da.class, Pig.class, Pnc.class })
 public class App {
 
     private String profile = "default";
@@ -107,14 +112,6 @@ public class App {
     public void setConfigurationFileLocation(String configPath) {
         this.configPath = configPath;
     }
-
-    // Both help/version commands could use standard mixin but in order to propagate the help via inheritance it is
-    // explicitly defined here. These could be removed once https://github.com/remkop/picocli/issues/1164 is complete.
-    @Option(names = { "-h", "--help" }, usageHelp = true, description = "display this help message", scope = INHERIT)
-    boolean usageHelpRequested;
-
-    @Option(names = { "-V", "--version" }, versionHelp = true, description = "display version info")
-    boolean versionInfoRequested;
 
     public int run(String[] args) {
 
@@ -203,9 +200,6 @@ public class App {
     }
 
     private int executionStrategy(CommandLine commandLine, CommandLine.ParseResult parseResult) {
-        if (!versionInfoRequested) { // Don't print version information if we are outputting version explicitly
-            commandLine.printVersionHelp(System.err);
-        }
         init(); // custom initialization to be done before executing any command or subcommand
         return new CommandLine.RunLast().execute(parseResult); // default execution strategy
     }

--- a/cli/src/main/java/org/jboss/pnc/bacon/cli/App.java
+++ b/cli/src/main/java/org/jboss/pnc/bacon/cli/App.java
@@ -28,47 +28,31 @@ import org.jboss.pnc.bacon.common.exception.FatalException;
 import org.jboss.pnc.bacon.config.Config;
 import org.jboss.pnc.bacon.pig.Pig;
 import org.jboss.pnc.bacon.pnc.Pnc;
-import org.jline.builtins.Options;
-import org.jline.console.ArgDesc;
-import org.jline.console.CmdDesc;
-import org.jline.console.CommandRegistry;
 import org.jline.console.SystemRegistry;
 import org.jline.console.impl.Builtins;
 import org.jline.console.impl.SystemRegistryImpl;
 import org.jline.keymap.KeyMap;
 import org.jline.reader.Binding;
-import org.jline.reader.Candidate;
-import org.jline.reader.Completer;
 import org.jline.reader.EndOfFileException;
 import org.jline.reader.LineReader;
 import org.jline.reader.LineReaderBuilder;
 import org.jline.reader.MaskingCallback;
-import org.jline.reader.ParsedLine;
 import org.jline.reader.Parser;
 import org.jline.reader.Reference;
 import org.jline.reader.UserInterruptException;
 import org.jline.reader.impl.DefaultParser;
-import org.jline.reader.impl.completer.SystemCompleter;
 import org.jline.terminal.Terminal;
 import org.jline.terminal.TerminalBuilder;
-import org.jline.utils.AttributedString;
 import org.jline.widget.TailTipWidgets;
 import picocli.CommandLine;
 import picocli.CommandLine.Command;
 import picocli.CommandLine.IExecutionExceptionHandler;
 import picocli.CommandLine.Option;
+import picocli.shell.jline3.PicocliCommands;
 
 import java.io.IOException;
 import java.nio.file.Path;
 import java.nio.file.Paths;
-import java.util.ArrayList;
-import java.util.Arrays;
-import java.util.HashMap;
-import java.util.List;
-import java.util.Map;
-import java.util.Set;
-import java.util.function.Supplier;
-import java.util.stream.Collectors;
 
 import static picocli.CommandLine.ScopeType.INHERIT;
 
@@ -148,7 +132,7 @@ public class App {
             builtins.alias("zle", "widget");
             builtins.alias("bindkey", "keymap");
 
-            PicocliCommands picocliCommands = new PicocliCommands(App::workDir, commandLine);
+            PicocliCommands picocliCommands = new PicocliCommands(commandLine);
             init();
 
             Parser parser = new DefaultParser();
@@ -249,219 +233,6 @@ public class App {
 
             return cmd.getExitCodeExceptionMapper() != null ? cmd.getExitCodeExceptionMapper().getExitCode(ex)
                     : cmd.getCommandSpec().exitCodeOnExecutionException();
-        }
-    }
-
-    // Explicit inline override of picocli jline3 until picocli 4.6 is released fixing
-    // https://github.com/remkop/picocli/issues/1175
-
-    /**
-     * Compiles SystemCompleter for command completion and implements a method commandDescription() that provides
-     * command descriptions for JLine TailTipWidgets to be displayed in terminal status bar. SystemCompleter implements
-     * the JLine 3 {@link Completer} interface. SystemCompleter generates completion candidates for the specified
-     * command line based on the {@link CommandLine.Model.CommandSpec} that this {@code PicocliCommands} was constructed
-     * with.
-     *
-     * @since 4.1.2
-     */
-    static class PicocliCommands implements CommandRegistry {
-        private final Supplier<Path> workDir;
-        private final CommandLine cmd;
-        private final Set<String> commands;
-        private final Map<String, String> aliasCommand = new HashMap<>();
-
-        public PicocliCommands(Path workDir, CommandLine cmd) {
-            this(() -> workDir, cmd);
-        }
-
-        public PicocliCommands(Supplier<Path> workDir, CommandLine cmd) {
-            this.workDir = workDir;
-            this.cmd = cmd;
-            commands = cmd.getCommandSpec().subcommands().keySet();
-            for (String c : commands) {
-                for (String a : cmd.getSubcommands().get(c).getCommandSpec().aliases()) {
-                    aliasCommand.put(a, c);
-                }
-            }
-        }
-
-        /**
-         *
-         * @param command
-         * @return true if PicocliCommands contains command
-         */
-        @Override
-        public boolean hasCommand(String command) {
-            return commands.contains(command) || aliasCommand.containsKey(command);
-        }
-
-        @Override
-        public SystemCompleter compileCompleters() {
-            SystemCompleter out = new SystemCompleter();
-            List<String> all = new ArrayList<>();
-            all.addAll(commands);
-            all.addAll(aliasCommand.keySet());
-            out.add(all, new PicocliCompleter());
-            return out;
-        }
-
-        private class PicocliCompleter implements Completer {
-
-            public PicocliCompleter() {
-            }
-
-            @Override
-            public void complete(LineReader reader, ParsedLine commandLine, List<Candidate> candidates) {
-                assert commandLine != null;
-                assert candidates != null;
-                String word = commandLine.word();
-                List<String> words = commandLine.words();
-                CommandLine sub = findSubcommandLine(words, commandLine.wordIndex());
-                if (sub == null) {
-                    return;
-                }
-                if (word.startsWith("-")) {
-                    String buffer = word.substring(0, commandLine.wordCursor());
-                    int eq = buffer.indexOf('=');
-                    for (CommandLine.Model.OptionSpec option : sub.getCommandSpec().options()) {
-                        if (option.arity().max() == 0 && eq < 0) {
-                            addCandidates(candidates, Arrays.asList(option.names()));
-                        } else {
-                            if (eq > 0) {
-                                String opt = buffer.substring(0, eq);
-                                if (Arrays.asList(option.names()).contains(opt)
-                                        && option.completionCandidates() != null) {
-                                    addCandidates(
-                                            candidates,
-                                            option.completionCandidates(),
-                                            buffer.substring(0, eq + 1),
-                                            "",
-                                            true);
-                                }
-                            } else {
-                                addCandidates(candidates, Arrays.asList(option.names()), "", "=", false);
-                            }
-                        }
-                    }
-                } else {
-                    addCandidates(candidates, sub.getSubcommands().keySet());
-                    for (CommandLine s : sub.getSubcommands().values()) {
-                        addCandidates(candidates, Arrays.asList(s.getCommandSpec().aliases()));
-                    }
-                }
-            }
-
-            private void addCandidates(List<Candidate> candidates, Iterable<String> cands) {
-                addCandidates(candidates, cands, "", "", true);
-            }
-
-            private void addCandidates(
-                    List<Candidate> candidates,
-                    Iterable<String> cands,
-                    String preFix,
-                    String postFix,
-                    boolean complete) {
-                for (String s : cands) {
-                    candidates.add(
-                            new Candidate(
-                                    AttributedString.stripAnsi(preFix + s + postFix),
-                                    s,
-                                    null,
-                                    null,
-                                    null,
-                                    null,
-                                    complete));
-                }
-            }
-
-        }
-
-        private CommandLine findSubcommandLine(List<String> args, int lastIdx) {
-            CommandLine out = cmd;
-            for (int i = 0; i < lastIdx; i++) {
-                if (!args.get(i).startsWith("-")) {
-                    out = findSubcommandLine(out, args.get(i));
-                    if (out == null) {
-                        break;
-                    }
-                }
-            }
-            return out;
-        }
-
-        private static CommandLine findSubcommandLine(CommandLine cmdline, String command) {
-            for (CommandLine s : cmdline.getSubcommands().values()) {
-                if (s.getCommandName().equals(command)
-                        || Arrays.asList(s.getCommandSpec().aliases()).contains(command)) {
-                    return s;
-                }
-            }
-            return null;
-        }
-
-        /**
-         *
-         * @param args
-         * @return command description for JLine TailTipWidgets to be displayed in terminal status bar.
-         */
-        @Override
-        public CmdDesc commandDescription(List<String> args) {
-            CommandLine sub = findSubcommandLine(args, args.size());
-            if (sub == null) {
-                return null;
-            }
-            CommandLine.Model.CommandSpec spec = sub.getCommandSpec();
-            CommandLine.Help cmdhelp = new picocli.CommandLine.Help(spec);
-            List<AttributedString> main = new ArrayList<>();
-            Map<String, List<AttributedString>> options = new HashMap<>();
-            String synopsis = AttributedString
-                    .stripAnsi(spec.usageMessage().sectionMap().get("synopsis").render(cmdhelp).toString());
-            main.add(Options.HelpException.highlightSyntax(synopsis.trim(), Options.HelpException.defaultStyle()));
-            // using JLine help highlight because the statement below does not work well...
-            // main.add(new
-            // AttributedString(spec.usageMessage().sectionMap().get("synopsis").render(cmdhelp).toString()));
-            for (CommandLine.Model.OptionSpec o : spec.options()) {
-                String key = Arrays.stream(o.names()).collect(Collectors.joining(" "));
-                List<AttributedString> val = new ArrayList<>();
-                for (String d : o.description()) {
-                    val.add(new AttributedString(d));
-                }
-                if (o.arity().max() > 0) {
-                    key += "=" + o.paramLabel();
-                }
-                options.put(key, val);
-            }
-            return new CmdDesc(main, ArgDesc.doArgNames(Arrays.asList("")), options);
-        }
-
-        @Override
-        public List<String> commandInfo(String command) {
-            List<String> out = new ArrayList<>();
-            CommandLine.Model.CommandSpec spec = cmd.getSubcommands().get(command).getCommandSpec();
-            CommandLine.Help cmdhelp = new picocli.CommandLine.Help(spec);
-            String description = AttributedString
-                    .stripAnsi(spec.usageMessage().sectionMap().get("description").render(cmdhelp));
-            out.addAll(Arrays.asList(description.split(System.lineSeparator())));
-            return out;
-        }
-
-        @Override
-        public Object invoke(CommandRegistry.CommandSession session, String command, Object[] args) throws Exception {
-            List<String> arguments = new ArrayList<>();
-            arguments.add(command);
-            arguments.addAll(Arrays.stream(args).map(Object::toString).collect(Collectors.toList()));
-            cmd.execute(arguments.toArray(new String[0]));
-            return null;
-        }
-
-        @Override
-        public Set<String> commandNames() {
-            return commands;
-        }
-
-        @Override
-        public Map<String, String> commandAliases() {
-            return aliasCommand;
         }
     }
 }

--- a/cli/src/test/java/org/jboss/pnc/bacon/cli/AppTest.java
+++ b/cli/src/test/java/org/jboss/pnc/bacon/cli/AppTest.java
@@ -193,16 +193,17 @@ class AppTest {
                                             "-h" })));
 
             String expected = String.format(
-                    "Usage: bacon pnc admin maintenance-mode activate [-hov]%n"
+                    "Usage: bacon pnc admin maintenance-mode activate [-hovV]%n"
                             + "       [-p=<configurationFileLocation>] [--profile=<profile>] <reason>%n"
                             + "This will disable any new builds from being accepted%n"
                             + "      <reason>              Reason%n"
-                            + "  -h, --help                display this help message%n"
+                            + "  -h, --help                Show this help message and exit.%n"
                             + "  -o, --jsonOutput          use json for output (default to yaml)%n"
                             + "  -p, --configPath=<configurationFileLocation>%n"
                             + "                            Path to PNC configuration folder%n"
                             + "      --profile=<profile>   PNC Configuration profile%n"
-                            + "  -v, --verbose             Verbose output%n" + "%n" + "Example:%n"
+                            + "  -v, --verbose             Verbose output%n"
+                            + "  -V, --version             Print version information and exit.%n" + "%n" + "Example:%n"
                             + "$ bacon pnc admin maintenance-mode activate \"Switching to maintenance mode for%n"
                             + "upcoming migration\"%n");
             assertThat(text).contains(expected);

--- a/pig/pom.xml
+++ b/pig/pom.xml
@@ -109,10 +109,10 @@
             <groupId>org.apache.httpcomponents</groupId>
             <artifactId>httpclient</artifactId>
         </dependency>
-        <!-- This is an uber-jar that brings in logback-classic as well -->
         <dependency>
             <groupId>org.commonjava.maven.ext</groupId>
             <artifactId>pom-manipulation-cli</artifactId>
+            <classifier>minimal</classifier>
         </dependency>
         <dependency>
             <groupId>org.projectlombok</groupId>

--- a/pom.xml
+++ b/pom.xml
@@ -200,6 +200,12 @@
             </dependency>
 
             <dependency>
+                <groupId>org.fusesource.jansi</groupId>
+                <artifactId>jansi</artifactId>
+                <version>2.1.1</version>
+            </dependency>
+
+            <dependency>
                 <groupId>org.slf4j</groupId>
                 <artifactId>slf4j-api</artifactId>
                 <version>1.7.30</version>
@@ -321,6 +327,7 @@
                 <groupId>org.commonjava.maven.ext</groupId>
                 <artifactId>pom-manipulation-cli</artifactId>
                 <version>${pme.version}</version>
+                <classifier>minimal</classifier>
                 <exclusions>
                     <exclusion>
                         <groupId>ch.qos.logback</groupId>


### PR DESCRIPTION
Special thanks to @matejonnet for figuring out how to resolve the issue with PME's uber jar having an older version of picocli overriding what we set in our pom.xml (use the minimal jar)

Special thanks to @rnc for submitting the changes/fixes to upstream picocli, and providing instructions on how to clean up the code once the fixes are in a picocli release.

### Checklist:

* [ ] Have you added a note in the [CHANGELOG wiki](https://github.com/project-ncl/bacon/wiki/Changelog) for your change if user-facing?
* [ ] Have you added unit tests for your change?
