### PR TITLE
[NCLSUP-306] Disable CLI output with --no-color flag

### DIFF
--- a/cli/src/main/java/org/jboss/pnc/bacon/cli/App.java
+++ b/cli/src/main/java/org/jboss/pnc/bacon/cli/App.java
@@ -113,7 +113,31 @@ public class App {
         this.configPath = configPath;
     }
 
+    /**
+     * Disable color in Picocli output
+     *
+     * @param noColorPresent if no-color mode is activated
+     */
+    @Option(
+            names = { "--no-color" },
+            description = "Disable color output. Useful when running in a non-ANSI environment",
+            scope = INHERIT)
+    public void setNoColorIfPresent(boolean noColorPresent) {
+        if (noColorPresent) {
+            // Documentation: https://picocli.info/#_forcing_ansi_onoff
+            System.setProperty("picocli.ansi", "false");
+        }
+    }
+
     public int run(String[] args) {
+
+        /*
+         * https://no-color.org/ If NO_COLOR env variable is present, regardless of its value, prevents the addition of
+         * ANSI color
+         */
+        if (System.getenv().containsKey("NO_COLOR")) {
+            setNoColorIfPresent(true);
+        }
 
         CommandLine commandLine = new CommandLine(this);
         commandLine.setExecutionExceptionHandler(new ExceptionMessageHandler());

--- a/cli/src/main/java/org/jboss/pnc/bacon/cli/App.java
+++ b/cli/src/main/java/org/jboss/pnc/bacon/cli/App.java
@@ -131,14 +131,6 @@ public class App {
 
     public int run(String[] args) {
 
-        /*
-         * https://no-color.org/ If NO_COLOR env variable is present, regardless of its value, prevents the addition of
-         * ANSI color
-         */
-        if (System.getenv().containsKey("NO_COLOR")) {
-            setNoColorIfPresent(true);
-        }
-
         CommandLine commandLine = new CommandLine(this);
         commandLine.setExecutionExceptionHandler(new ExceptionMessageHandler());
         commandLine.setUsageHelpAutoWidth(true);

--- a/cli/src/main/resources/logback-test.xml
+++ b/cli/src/main/resources/logback-test.xml
@@ -35,7 +35,7 @@
     <appender name="STDERR" class="ch.qos.logback.core.ConsoleAppender">
         <target>System.err</target>
         <encoder>
-            <pattern>[%highlight(%-5level)] - %msg%n</pattern>
+            <pattern>[%-5level] - %msg%n</pattern>
         </encoder>
     </appender>
 

--- a/cli/src/test/java/org/jboss/pnc/bacon/cli/AppTest.java
+++ b/cli/src/test/java/org/jboss/pnc/bacon/cli/AppTest.java
@@ -24,7 +24,9 @@ class AppTest {
             System.setProperty("picocli.ansi", "false");
             app.run(new String[] { "-h" });
             String text = tapSystemOut(() -> assertEquals(0, app.run(new String[] { "-h" })));
-            assertThat(text).contains("Usage: bacon [-hovV] [-p=<configurationFileLocation>] [--profile=<profile>]");
+            assertThat(text).contains(
+                    "Usage: bacon [-hovV] [--no-color] [-p=<configurationFileLocation>]",
+                    "[--profile=<profile>]");
         });
     }
 
@@ -193,11 +195,13 @@ class AppTest {
                                             "-h" })));
 
             String expected = String.format(
-                    "Usage: bacon pnc admin maintenance-mode activate [-hovV]%n"
+                    "Usage: bacon pnc admin maintenance-mode activate [-hovV] [--no-color]%n"
                             + "       [-p=<configurationFileLocation>] [--profile=<profile>] <reason>%n"
                             + "This will disable any new builds from being accepted%n"
                             + "      <reason>              Reason%n"
                             + "  -h, --help                Show this help message and exit.%n"
+                            + "      --no-color            Disable color output. Useful when running in a%n"
+                            + "                              non-ANSI environment%n"
                             + "  -o, --jsonOutput          use json for output (default to yaml)%n"
                             + "  -p, --configPath=<configurationFileLocation>%n"
                             + "                            Path to PNC configuration folder%n"


### PR DESCRIPTION
When running bacon in specific environment where the logs are piped into
files, the ANSI color commands show up in those logs and make them hard
to read.

This commit adds the --no-color flag to disable color/ANSI output in
picocli output. The user can also disable coloring by setting the
'NO_COLOR' environment variable with any value (https://no-color.org/).

We also remove the '%highlight' in the logback file to disable coloring
of the message level printed in stderr for logging.

![ansi](https://user-images.githubusercontent.com/630746/116603345-d55f1200-a8fa-11eb-85c3-b2e5376a3d5f.png)
![ansi-log](https://user-images.githubusercontent.com/630746/116603357-d728d580-a8fa-11eb-9bea-76a497fb4b61.png)


### Checklist:

* [x] Have you added a note in the [CHANGELOG wiki](https://github.com/project-ncl/bacon/wiki/Changelog) for your change if user-facing?
* [ ] Have you added unit tests for your change?
