### PR TITLE
[NCL-5973] Add option to be strict for source jars

### DIFF
--- a/pig/src/main/java/org/jboss/pnc/bacon/pig/Pig.java
+++ b/pig/src/main/java/org/jboss/pnc/bacon/pig/Pig.java
@@ -233,6 +233,12 @@ public class Pig {
                 description = "if set to true will fail on license zip with missing/invalid entries")
         private boolean strictLicenseCheck;
 
+        @Option(
+                names = "--strictDownloadSource",
+                defaultValue = "false",
+                description = "If set, any missing source jars will throw an error")
+        private boolean strictDownloadSource;
+
         @Override
         public PigRunOutput doExecute() {
 
@@ -253,6 +259,7 @@ public class Pig {
                     RebuildMode.valueOf(rebuildMode),
                     skipBranchCheck,
                     strictLicenseCheck,
+                    strictDownloadSource,
                     configurationDirectory);
 
             PigContext context = PigContext.get();
@@ -354,11 +361,20 @@ public class Pig {
                 description = "if set to true will fail on license zip with missing/invalid entries")
         private boolean strictLicenseCheck;
 
+        @Option(
+                names = "--strictDownloadSource",
+                defaultValue = "false",
+                description = "If set, any missing source jars will throw an error")
+        private boolean strictDownloadSource;
+
         @Override
         public RepositoryData doExecute() {
             Path configurationDirectory = Paths.get(configDir);
-            RepositoryData result = PigFacade
-                    .generateRepo(removeGeneratedM2Dups, configurationDirectory, strictLicenseCheck);
+            RepositoryData result = PigFacade.generateRepo(
+                    removeGeneratedM2Dups,
+                    configurationDirectory,
+                    strictLicenseCheck,
+                    strictDownloadSource);
             PigContext.get().setRepositoryData(result);
             PigContext.get().storeContext();
             return result;

--- a/pig/src/main/java/org/jboss/pnc/bacon/pig/PigFacade.java
+++ b/pig/src/main/java/org/jboss/pnc/bacon/pig/PigFacade.java
@@ -143,6 +143,7 @@ public final class PigFacade {
             RebuildMode rebuildMode,
             boolean skipBranchCheck,
             boolean strictLicenseCheck,
+            boolean strictDownloadSource,
             Path configurationDirectory) {
 
         PigContext context = context();
@@ -181,7 +182,11 @@ public final class PigFacade {
             if (repoZipPath != null) {
                 repo = parseRepository(new File(repoZipPath));
             } else {
-                repo = generateRepo(removeGeneratedM2Dups, configurationDirectory, strictLicenseCheck);
+                repo = generateRepo(
+                        removeGeneratedM2Dups,
+                        configurationDirectory,
+                        strictLicenseCheck,
+                        strictDownloadSource);
             }
             context.setRepositoryData(repo);
             context.storeContext();
@@ -416,7 +421,8 @@ public final class PigFacade {
     public static RepositoryData generateRepo(
             boolean removeGeneratedM2Dups,
             Path configurationDirectory,
-            boolean strictLicenseCheck) {
+            boolean strictLicenseCheck,
+            boolean strictSourceDownload) {
         abortIfBuildDataAbsentFromContext();
         PigContext context = context();
         try (RepoManager repoManager = new RepoManager(
@@ -426,7 +432,8 @@ public final class PigFacade {
                 context.getBuilds(),
                 configurationDirectory,
                 removeGeneratedM2Dups,
-                strictLicenseCheck)) {
+                strictLicenseCheck,
+                strictSourceDownload)) {
 
             RepositoryData repositoryData = repoManager.prepare();
 

--- a/pig/src/main/java/org/jboss/pnc/bacon/pig/impl/repo/RepoManager.java
+++ b/pig/src/main/java/org/jboss/pnc/bacon/pig/impl/repo/RepoManager.java
@@ -78,6 +78,7 @@ public class RepoManager extends DeliverableManager<RepoGenerationData, Reposito
     private final boolean removeGeneratedM2Dups;
     private final Path configurationDirectory;
     private final boolean strictLicenseCheck;
+    private final boolean strictDownloadSource;
     private final boolean isTestMode;
 
     public RepoManager(
@@ -87,12 +88,14 @@ public class RepoManager extends DeliverableManager<RepoGenerationData, Reposito
             Map<String, PncBuild> builds,
             Path configurationDirectory,
             boolean removeGeneratedM2Dups,
-            boolean strictLicenseCheck) {
+            boolean strictLicenseCheck,
+            boolean strictDownloadSource) {
         super(pigConfiguration, releasePath, deliverables, builds);
         generationData = pigConfiguration.getFlow().getRepositoryGeneration();
         this.removeGeneratedM2Dups = removeGeneratedM2Dups;
         this.configurationDirectory = configurationDirectory;
         this.strictLicenseCheck = strictLicenseCheck;
+        this.strictDownloadSource = strictDownloadSource;
         buildInfoCollector = new BuildInfoCollector();
         isTestMode = false;
     }
@@ -105,6 +108,7 @@ public class RepoManager extends DeliverableManager<RepoGenerationData, Reposito
             Path configurationDirectory,
             boolean removeGeneratedM2Dups,
             boolean strictLicenseCheck,
+            boolean strictDownloadSource,
             BuildInfoCollector buildInfoCollector,
             Boolean isTestMode) {
         super(pigConfiguration, releasePath, deliverables, builds);
@@ -112,6 +116,7 @@ public class RepoManager extends DeliverableManager<RepoGenerationData, Reposito
         this.removeGeneratedM2Dups = removeGeneratedM2Dups;
         this.configurationDirectory = configurationDirectory;
         this.strictLicenseCheck = strictLicenseCheck;
+        this.strictDownloadSource = strictDownloadSource;
         this.buildInfoCollector = buildInfoCollector;
         this.isTestMode = isTestMode;
     }
@@ -191,7 +196,8 @@ public class RepoManager extends DeliverableManager<RepoGenerationData, Reposito
                     .map(GAV::toJavadocJar)
                     .forEach(gavsToPack::add);
         }
-        gavsToPack.forEach(a -> ExternalArtifactDownloader.downloadExternalArtifact(a, sourceDir.toPath(), true));
+        gavsToPack.forEach(
+                a -> ExternalArtifactDownloader.downloadExternalArtifact(a, sourceDir.toPath(), !strictDownloadSource));
     }
 
     @Deprecated

--- a/pig/src/main/java/org/jboss/pnc/bacon/pig/impl/repo/RepoManager.java
+++ b/pig/src/main/java/org/jboss/pnc/bacon/pig/impl/repo/RepoManager.java
@@ -196,7 +196,7 @@ public class RepoManager extends DeliverableManager<RepoGenerationData, Reposito
 
     @Deprecated
     private RepositoryData packAllBuiltAndDependencies() {
-        log.warn("Repo generation stratagy 'PACK_ALL' is deprecated please use BUILD_CONFIGS");
+        log.warn("Repo generation strategy 'PACK_ALL' is deprecated please use BUILD_CONFIGS");
         PncBuild build = getBuild(generationData.getSourceBuild());
         List<ArtifactWrapper> artifactsToPack = new ArrayList<>();
         getRedhatArtifacts(artifactsToPack, build);

--- a/pig/src/test/java/org/jboss/pnc/bacon/pig/impl/repo/ResolveOnlyRepositoryTest.java
+++ b/pig/src/test/java/org/jboss/pnc/bacon/pig/impl/repo/ResolveOnlyRepositoryTest.java
@@ -70,6 +70,7 @@ public class ResolveOnlyRepositoryTest {
                 configurationDirectory,
                 false,
                 false,
+                false,
                 buildInfoCollectorMock,
                 true);
 


### PR DESCRIPTION
When generating the maven repository, the user can now specify if she wants a failed source jar download to terminate the generation or not (default).

The flag option is: `--strictDownloadSource`. It is by default switched off.

The flag is added to command:
- `bacon pig run`
- `bacon pig maven`


### Checklist:

* [ ] Have you added a note in the [CHANGELOG wiki](https://github.com/project-ncl/bacon/wiki/Changelog) for your change if user-facing?
* [ ] Have you added unit tests for your change?
