### PR TITLE
[NCLSUP-425] Add retries for Keycloak client

### DIFF
--- a/auth/pom.xml
+++ b/auth/pom.xml
@@ -31,24 +31,8 @@
 
         <!-- unirest and family -->
         <dependency>
-            <groupId>com.mashape.unirest</groupId>
+            <groupId>com.konghq</groupId>
             <artifactId>unirest-java</artifactId>
-        </dependency>
-        <dependency>
-            <groupId>org.apache.httpcomponents</groupId>
-            <artifactId>httpclient</artifactId>
-        </dependency>
-        <dependency>
-            <groupId>org.apache.httpcomponents</groupId>
-            <artifactId>httpasyncclient</artifactId>
-        </dependency>
-        <dependency>
-            <groupId>org.apache.httpcomponents</groupId>
-            <artifactId>httpmime</artifactId>
-        </dependency>
-        <dependency>
-            <groupId>org.json</groupId>
-            <artifactId>json</artifactId>
         </dependency>
 
         <!-- jackson -->

--- a/auth/src/main/java/org/jboss/pnc/bacon/auth/DirectKeycloakClientImpl.java
+++ b/auth/src/main/java/org/jboss/pnc/bacon/auth/DirectKeycloakClientImpl.java
@@ -1,10 +1,9 @@
 package org.jboss.pnc.bacon.auth;
 
-import com.fasterxml.jackson.core.JsonProcessingException;
-import com.mashape.unirest.http.HttpResponse;
-import com.mashape.unirest.http.ObjectMapper;
-import com.mashape.unirest.http.Unirest;
-import com.mashape.unirest.http.exceptions.UnirestException;
+import kong.unirest.HttpResponse;
+import kong.unirest.Unirest;
+import kong.unirest.UnirestException;
+import kong.unirest.jackson.JacksonObjectMapper;
 import lombok.extern.slf4j.Slf4j;
 import org.jboss.pnc.bacon.auth.model.CacheFile;
 import org.jboss.pnc.bacon.auth.model.Credential;
@@ -13,7 +12,6 @@ import org.jboss.pnc.bacon.auth.spi.KeycloakClient;
 import org.jboss.pnc.bacon.common.exception.FatalException;
 
 import java.io.Console;
-import java.io.IOException;
 import java.time.Instant;
 import java.util.Optional;
 
@@ -24,32 +22,8 @@ import java.util.Optional;
 public class DirectKeycloakClientImpl implements KeycloakClient {
 
     static {
-        setupUnirest();
-    }
-
-    private static void setupUnirest() {
-        // Only one time
-        Unirest.setObjectMapper(new ObjectMapper() {
-            private com.fasterxml.jackson.databind.ObjectMapper jacksonObjectMapper = new com.fasterxml.jackson.databind.ObjectMapper();
-
-            @Override
-            public <T> T readValue(String value, Class<T> valueType) {
-                try {
-                    return jacksonObjectMapper.readValue(value, valueType);
-                } catch (IOException e) {
-                    throw new RuntimeException(e);
-                }
-            }
-
-            @Override
-            public String writeValue(Object value) {
-                try {
-                    return jacksonObjectMapper.writeValueAsString(value);
-                } catch (JsonProcessingException e) {
-                    throw new RuntimeException(e);
-                }
-            }
-        });
+        // Configure Unirest ObjectMapper
+        Unirest.config().setObjectMapper(new JacksonObjectMapper());
     }
 
     @Override

--- a/pom.xml
+++ b/pom.xml
@@ -217,10 +217,11 @@
 
             <!-- unirest and family -->
             <dependency>
-                <groupId>com.mashape.unirest</groupId>
+                <groupId>com.konghq</groupId>
                 <artifactId>unirest-java</artifactId>
-                <version>1.4.9</version>
+                <version>3.11.10</version>
             </dependency>
+
             <dependency>
                 <groupId>org.apache.httpcomponents</groupId>
                 <artifactId>httpclient</artifactId>


### PR DESCRIPTION
The first commit ports from the old Unirest 1.x to Unirest 3.11.10, which comes with package name changes and a different way to configure the object mapper. Overall, Unirest 3.11.10 has a simpler design, which I like.

The second commit attempts to solve NCLSUP-425, which is to add retries to the Keycloak client. We have retries when reaching PNC-Orch, and retries when downloading from Indy, so there should also be a retry for the Keyclaok client! :) The retries however should help us resolve some instability that we've been seeing when reaching the SSO server lately.

### Checklist:

* [x] Have you added a note in the [CHANGELOG wiki](https://github.com/project-ncl/bacon/wiki/Changelog) for your change if user-facing?
* [ ] Have you added unit tests for your change?
