### PR TITLE
Remove unecessary temporary build log

### DIFF
--- a/pig/src/main/java/org/jboss/pnc/bacon/pig/PigFacade.java
+++ b/pig/src/main/java/org/jboss/pnc/bacon/pig/PigFacade.java
@@ -160,9 +160,6 @@ public final class PigFacade {
             log.info("Skipping builds");
             groupBuildInfo = getBuilds(importResult, tempBuild);
         } else {
-            if (tempBuild) {
-                log.info("Temporary build");
-            }
             groupBuildInfo = build(tempBuild, tempBuildTS, rebuildMode, true);
         }
 


### PR DESCRIPTION
The same log is printed in the `build` method, which the `run` method calls.

### Checklist:

* [ ] Have you added a note in the [CHANGELOG wiki](https://github.com/project-ncl/bacon/wiki/Changelog) for your change if user-facing?
* [ ] Have you added unit tests for your change?
