### PR TITLE
Add excludedSourceBuilds to BUILD_GROUP strategy

### DIFF
--- a/pig/src/main/java/org/jboss/pnc/bacon/pig/impl/config/RepoGenerationData.java
+++ b/pig/src/main/java/org/jboss/pnc/bacon/pig/impl/config/RepoGenerationData.java
@@ -39,6 +39,7 @@ public class RepoGenerationData extends GenerationData<RepoGenerationStrategy> {
     private List<String> externalAdditionalArtifacts = new ArrayList<>();
     private List<String> excludeArtifacts = new ArrayList<>();
     private List<String> sourceBuilds = new ArrayList<>();
+    private List<String> excludeSourceBuilds = new ArrayList<>();
     private String bomGroupId;
     private String bomArtifactId;
     private boolean includeJavadoc;

--- a/pig/src/main/java/org/jboss/pnc/bacon/pig/impl/repo/RepoManager.java
+++ b/pig/src/main/java/org/jboss/pnc/bacon/pig/impl/repo/RepoManager.java
@@ -170,9 +170,10 @@ public class RepoManager extends DeliverableManager<RepoGenerationData, Reposito
             throw new RuntimeException("There are no builds captured for the build group. Aborting!");
         }
         List<ArtifactWrapper> artifactsToPack = new ArrayList<>();
-        for (PncBuild build : builds.values()) {
-            getRedhatArtifacts(artifactsToPack, build);
-        }
+        builds.values()
+                .stream()
+                .filter(b -> !generationData.getExcludeSourceBuilds().contains(b.getName()))
+                .forEach(b -> getRedhatArtifacts(artifactsToPack, b));
         File sourceDir = createMavenGenerationDir();
         filterAndDownload(artifactsToPack, sourceDir);
         return repackage(sourceDir);


### PR DESCRIPTION
Add excludedSourceBuilds list field to ignore specified projects in the BUILD_GROUP repository generation strategy

Signed-off-by: Alberto Morales Pérez <almorale@redhat.com>

Documented in: https://github.com/project-ncl/bacon/pull/618

### Checklist:

* [ ] Have you added a note in the [CHANGELOG wiki](https://github.com/project-ncl/bacon/wiki/Changelog) for your change if user-facing?
* [ ] Have you added unit tests for your change?
