### PR TITLE
Change devtoolsJarName in QuarkusCommunityDepAnalyser

### DIFF
--- a/pig/src/main/java/org/jboss/pnc/bacon/pig/impl/addons/quarkus/QuarkusCommunityDepAnalyzer.java
+++ b/pig/src/main/java/org/jboss/pnc/bacon/pig/impl/addons/quarkus/QuarkusCommunityDepAnalyzer.java
@@ -270,10 +270,11 @@ public class QuarkusCommunityDepAnalyzer extends AddOn {
 
     private String devtoolsJarName() {
         String bomArtifactId = getBomArtifactId();
+        String jsonSuffix = "quarkus-platform-descriptor-" + quarkusVersion + "-" + quarkusVersion + ".json";
         if (!isProductBom(bomArtifactId)) {
-            return "quarkus-bom-descriptor-json-" + quarkusVersion + ".json";
+            return "quarkus-bom-" + jsonSuffix;
         } else {
-            return bomArtifactId + "-" + quarkusVersion + ".json";
+            return bomArtifactId + "-" + jsonSuffix;
         }
     }
 


### PR DESCRIPTION
cc @michalszynkiewicz  @paulgallagher75 

Generated devtoolsJarName is changed due to changes in upstream 
https://github.com/quarkusio/quarkus/blob/8e3fdd379c41f280049ec83e9f273e22643df534/bom/application/pom.xml#L218

Due to which I have make changes in QuarkusCommunityDepAnalyser
