### PR TITLE
[NCL-6058] Add quiet option (-q)

### DIFF
--- a/cli/src/main/java/org/jboss/pnc/bacon/cli/App.java
+++ b/cli/src/main/java/org/jboss/pnc/bacon/cli/App.java
@@ -100,6 +100,17 @@ public class App {
         }
     }
 
+    /**
+     * Make logback quiet if quiet flag is set
+     */
+    @Option(names = { "-q", "--quiet" }, description = "Silent output", scope = INHERIT)
+    public static void setQuietIfPresent(boolean quiet) {
+
+        if (quiet) {
+            ObjectHelper.setRootLoggingLevel(ObjectHelper.LOG_LEVEL_SILENT);
+        }
+    }
+
     @Option(names = "--profile", description = "PNC Configuration profile", scope = INHERIT)
     public void setProfile(String profile) {
         this.profile = profile;

--- a/cli/src/test/java/org/jboss/pnc/bacon/cli/AppTest.java
+++ b/cli/src/test/java/org/jboss/pnc/bacon/cli/AppTest.java
@@ -25,7 +25,7 @@ class AppTest {
             app.run(new String[] { "-h" });
             String text = tapSystemOut(() -> assertEquals(0, app.run(new String[] { "-h" })));
             assertThat(text).contains(
-                    "Usage: bacon [-hovV] [--no-color] [-p=<configurationFileLocation>]",
+                    "Usage: bacon [-hoqvV] [--no-color] [-p=<configurationFileLocation>]",
                     "[--profile=<profile>]");
         });
     }
@@ -195,7 +195,7 @@ class AppTest {
                                             "-h" })));
 
             String expected = String.format(
-                    "Usage: bacon pnc admin maintenance-mode activate [-hovV] [--no-color]%n"
+                    "Usage: bacon pnc admin maintenance-mode activate [-hoqvV] [--no-color]%n"
                             + "       [-p=<configurationFileLocation>] [--profile=<profile>] <reason>%n"
                             + "This will disable any new builds from being accepted%n"
                             + "      <reason>              Reason%n"
@@ -206,6 +206,7 @@ class AppTest {
                             + "  -p, --configPath=<configurationFileLocation>%n"
                             + "                            Path to PNC configuration folder%n"
                             + "      --profile=<profile>   PNC Configuration profile%n"
+                            + "  -q, --quiet               Silent output%n"
                             + "  -v, --verbose             Verbose output%n"
                             + "  -V, --version             Print version information and exit.%n" + "%n" + "Example:%n"
                             + "$ bacon pnc admin maintenance-mode activate \"Switching to maintenance mode for%n"

--- a/common/src/main/java/org/jboss/pnc/bacon/common/ObjectHelper.java
+++ b/common/src/main/java/org/jboss/pnc/bacon/common/ObjectHelper.java
@@ -1,6 +1,7 @@
 package org.jboss.pnc.bacon.common;
 
 import ch.qos.logback.classic.Level;
+import ch.qos.logback.classic.Logger;
 import com.fasterxml.jackson.core.JsonFactory;
 import com.fasterxml.jackson.core.JsonProcessingException;
 import com.fasterxml.jackson.databind.ObjectMapper;
@@ -11,6 +12,8 @@ import com.fasterxml.jackson.datatype.jsr310.JavaTimeModule;
 
 public class ObjectHelper {
 
+    public static Level LOG_LEVEL_SILENT = Level.ERROR;
+
     private static ObjectMapper getOutputMapper(boolean json) {
         ObjectMapper om = json ? new ObjectMapper(new JsonFactory())
                 : new ObjectMapper(new YAMLFactory().configure(YAMLGenerator.Feature.USE_PLATFORM_LINE_BREAKS, true));
@@ -19,19 +22,32 @@ public class ObjectHelper {
         return om;
     }
 
+    /**
+     * Print the object in YAML format by default, unless the json parameter is set to true
+     *
+     * If the root logger is set to LOG_LEVEL_SILENT or more, nothing is printed
+     *
+     * @param json whether to print JSON instead of YAML
+     * @param o Object to print
+     * @throws JsonProcessingException
+     */
     public static void print(boolean json, Object o) throws JsonProcessingException {
-        System.out.println(getOutputMapper(json).writeValueAsString(o));
+        if (!getLogger(Logger.ROOT_LOGGER_NAME).getLevel().isGreaterOrEqual(LOG_LEVEL_SILENT)) {
+            System.out.println(getOutputMapper(json).writeValueAsString(o));
+        }
     }
 
     public static void setRootLoggingLevel(Level level) {
-        ch.qos.logback.classic.Logger root = (ch.qos.logback.classic.Logger) org.slf4j.LoggerFactory
-                .getLogger(ch.qos.logback.classic.Logger.ROOT_LOGGER_NAME);
+        ch.qos.logback.classic.Logger root = getLogger(ch.qos.logback.classic.Logger.ROOT_LOGGER_NAME);
         root.setLevel(level);
     }
 
     public static void setLoggingLevel(String loggerName, Level level) {
-        ch.qos.logback.classic.Logger logger = (ch.qos.logback.classic.Logger) org.slf4j.LoggerFactory
-                .getLogger(loggerName);
+        ch.qos.logback.classic.Logger logger = getLogger(loggerName);
         logger.setLevel(level);
+    }
+
+    private static ch.qos.logback.classic.Logger getLogger(String loggerName) {
+        return (ch.qos.logback.classic.Logger) org.slf4j.LoggerFactory.getLogger(loggerName);
     }
 }


### PR DESCRIPTION
When the quiet option is enabled, the logging level is set to 'ERROR' (no
logs, unless critical will be printed) and any YAML/JSON printed at the end will also not
be printed

### Checklist:

* [ ] Have you added a note in the [CHANGELOG wiki](https://github.com/project-ncl/bacon/wiki/Changelog) for your change if user-facing?
* [ ] Have you added unit tests for your change?
