### PR TITLE
Adding details of vertx addon in the doc

### DIFF
--- a/guide/pig.md
+++ b/guide/pig.md
@@ -105,3 +105,17 @@ addons:
     offlineManifestFileName: offliner.txt
 
 ```
+
+### Vertx Artifact Finder
+
+This Add-on automates the process of creating vertx artifacts list which are used in Quarkus. 
+
+Now, in order to create a list of vertx artifacts, you don't need to manually search for it in the project, this addon will do the work for you.
+
+Adding the following to the bottom of your `build-config.yaml` will generate `vertxList.txt` inside the target directory.
+
+```
+addons:
+   vertxArtifactFinder:
+
+```


### PR DESCRIPTION
Hi @thescouser89 @rnc,

Here is the PR updating the doc with the newly added add-on  `Vertx Artifact Finder` #648  :)

I previewed the changes using ` Jekyll ` and it is looking like this - 

![image](https://user-images.githubusercontent.com/46818757/114163881-4b99d580-9948-11eb-90b1-0a6018622872.png)


