### PR TITLE
[NCL-6464] Deprecate Timestamped teporary builds option in Bacon

### DIFF
--- a/pig/src/main/java/org/jboss/pnc/bacon/pig/Pig.java
+++ b/pig/src/main/java/org/jboss/pnc/bacon/pig/Pig.java
@@ -81,7 +81,7 @@ public class Pig {
     public static final String REBUILD_MODE = "--mode";
     public static final String TEMP_BUILD_TIME_STAMP = "--tempBuildTimeStamp";
     public static final String TEMP_BUILD_TIME_STAMP_DEFAULT = "false";
-    public static final String TEMP_BUILD_TIME_STAMP_DESC = "If specified, artifacts from temporary builds will have timestamp in versions";
+    public static final String TEMP_BUILD_TIME_STAMP_DESC = "NOT SUPPORTED - If specified, artifacts from temporary builds will have timestamp in versions";
 
     public static final String REMOVE_M2_DUPLICATES_DESC = "If enabled, only the newest versions of each of the dependencies (groupId:artifactId) "
             + "are kept in the generated repository zip";

--- a/pig/src/main/java/org/jboss/pnc/bacon/pig/impl/pnc/PncBuilder.java
+++ b/pig/src/main/java/org/jboss/pnc/bacon/pig/impl/pnc/PncBuilder.java
@@ -82,10 +82,12 @@ public class PncBuilder implements Closeable {
             boolean tempBuildTS,
             RebuildMode rebuildMode) {
         log.info("Performing builds of build group {} in PNC", group.getId());
+        if (tempBuildTS)
+            log.warn(
+                    "Temporary builds with timestamp alignment are not supported, running temporary builds instead...");
         GroupBuildParameters buildParams = new GroupBuildParameters();
         buildParams.setRebuildMode(rebuildMode);
         buildParams.setTemporaryBuild(tempBuild);
-        buildParams.setTimestampAlignment(tempBuildTS);
         GroupBuildRequest request = GroupBuildRequest.builder().build();
 
         try {

--- a/pnc/src/main/java/org/jboss/pnc/bacon/pnc/BuildCli.java
+++ b/pnc/src/main/java/org/jboss/pnc/bacon/pnc/BuildCli.java
@@ -93,7 +93,9 @@ public class BuildCli {
         private String rebuildMode;
         @Option(names = "--keep-pod-on-failure", description = "Keep the builder pod online after the build fails.")
         private boolean keepPodOnFailure = false;
-        @Option(names = "--timestamp-alignment", description = "Do timestamp alignment with temprary build.")
+        @Option(
+                names = "--timestamp-alignment",
+                description = "NOT SUPPORTED - Do timestamp alignment with temporary build.")
         private boolean timestampAlignment = false;
         @Option(names = "--temporary-build", description = "Perform a temporary build.")
         private boolean temporaryBuild = false;
@@ -122,7 +124,6 @@ public class BuildCli {
             ParameterChecker.checkRebuildModeOption(rebuildMode);
             buildParams.setRebuildMode(RebuildMode.valueOf(rebuildMode));
             buildParams.setKeepPodOnFailure(keepPodOnFailure);
-            buildParams.setTimestampAlignment(timestampAlignment);
             buildParams.setTemporaryBuild(temporaryBuild);
             buildParams.setBuildDependencies(!noBuildDependencies);
 

--- a/pnc/src/main/java/org/jboss/pnc/bacon/pnc/GroupBuildCli.java
+++ b/pnc/src/main/java/org/jboss/pnc/bacon/pnc/GroupBuildCli.java
@@ -73,7 +73,9 @@ public class GroupBuildCli {
                 names = "--rebuild-mode",
                 description = "Default: IMPLICIT_DEPENDENCY_CHECK. Other options are: EXPLICIT_DEPENDENCY_CHECK, FORCE")
         private String rebuildMode;
-        @Option(names = "--timestamp-alignment", description = "Do timestamp alignment with temporary builds")
+        @Option(
+                names = "--timestamp-alignment",
+                description = "NOT SUPPORTED - Do timestamp alignment with temporary builds")
         private boolean timestampAlignment = false;
         @Option(names = "--temporary-build", description = "Perform temporary builds")
         private boolean temporaryBuild = false;
@@ -97,7 +99,6 @@ public class GroupBuildCli {
             ParameterChecker.checkRebuildModeOption(rebuildMode);
 
             groupBuildParams.setRebuildMode(RebuildMode.valueOf(rebuildMode));
-            groupBuildParams.setTimestampAlignment(timestampAlignment);
             groupBuildParams.setTemporaryBuild(temporaryBuild);
 
             // TODO add GroupBuildRequest with an option to specify BC revisions


### PR DESCRIPTION
### Checklist:

* [ ] Have you added a note in the [CHANGELOG wiki](https://github.com/project-ncl/bacon/wiki/Changelog) for your change if user-facing?
* [ ] Have you added unit tests for your change?
