### PR TITLE
Removing artifacts which contained invalid license name

### DIFF
--- a/pig/src/main/resources/rh-license-exceptions.json
+++ b/pig/src/main/resources/rh-license-exceptions.json
@@ -978,35 +978,5 @@
         "url": "http://repository.jboss.org/licenses/gpl-2.0-ce.txt"
       }
     ]
-  },
-  {
-    "groupId": "com.github.java-json-tools",
-    "artifactId": "jackson-coreutils",
-    "version-regexp": "2\\.0\\.0\\..+",
-    "licenses": [
-      {
-        "name": "Lesser General Public License v3.0 or later",
-        "url": "https://www.gnu.org/licenses/lgpl-3.0.txt"
-      },
-      {
-        "name": "Apache License 2.0",
-        "url": "http://www.apache.org/licenses/LICENSE-2.0.txt"
-      }
-    ]
-  },
-  {
-    "groupId": "com.github.java-json-tools",
-    "artifactId": "json-patch",
-    "version-regexp": "1\\.13\\.0\\..+",
-    "licenses": [
-      {
-        "name": "Lesser General Public License v3.0 or later",
-        "url": "https://www.gnu.org/licenses/lgpl-3.0.txt"
-      },
-      {
-        "name": "Apache License 2.0",
-        "url": "http://www.apache.org/licenses/LICENSE-2.0.txt"
-      }
-    ]
-   }
+  }
 ]


### PR DESCRIPTION
Removing licenses which contained invalid name "Lesser General Public License v3.0 or later". As the same artifacts are present under correct license names in the json file, I removed the license instead of just updating the license name 

### Checklist:

* [ ] Have you added a note in the [CHANGELOG wiki](https://github.com/project-ncl/bacon/wiki/Changelog) for your change if user-facing?
* [ ] Have you added unit tests for your change?
