### PR TITLE
[NCLSUP-491] Reduce confusion on pnc output for Url

### DIFF
--- a/pig/src/main/java/org/jboss/pnc/bacon/pig/PigFacade.java
+++ b/pig/src/main/java/org/jboss/pnc/bacon/pig/PigFacade.java
@@ -299,7 +299,7 @@ public final class PigFacade {
                     throw new RuntimeException(
                             "Failed to push build " + build.getId() + " to brew. Push result: " + pushResult);
                 }
-                log.info("{} pushed to brew ({}) ", build.getId(), UrlGenerator.generateBuildUrl(build.getId()));
+                log.info("{} pushed to brew ( {} ) ", build.getId(), UrlGenerator.generateBuildUrl(build.getId()));
             } catch (RemoteResourceException e) {
                 throw new RuntimeException(
                         "Failed to push build " + build.getId() + " to brew ("

--- a/pig/src/main/java/org/jboss/pnc/bacon/pig/impl/pnc/PncBuild.java
+++ b/pig/src/main/java/org/jboss/pnc/bacon/pig/impl/pnc/PncBuild.java
@@ -161,7 +161,7 @@ public class PncBuild {
                     buildLog = readLog(inputStream);
                 }
             } else {
-                log.debug("Couldn't find logs for build id: {} ({})", id, UrlGenerator.generateBuildUrl(id));
+                log.debug("Couldn't find logs for build id: {} ( {} )", id, UrlGenerator.generateBuildUrl(id));
                 buildLog = Collections.emptyList();
             }
 

--- a/pig/src/main/java/org/jboss/pnc/bacon/pig/impl/pnc/PncBuilder.java
+++ b/pig/src/main/java/org/jboss/pnc/bacon/pig/impl/pnc/PncBuilder.java
@@ -86,7 +86,7 @@ public class PncBuilder implements Closeable {
             boolean tempBuildTS,
             RebuildMode rebuildMode) {
         log.info(
-                "Performing builds of group config {} in PNC ({})",
+                "Performing builds of group config {} in PNC ( {} )",
                 group.getId(),
                 UrlGenerator.generateGroupConfigUrl(group.getId()));
         if (tempBuildTS)
@@ -129,7 +129,7 @@ public class PncBuilder implements Closeable {
 
     void waitForSuccessfulFinish(String groupBuildId) {
         log.info(
-                "Waiting for finish of group build {} ({})",
+                "Waiting for finish of group build {} ( {} )",
                 groupBuildId,
                 UrlGenerator.generateGroupBuildUrl(groupBuildId));
         SleepUtils.waitFor(() -> isSuccessfullyFinished(groupBuildId), 30, true);
@@ -154,7 +154,7 @@ public class PncBuilder implements Closeable {
             }
         } catch (ClientException e) {
             log.warn(
-                    "Failed to check if build is finished for {} ({}). Assuming it is not finished",
+                    "Failed to check if build is finished for {} ( {} ). Assuming it is not finished",
                     groupBuildId,
                     UrlGenerator.generateGroupBuildUrl(groupBuildId),
                     e);
@@ -182,7 +182,7 @@ public class PncBuilder implements Closeable {
 
         // log set to info for CPaaS to detect infinite loop
         log.info(
-                "Checking if all builds in group build {} are in final state with proper count of builds ({})",
+                "Checking if all builds in group build {} are in final state with proper count of builds ( {} )",
                 groupBuildId,
                 UrlGenerator.generateGroupBuildUrl(groupBuildId));
         BuildsFilterParameters filter = new BuildsFilterParameters();

--- a/pnc/src/main/java/org/jboss/pnc/bacon/pnc/GroupConfigCli.java
+++ b/pnc/src/main/java/org/jboss/pnc/bacon/pnc/GroupConfigCli.java
@@ -285,7 +285,7 @@ public class GroupConfigCli {
                     return 0;
                 } else {
                     log.error(
-                            "Couldn't find any group build from group config id: {} ({})",
+                            "Couldn't find any group build from group config id: {} ( {} )",
                             id,
                             UrlGenerator.generateGroupConfigUrl(id));
                     return 1;


### PR DESCRIPTION
Bacon likes to add the URL information of PNC elements inside brackets.

e.g "here (https://hello.com)"

It looks from our PNC logs that users copy the URL by hand and
unfortunately also copies the end of the bracket.

PNC then gets requests like:
- https://hello.com)

which confuses it. To reduce those kinds of errors, this commit adds an
extra space with the closing bracket to help the user not copy that kind
of error.

The output will then become:
- "here ( https://hello.com )"

### Checklist:

* [ ] Have you added a note in the [CHANGELOG wiki](https://github.com/project-ncl/bacon/wiki/Changelog) for your change if user-facing?
* [ ] Have you added unit tests for your change?
