### PR TITLE
[NCL-6714] Export a build-config into PiG format

### DIFF
--- a/pig/src/main/java/org/jboss/pnc/bacon/pig/Pig.java
+++ b/pig/src/main/java/org/jboss/pnc/bacon/pig/Pig.java
@@ -71,7 +71,8 @@ import java.util.concurrent.Callable;
                 Pig.GenerateDocuments.class,
                 Pig.Release.class,
                 Pig.PreProcessYaml.class,
-                Pig.TriggerAddOns.class })
+                Pig.TriggerAddOns.class,
+                PigExport.class })
 public class Pig {
 
     private Pig() {

--- a/pig/src/main/java/org/jboss/pnc/bacon/pig/PigExport.java
+++ b/pig/src/main/java/org/jboss/pnc/bacon/pig/PigExport.java
@@ -1,0 +1,34 @@
+package org.jboss.pnc.bacon.pig;
+
+import org.jboss.pnc.bacon.common.cli.AbstractGetSpecificCommand;
+import org.jboss.pnc.bacon.pig.impl.config.BuildConfig;
+import org.jboss.pnc.bacon.pig.impl.mapping.BuildConfigMapping;
+import org.jboss.pnc.bacon.pnc.common.ClientCreator;
+import org.jboss.pnc.client.BuildConfigurationClient;
+import org.jboss.pnc.client.ClientException;
+import org.jboss.pnc.dto.BuildConfiguration;
+import picocli.CommandLine;
+
+@CommandLine.Command(
+        name = "export",
+        description = "Export feature",
+        subcommands = { PigExport.BuildConfigExport.class })
+public class PigExport {
+
+    @CommandLine.Command(
+            name = "build-config",
+            description = "Export a build-config in a format that can be injected into PiG's build-config.yaml")
+    public static class BuildConfigExport extends AbstractGetSpecificCommand<BuildConfig> {
+
+        private static final ClientCreator<BuildConfigurationClient> CREATOR = new ClientCreator<>(
+                BuildConfigurationClient::new);
+
+        @Override
+        public BuildConfig getSpecific(String id) throws ClientException {
+            try (BuildConfigurationClient client = CREATOR.newClient()) {
+                BuildConfiguration bc = client.getSpecific(id);
+                return BuildConfigMapping.toBuildConfig(bc);
+            }
+        }
+    }
+}

--- a/pig/src/main/java/org/jboss/pnc/bacon/pig/impl/config/BuildConfig.java
+++ b/pig/src/main/java/org/jboss/pnc/bacon/pig/impl/config/BuildConfig.java
@@ -18,6 +18,7 @@
 package org.jboss.pnc.bacon.pig.impl.config;
 
 import com.fasterxml.jackson.annotation.JsonIgnore;
+import com.fasterxml.jackson.annotation.JsonInclude;
 import lombok.Data;
 import org.apache.commons.lang3.StringUtils;
 import org.jboss.pnc.bacon.common.exception.FatalException;
@@ -62,6 +63,7 @@ import static org.apache.commons.lang3.RandomStringUtils.randomAlphabetic;
  *         Date: 11/28/17
  */
 @Data
+@JsonInclude(JsonInclude.Include.NON_EMPTY)
 public class BuildConfig {
     public static final String BUILD_FORCE = "BUILD_FORCE";
 
@@ -291,13 +293,6 @@ public class BuildConfig {
         return result;
     }
 
-    public static void main(String[] args) {
-        List<String> test = new ArrayList<>();
-        test.add("boo");
-        test.add("ya");
-        System.out.println(String.join("\\n", test));
-    }
-
     public boolean isUpgradableFrom(BuildConfiguration oldConfig) {
         String oldInternalUrl = oldConfig.getScmRepository().getInternalUrl();
         String oldExternalUrl = oldConfig.getScmRepository().getExternalUrl();
@@ -320,6 +315,7 @@ public class BuildConfig {
      *
      * @return environmentId
      */
+    @JsonIgnore
     public String getEnvironmentId() {
 
         if (environmentId != null) {
@@ -356,6 +352,7 @@ public class BuildConfig {
         return null;
     }
 
+    @JsonIgnore
     public String getRawEnvironmentId() {
         return environmentId;
     }

--- a/pig/src/main/java/org/jboss/pnc/bacon/pig/impl/mapping/BuildConfigMapping.java
+++ b/pig/src/main/java/org/jboss/pnc/bacon/pig/impl/mapping/BuildConfigMapping.java
@@ -1,0 +1,70 @@
+package org.jboss.pnc.bacon.pig.impl.mapping;
+
+import org.jboss.pnc.bacon.pig.impl.config.BuildConfig;
+import org.jboss.pnc.dto.BuildConfiguration;
+
+import java.util.ArrayList;
+import java.util.Arrays;
+import java.util.HashSet;
+import java.util.Map;
+
+public class BuildConfigMapping {
+
+    public static BuildConfig toBuildConfig(BuildConfiguration buildConfiguration) {
+        BuildConfig buildConfig = new BuildConfig();
+        buildConfig.setName(buildConfiguration.getName());
+        buildConfig.setProject(buildConfiguration.getProject().getName());
+        buildConfig.setBuildScript(buildConfiguration.getBuildScript());
+
+        if (buildConfiguration.getScmRepository().getExternalUrl() != null) {
+            buildConfig.setScmUrl(buildConfiguration.getScmRepository().getExternalUrl());
+        } else {
+            buildConfig.setScmUrl(buildConfiguration.getScmRepository().getInternalUrl());
+        }
+
+        buildConfig.setScmRevision(buildConfiguration.getScmRevision());
+        buildConfig.setDescription(buildConfiguration.getDescription());
+
+        // favor systemImageId
+        buildConfig.setSystemImageId(buildConfiguration.getEnvironment().getSystemImageId());
+        buildConfig.setDependencies(new ArrayList<>(buildConfiguration.getDependencies().keySet()));
+
+        buildConfig.setBrewPullActive(buildConfiguration.getBrewPullActive());
+        buildConfig.setBuildType(buildConfiguration.getBuildType().toString());
+
+        setBuildConfigFieldsBasedOnParameters(buildConfiguration, buildConfig);
+        return buildConfig;
+    }
+
+    static void setBuildConfigFieldsBasedOnParameters(BuildConfiguration buildConfiguration, BuildConfig buildConfig) {
+
+        Map<String, String> parameters = buildConfiguration.getParameters();
+
+        // TODO: could this code be unified with the code in BuildConfig.java?
+        if (parameters.containsKey("ALIGNMENT_PARAMETERS")) {
+            String[] alignmentParameters = parameters.get("ALIGNMENT_PARAMETERS").split(",");
+            buildConfig.setAlignmentParameters(new HashSet<>(Arrays.asList(alignmentParameters)));
+        }
+
+        if (parameters.containsKey("BUILDER_POD_MEMORY")) {
+            buildConfig.setBuildPodMemory(Double.parseDouble(parameters.get("BUILDER_POD_MEMORY")));
+        }
+
+        if (parameters.containsKey("BUILD_CATEGORY")) {
+            buildConfig.setBuildCategory(parameters.get("BUILD_CATEGORY"));
+        }
+
+        if (parameters.containsKey("PIG_YAML_METADATA")) {
+            buildConfig.setPigYamlMetadata(parameters.get("PIG_YAML_METADATA"));
+        }
+
+        if (parameters.containsKey("BREW_BUILD_NAME")) {
+            buildConfig.setBrewBuildName(parameters.get("BREW_BUILD_NAME"));
+        }
+
+        if (parameters.containsKey("EXTRA_REPOSITORIES")) {
+            String[] extraRepositories = parameters.get("EXTRA_REPOSITORIES").split("\n");
+            buildConfig.setExtraRepositories(new HashSet<>(Arrays.asList(extraRepositories)));
+        }
+    }
+}

--- a/pig/src/test/java/org/jboss/pnc/bacon/pig/impl/mapping/BuildConfigMappingTest.java
+++ b/pig/src/test/java/org/jboss/pnc/bacon/pig/impl/mapping/BuildConfigMappingTest.java
@@ -1,0 +1,162 @@
+package org.jboss.pnc.bacon.pig.impl.mapping;
+
+import org.jboss.pnc.bacon.pig.impl.config.BuildConfig;
+import org.jboss.pnc.dto.BuildConfiguration;
+import org.jeasy.random.EasyRandom;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+
+import java.util.HashMap;
+import java.util.HashSet;
+import java.util.Map;
+
+import static org.junit.jupiter.api.Assertions.*;
+
+class BuildConfigMappingTest {
+
+    BuildConfig buildConfig;
+
+    @BeforeEach
+    void setup() {
+        buildConfig = new BuildConfig();
+    }
+
+    @Test
+    void testAlignmentParametersSet() {
+        Map<String, String> parameters = new HashMap<>();
+        parameters.put("ALIGNMENT_PARAMETERS", "-Dtest=true -Dme=false");
+        BuildConfiguration buildConfiguration = BuildConfiguration.builder().parameters(parameters).build();
+
+        BuildConfigMapping.setBuildConfigFieldsBasedOnParameters(buildConfiguration, buildConfig);
+        assertEquals("-Dtest=true -Dme=false", buildConfig.getAlignmentParameters().stream().findFirst().get());
+
+        // make sure no other parameters are set
+        assertNull(buildConfig.getBuildPodMemory());
+        assertNull(buildConfig.getBuildCategory());
+        assertNull(buildConfig.getPigYamlMetadata());
+        assertNull(buildConfig.getBrewBuildName());
+        assertTrue(buildConfig.getExtraRepositories().size() == 0);
+    }
+
+    @Test
+    void testBuilderPodMemorySet() {
+        Map<String, String> parameters = new HashMap<>();
+        parameters.put("BUILDER_POD_MEMORY", "10");
+        BuildConfiguration buildConfiguration = BuildConfiguration.builder().parameters(parameters).build();
+
+        BuildConfigMapping.setBuildConfigFieldsBasedOnParameters(buildConfiguration, buildConfig);
+        assertTrue(Math.abs(10.0 - buildConfig.getBuildPodMemory()) <= 0.000001);
+
+        // make sure no other parameters are set
+        assertTrue(buildConfig.getAlignmentParameters().size() == 0);
+        assertNull(buildConfig.getBuildCategory());
+        assertNull(buildConfig.getPigYamlMetadata());
+        assertNull(buildConfig.getBrewBuildName());
+        assertTrue(buildConfig.getExtraRepositories().size() == 0);
+    }
+
+    @Test
+    void testBuildCategorySet() {
+        Map<String, String> parameters = new HashMap<>();
+        parameters.put("BUILD_CATEGORY", "SERVICE");
+        BuildConfiguration buildConfiguration = BuildConfiguration.builder().parameters(parameters).build();
+
+        BuildConfigMapping.setBuildConfigFieldsBasedOnParameters(buildConfiguration, buildConfig);
+        assertEquals("SERVICE", buildConfig.getBuildCategory());
+
+        // make sure no other parameters are set
+        assertTrue(buildConfig.getAlignmentParameters().size() == 0);
+        assertNull(buildConfig.getBuildPodMemory());
+        assertNull(buildConfig.getPigYamlMetadata());
+        assertNull(buildConfig.getBrewBuildName());
+        assertTrue(buildConfig.getExtraRepositories().size() == 0);
+    }
+
+    @Test
+    void testPigYamlMetadataSet() {
+        Map<String, String> parameters = new HashMap<>();
+        parameters.put("PIG_YAML_METADATA", "12345");
+        BuildConfiguration buildConfiguration = BuildConfiguration.builder().parameters(parameters).build();
+
+        BuildConfigMapping.setBuildConfigFieldsBasedOnParameters(buildConfiguration, buildConfig);
+        assertEquals("12345", buildConfig.getPigYamlMetadata());
+
+        // make sure no other parameters are set
+        assertTrue(buildConfig.getAlignmentParameters().size() == 0);
+        assertNull(buildConfig.getBuildPodMemory());
+        assertNull(buildConfig.getBuildCategory());
+        assertNull(buildConfig.getBrewBuildName());
+        assertTrue(buildConfig.getExtraRepositories().size() == 0);
+    }
+
+    @Test
+    void testBrewBuildNameSet() {
+        Map<String, String> parameters = new HashMap<>();
+        parameters.put("BREW_BUILD_NAME", "testme");
+        BuildConfiguration buildConfiguration = BuildConfiguration.builder().parameters(parameters).build();
+
+        BuildConfigMapping.setBuildConfigFieldsBasedOnParameters(buildConfiguration, buildConfig);
+        assertEquals("testme", buildConfig.getBrewBuildName());
+
+        // make sure no other parameters are set
+        assertTrue(buildConfig.getAlignmentParameters().size() == 0);
+        assertNull(buildConfig.getBuildPodMemory());
+        assertNull(buildConfig.getBuildCategory());
+        assertNull(buildConfig.getPigYamlMetadata());
+        assertTrue(buildConfig.getExtraRepositories().size() == 0);
+    }
+
+    @Test
+    void testExtraRepositoriesSet() {
+        Map<String, String> parameters = new HashMap<>();
+        parameters.put("EXTRA_REPOSITORIES", "hello\nworld");
+        BuildConfiguration buildConfiguration = BuildConfiguration.builder().parameters(parameters).build();
+
+        BuildConfigMapping.setBuildConfigFieldsBasedOnParameters(buildConfiguration, buildConfig);
+        assertTrue(buildConfig.getExtraRepositories().contains("hello"));
+        assertTrue(buildConfig.getExtraRepositories().contains("world"));
+        assertTrue(buildConfig.getExtraRepositories().size() == 2);
+
+        // make sure no other parameters are set
+        assertTrue(buildConfig.getAlignmentParameters().size() == 0);
+        assertNull(buildConfig.getBuildPodMemory());
+        assertNull(buildConfig.getBuildCategory());
+        assertNull(buildConfig.getPigYamlMetadata());
+        assertNull(buildConfig.getBrewBuildName());
+    }
+
+    @Test
+    void testCanSetMultipleParameters() {
+        Map<String, String> parameters = new HashMap<>();
+        parameters.put("ALIGNMENT_PARAMETERS", "-Dtest=true -Dme=false");
+        parameters.put("BREW_BUILD_NAME", "testme");
+        BuildConfiguration buildConfiguration = BuildConfiguration.builder().parameters(parameters).build();
+
+        BuildConfigMapping.setBuildConfigFieldsBasedOnParameters(buildConfiguration, buildConfig);
+        assertEquals("-Dtest=true -Dme=false", buildConfig.getAlignmentParameters().stream().findFirst().get());
+        assertEquals("testme", buildConfig.getBrewBuildName());
+
+        // make sure no other parameters are set
+        assertNull(buildConfig.getBuildPodMemory());
+        assertNull(buildConfig.getBuildCategory());
+        assertNull(buildConfig.getPigYamlMetadata());
+        assertTrue(buildConfig.getExtraRepositories().size() == 0);
+    }
+
+    @Test
+    void testEntireMapping() {
+        EasyRandom easyRandom = new EasyRandom();
+        BuildConfiguration buildConfiguration = easyRandom.nextObject(BuildConfiguration.class);
+        BuildConfig bc = BuildConfigMapping.toBuildConfig(buildConfiguration);
+        assertEquals(buildConfiguration.getName(), bc.getName());
+        assertEquals(buildConfiguration.getProject().getName(), bc.getProject());
+        assertEquals(buildConfiguration.getBuildScript(), bc.getBuildScript());
+        assertEquals(buildConfiguration.getScmRepository().getExternalUrl(), bc.getScmUrl());
+        assertEquals(buildConfiguration.getScmRevision(), bc.getScmRevision());
+        assertEquals(buildConfiguration.getDescription(), bc.getDescription());
+        assertEquals(buildConfiguration.getEnvironment().getSystemImageId(), bc.getSystemImageId());
+        assertEquals(buildConfiguration.getDependencies().keySet(), new HashSet(bc.getDependencies()));
+        assertEquals(buildConfiguration.getBrewPullActive(), bc.getBrewPullActive());
+        assertEquals(buildConfiguration.getBuildType().toString(), bc.getBuildType());
+    }
+}


### PR DESCRIPTION
This commit adds a new command to export a build-config into a YAML
output suitable to be added into PiG's build-config.yaml format.

Usage:
```
$ bacon pig export build-config <build-config-id>
---
name: "TC37-memory-allocation"
project: "TC37"
buildScript: "mvn deploy"
scmUrl: "https://github.com/michalszynkiewicz/empty.git"
scmRevision: "master"
systemImageId: "builder-rhel-7-j8-mvn3.6.0:1.0.4"
buildPodMemory: 5.0
brewPullActive: false
buildType: "MVN"
```

Doc PR is: #831 

### Checklist:

* [ ] Have you added a note in the [CHANGELOG wiki](https://github.com/project-ncl/bacon/wiki/Changelog) for your change if user-facing?
* [x] Have you added unit tests for your change?
