### PR TITLE
[NCLSUP-470] Add bacon_test.py

### DIFF
--- a/bacon_test.py
+++ b/bacon_test.py
@@ -1,0 +1,108 @@
+import bacon_install
+
+import os
+import shutil
+import subprocess
+import tempfile
+import unittest
+
+
+class TestBacon(unittest.TestCase):
+
+    def test_create_folder_if_absent(self):
+        with tempfile.TemporaryDirectory() as f:
+            # make sure no exceptions thrown
+            bacon_install.create_folder_if_absent(f)
+
+        # create a temp_folder and delete it
+        temp_folder = tempfile.mkdtemp()
+        shutil.rmtree(temp_folder)
+
+        # see if create_folder_if_absent creates it back
+        bacon_install.create_folder_if_absent(temp_folder)
+        self.assertTrue(os.path.exists(temp_folder))
+
+
+    def test_download_link(self):
+        with tempfile.TemporaryDirectory() as f:
+            bacon_install.download_link(
+                    "https://repo1.maven.org/maven2/org/jboss/pnc/bacon/cli/maven-metadata.xml",
+                    f, "testme")
+            self.assertTrue(os.path.exists(os.path.join(f, "testme")))
+
+    def test_calculate_sha1(self):
+        f = tempfile.NamedTemporaryFile(delete=False)
+        f.write(b"hello\n")
+        f.close()
+
+        self.assertEqual(
+                bacon_install.calculate_sha1(f.name),
+                "f572d396fae9206628714fb2ce00f72e94f2258f")
+
+        # cleanup
+        os.remove(f.name)
+
+    def test_bacon_install(self):
+        bacon_jar_location = tempfile.mkdtemp()
+        shell_location = tempfile.mkdtemp()
+        maven_link = "https://repo1.maven.org/maven2/org/jboss/pnc/bacon/cli/"
+
+        install = bacon_install.BaconInstall(
+                bacon_jar_location,
+                shell_location,
+                maven_link)
+        install.run()
+
+        self.assertTrue(os.path.exists(os.path.join(bacon_jar_location, "bacon.jar")))
+        self.assertTrue(os.path.exists(os.path.join(shell_location, "bacon")))
+        self.assertTrue(os.path.exists(os.path.join(shell_location, "da")))
+        self.assertTrue(os.path.exists(os.path.join(shell_location, "pnc")))
+        self.assertTrue(os.path.exists(os.path.join(shell_location, "pig")))
+
+        # test if bacon.jar runs
+        bacon_version = subprocess.run([
+            "java",
+            "-jar",
+            os.path.join(bacon_jar_location, "bacon.jar"),
+            "--version"],
+            stdout=subprocess.PIPE)
+
+        self.assertIn("Bacon version", str(bacon_version.stdout))
+        self.assertEqual(bacon_version.returncode, 0)
+
+        # cleanup
+        shutil.rmtree(bacon_jar_location)
+        shutil.rmtree(shell_location)
+
+
+    def test_bacon_install_with_version(self):
+        bacon_jar_location = tempfile.mkdtemp()
+        shell_location = tempfile.mkdtemp()
+        maven_link = "https://repo1.maven.org/maven2/org/jboss/pnc/bacon/cli/"
+
+        install = bacon_install.BaconInstall(
+                bacon_jar_location,
+                shell_location,
+                maven_link,
+                version="2.1.8")
+        install.run()
+
+        self.assertTrue(os.path.exists(os.path.join(bacon_jar_location, "bacon.jar")))
+        self.assertTrue(os.path.exists(os.path.join(shell_location, "bacon")))
+        self.assertTrue(os.path.exists(os.path.join(shell_location, "da")))
+        self.assertTrue(os.path.exists(os.path.join(shell_location, "pnc")))
+        self.assertTrue(os.path.exists(os.path.join(shell_location, "pig")))
+
+        bacon_version = subprocess.run([
+            "java",
+            "-jar",
+            os.path.join(bacon_jar_location, "bacon.jar"),
+            "--version"],
+            stdout=subprocess.PIPE)
+
+        self.assertTrue("2.1.8", str(bacon_version.stdout))
+        self.assertEqual(bacon_version.returncode, 0)
+
+        # cleanup
+        shutil.rmtree(bacon_jar_location)
+        shutil.rmtree(shell_location)

--- a/cli/pom.xml
+++ b/cli/pom.xml
@@ -122,6 +122,29 @@
                     </execution>
                 </executions>
             </plugin>
+            <plugin>
+                <groupId>org.codehaus.mojo</groupId>
+                <artifactId>exec-maven-plugin</artifactId>
+                <version>3.0.0</version>
+                <executions>
+                    <execution>
+                        <id>python-test</id>
+                        <goals>
+                            <goal>exec</goal>
+                        </goals>
+                        <phase>test</phase>
+                        <configuration>
+                            <workingDirectory>${project.parent.basedir}</workingDirectory>
+                            <executable>python3</executable>
+                            <arguments>
+                                <argument>-m</argument>
+                                <argument>unittest</argument>
+                                <argument>bacon_test</argument>
+                            </arguments>
+                        </configuration>
+                    </execution>
+                </executions>
+            </plugin>
         </plugins>
     </build>
 </project>


### PR DESCRIPTION
The bacon_test.py is run on the cli module test phase. If the tests
fail, the compilation will also fail.

bacon_test.py is used to test the bacon install script.

```
[INFO] --- exec-maven-plugin:3.0.0:exec (python-test) @ cli ---
.F...
======================================================================
FAIL: test_bacon_install_with_version (bacon_test.TestBacon)
----------------------------------------------------------------------
Traceback (most recent call last):
  File "/home/dcheung/projects/work/bacon/bacon_test.py", line 109, in test_bacon_install_with_version
    self.assertTrue(False)
AssertionError: False is not true

----------------------------------------------------------------------
Ran 5 tests in 30.782s

FAILED (failures=1)
Downloading: https://repo1.maven.org/maven2/org/jboss/pnc/bacon/cli/maven-metadata.xml
Downloading: https://repo1.maven.org/maven2/org/jboss/pnc/bacon/cli/2.1.10/cli-2.1.10-shaded.jar.sha1
Downloading: https://repo1.maven.org/maven2/org/jboss/pnc/bacon/cli/2.1.10/cli-2.1.10-shaded.jar
Verifying checksums... Success!
bacon installed in: /tmp/tmpyts5c5py/bacon.jar

Installed version: 2.1.10!
Downloading: https://repo1.maven.org/maven2/org/jboss/pnc/bacon/cli/maven-metadata.xml
Downloading: https://repo1.maven.org/maven2/org/jboss/pnc/bacon/cli/2.1.8/cli-2.1.8-shaded.jar.sha1
Downloading: https://repo1.maven.org/maven2/org/jboss/pnc/bacon/cli/2.1.8/cli-2.1.8-shaded.jar
Verifying checksums... Success!
bacon installed in: /tmp/tmppfosew7m/bacon.jar

Installed version: 2.1.8!
Downloading: https://repo1.maven.org/maven2/org/jboss/pnc/bacon/cli/maven-metadata.xml
[ERROR] Command execution failed.
org.apache.commons.exec.ExecuteException: Process exited with an error: 1 (Exit value: 1)
    at org.apache.commons.exec.DefaultExecutor.executeInternal (DefaultExecutor.java:404)
    at org.apache.commons.exec.DefaultExecutor.execute (DefaultExecutor.java:166)
    at org.codehaus.mojo.exec.ExecMojo.executeCommandLine (ExecMojo.java:982)
    at org.codehaus.mojo.exec.ExecMojo.executeCommandLine (ExecMojo.java:929)
    at org.codehaus.mojo.exec.ExecMojo.execute (ExecMojo.java:457)
    at org.apache.maven.plugin.DefaultBuildPluginManager.executeMojo (DefaultBuildPluginManager.java:137)
    at org.apache.maven.lifecycle.internal.MojoExecutor.execute (MojoExecutor.java:210)
    at org.apache.maven.lifecycle.internal.MojoExecutor.execute (MojoExecutor.java:156)
    at org.apache.maven.lifecycle.internal.MojoExecutor.execute (MojoExecutor.java:148)
    at org.apache.maven.lifecycle.internal.LifecycleModuleBuilder.buildProject (LifecycleModuleBuilder.java:117)
    at org.apache.maven.lifecycle.internal.LifecycleModuleBuilder.buildProject (LifecycleModuleBuilder.java:81)
    at org.apache.maven.lifecycle.internal.builder.singlethreaded.SingleThreadedBuilder.build (SingleThreadedBuilder.java:56)
    at org.apache.maven.lifecycle.internal.LifecycleStarter.execute (LifecycleStarter.java:128)
    at org.apache.maven.DefaultMaven.doExecute (DefaultMaven.java:305)
    at org.apache.maven.DefaultMaven.doExecute (DefaultMaven.java:192)
    at org.apache.maven.DefaultMaven.execute (DefaultMaven.java:105)
    at org.apache.maven.cli.MavenCli.execute (MavenCli.java:957)
    at org.apache.maven.cli.MavenCli.doMain (MavenCli.java:289)
    at org.apache.maven.cli.MavenCli.main (MavenCli.java:193)
    at jdk.internal.reflect.NativeMethodAccessorImpl.invoke0 (Native Method)
    at jdk.internal.reflect.NativeMethodAccessorImpl.invoke (NativeMethodAccessorImpl.java:62)
    at jdk.internal.reflect.DelegatingMethodAccessorImpl.invoke (DelegatingMethodAccessorImpl.java:43)
    at java.lang.reflect.Method.invoke (Method.java:566)
    at org.codehaus.plexus.classworlds.launcher.Launcher.launchEnhanced (Launcher.java:282)
    at org.codehaus.plexus.classworlds.launcher.Launcher.launch (Launcher.java:225)
    at org.codehaus.plexus.classworlds.launcher.Launcher.mainWithExitCode (Launcher.java:406)
    at org.codehaus.plexus.classworlds.launcher.Launcher.main (Launcher.java:347)
[INFO] ------------------------------------------------------------------------
[INFO] BUILD FAILURE
[INFO] ------------------------------------------------------------------------
[INFO] Total time:  48.230 s
[INFO] Finished at: 2021-11-15T16:58:53-05:00
[INFO] ------------------------------------------------------------------------
```

### Checklist:

* [ ] Have you added a note in the [CHANGELOG wiki](https://github.com/project-ncl/bacon/wiki/Changelog) for your change if user-facing?
* [x] Have you added unit tests for your change?
