### PR TITLE
BXMSPROD-1300 - use excludeSourceBuilds to generate offliner manifest

### DIFF
--- a/pig/src/test/java/org/jboss/pnc/bacon/pig/impl/addons/rhba/OfflineManifestGeneratorTest.java
+++ b/pig/src/test/java/org/jboss/pnc/bacon/pig/impl/addons/rhba/OfflineManifestGeneratorTest.java
@@ -28,7 +28,6 @@ import java.util.stream.Collectors;
 
 import static org.jboss.pnc.bacon.pig.impl.config.RepoGenerationStrategy.BUILD_GROUP;
 import static org.junit.jupiter.api.Assertions.assertEquals;
-import static org.junit.jupiter.api.Assertions.assertFalse;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 
 public class OfflineManifestGeneratorTest {
@@ -136,7 +135,7 @@ public class OfflineManifestGeneratorTest {
         }
     }
 
-    private void assertBuildInclusion(PncBuild build, List<String> offlinerContent, boolean isIncluded) {
+    private void assertBuildInclusion(PncBuild build, List<String> offlinerContent, boolean shouldBeIncluded) {
         List<ArtifactWrapper> builtAndDependencies = new ArrayList<>();
         builtAndDependencies.addAll(build.getBuiltArtifacts());
         builtAndDependencies.addAll(build.getDependencyArtifacts());
@@ -144,11 +143,7 @@ public class OfflineManifestGeneratorTest {
             GAV gav = artifact.toGAV();
             String offlinerEntry = String
                     .format("%s,%s/%s", artifact.getSha256(), gav.toVersionPath(), gav.toFileName());
-            if (isIncluded) {
-                assertTrue(offlinerContent.contains(offlinerEntry));
-            } else {
-                assertFalse(offlinerContent.contains(offlinerEntry));
-            }
+            assertEquals(shouldBeIncluded, offlinerContent.contains(offlinerEntry));
         }
     }
 }


### PR DESCRIPTION
Use excludeSourceBuilds repo config to generate offliner manifest when repo strategy is set to BUILD_GROUP or IGNORE

Signed-off-by: Alberto Morales Perez <almorale@redhat.com>

### Checklist:

* [ ] Have you added a note in the [CHANGELOG wiki](https://github.com/project-ncl/bacon/wiki/Changelog) for your change if user-facing?
* [x] Have you added unit tests for your change?
