### PR TITLE
[NCL-6767] Fix init of QuarkusCommunityDepAnalyzer when not running

### DIFF
--- a/pig/src/main/java/org/jboss/pnc/bacon/pig/impl/addons/quarkus/QuarkusCommunityDepAnalyzer.java
+++ b/pig/src/main/java/org/jboss/pnc/bacon/pig/impl/addons/quarkus/QuarkusCommunityDepAnalyzer.java
@@ -81,9 +81,16 @@ public class QuarkusCommunityDepAnalyzer extends AddOn {
             Deliverables deliverables) {
         super(pigConfiguration, builds, releasePath, extrasPath);
         this.deliverables = deliverables;
-        @SuppressWarnings("unchecked")
-        Collection<String> skippedExtensions = (Collection<String>) getAddOnConfiguration().get("skippedExtensions");
-        this.skippedExtensions = skippedExtensions == null ? Collections.emptySet() : new HashSet<>(skippedExtensions);
+
+        if (shouldRun()) {
+            @SuppressWarnings("unchecked")
+            Collection<String> skippedExtensions = (Collection<String>) getAddOnConfiguration()
+                    .get("skippedExtensions");
+            this.skippedExtensions = skippedExtensions == null ? Collections.emptySet()
+                    : new HashSet<>(skippedExtensions);
+        } else {
+            skippedExtensions = Collections.emptySet();
+        }
     }
 
     @Override


### PR DESCRIPTION
We call the constructor of QuarkusCommunityDepAnalyzer even if it's not
supposed to run as part of PiG startup.

However, the constructor throws an NPE if the PiG configuration doesn't
have any config on the analyzer. This commit fixes this by disabling
code for parsing analyzer config if the latter is absent.

### Checklist:

* [ ] Have you added a note in the [CHANGELOG wiki](https://github.com/project-ncl/bacon/wiki/Changelog) for your change if user-facing?
* [ ] Have you added unit tests for your change?
