### PR TITLE
Stop source artifact downloads from retrying

### DIFF
--- a/pig/src/main/java/org/jboss/pnc/bacon/pig/impl/repo/ExternalArtifactDownloader.java
+++ b/pig/src/main/java/org/jboss/pnc/bacon/pig/impl/repo/ExternalArtifactDownloader.java
@@ -50,14 +50,23 @@ public class ExternalArtifactDownloader {
         String indyUrl = gav.isTemporary() ? Indy.getIndyTempUrl() : Indy.getIndyUrl();
 
         URI downloadUrl = URI.create(String.format("%s/%s", indyUrl, gav.toUri()));
-        try {
-            FileDownloadUtils.downloadTo(downloadUrl, targetPath);
-        } catch (RuntimeException any) {
-            if (sourcesOptional && "sources".equals(gav.getClassifier()) || "javadoc".equals(gav.getClassifier())) {
-                log.warn("Unable to download sources for {}", gav, any);
-            } else {
+        if ("sources".equals(gav.getClassifier()) || "javadoc".equals(gav.getClassifier())) {
+            try {
+                FileDownloadUtils.downloadTo(downloadUrl, targetPath, 1);
+            } catch (RuntimeException any) {
+                if (sourcesOptional && "sources".equals(gav.getClassifier()) || "javadoc".equals(gav.getClassifier())) {
+                    log.warn("Unable to download sources for {}", gav, any);
+                } else {
+                    throw any;
+                }
+            }
+        } else {
+            try {
+                FileDownloadUtils.downloadTo(downloadUrl, targetPath);
+            } catch (RuntimeException any) {
                 throw any;
             }
+
         }
 
         return targetPath;

--- a/pig/src/main/java/org/jboss/pnc/bacon/pig/impl/utils/FileDownloadUtils.java
+++ b/pig/src/main/java/org/jboss/pnc/bacon/pig/impl/utils/FileDownloadUtils.java
@@ -60,6 +60,12 @@ public class FileDownloadUtils {
         log.info("Downloaded {} to {}", downloadUrl, targetPath);
     }
 
+    public static void downloadTo(URI downloadUrl, File targetPath, int attempts) {
+        log.info("Downloading {} to {}", downloadUrl, targetPath);
+        doDownload(downloadUrl, targetPath, attempts);
+        log.info("Downloaded {} to {}", downloadUrl, targetPath);
+    }
+
     private static void doDownload(URI downloadUrl, File targetPath, int attemptsLeft) {
         try (CloseableHttpClient httpClient = HttpClients.custom().setDefaultRequestConfig(requestConfig).build()) {
             downloadWithClient(httpClient, downloadUrl, targetPath);


### PR DESCRIPTION
Only try once to download source artifacts as they can be missing (and from our repo there are a lot of missing source artifacts) which can cause the repo build time to be considerably larger. 

### Checklist:

* [ ] Have you added a note in the [CHANGELOG wiki](https://github.com/project-ncl/bacon/wiki/Changelog) for your change if user-facing?
* [ ] Have you added unit tests for your change?
