### PR TITLE
[NCLSUP-298] use temporary hosted repo instead of a group

### DIFF
--- a/pig/src/main/java/org/jboss/pnc/bacon/pig/impl/utils/indy/Indy.java
+++ b/pig/src/main/java/org/jboss/pnc/bacon/pig/impl/utils/indy/Indy.java
@@ -20,7 +20,7 @@ public class Indy {
 
     public static String getIndyTempUrl() {
         if (indyTempRepoUrl == null) {
-            indyTempRepoUrl = pigUrl() + "api/content/maven/group/temporary-builds";
+            indyTempRepoUrl = pigUrl() + "api/content/maven/hosted/temporary-builds";
         }
 
         return indyTempRepoUrl;


### PR DESCRIPTION
The temporary builds group consists of only the hosted repo so it doesn't make sense not to use the hosted repo directly.

### Checklist:

* [ ] Have you added a note in the [CHANGELOG wiki](https://github.com/project-ncl/bacon/wiki/Changelog) for your change if user-facing?
* [ ] Have you added unit tests for your change?
