### PR TITLE
[NCLSUP-475] Don't retry when keycloak error is missing certificate

### DIFF
--- a/auth/pom.xml
+++ b/auth/pom.xml
@@ -48,5 +48,16 @@
             <groupId>com.fasterxml.jackson.datatype</groupId>
             <artifactId>jackson-datatype-jsr310</artifactId>
         </dependency>
+
+        <dependency>
+            <groupId>org.assertj</groupId>
+            <artifactId>assertj-core</artifactId>
+            <scope>test</scope>
+        </dependency>
+        <dependency>
+            <groupId>org.junit.jupiter</groupId>
+            <artifactId>junit-jupiter-engine</artifactId>
+            <scope>test</scope>
+        </dependency>
     </dependencies>
 </project>

--- a/auth/src/main/java/org/jboss/pnc/bacon/auth/DirectKeycloakClientImpl.java
+++ b/auth/src/main/java/org/jboss/pnc/bacon/auth/DirectKeycloakClientImpl.java
@@ -12,6 +12,8 @@ import org.jboss.pnc.bacon.auth.model.KeycloakResponse;
 import org.jboss.pnc.bacon.auth.spi.KeycloakClient;
 import org.jboss.pnc.bacon.common.exception.FatalException;
 
+import javax.net.ssl.SSLHandshakeException;
+
 import java.io.Console;
 import java.time.Instant;
 import java.util.Optional;
@@ -208,6 +210,11 @@ public class DirectKeycloakClientImpl implements KeycloakClient {
                 HttpResponse<KeycloakResponse> postResponse = body.asObject(KeycloakResponse.class);
                 return postResponse.getBody();
             } catch (UnirestException e) {
+                if (e.getCause().getClass().equals(SSLHandshakeException.class)) {
+                    throw new FatalException(
+                            "Cannot reach the Keycloak server because of missing TLS certificates",
+                            e.getCause());
+                }
                 retries++;
 
                 if (retries > MAX_RETRIES) {

--- a/auth/src/test/java/org/jboss/pnc/bacon/auth/DirectKeycloakClientImplTest.java
+++ b/auth/src/test/java/org/jboss/pnc/bacon/auth/DirectKeycloakClientImplTest.java
@@ -1,0 +1,24 @@
+package org.jboss.pnc.bacon.auth;
+
+import org.jboss.pnc.bacon.auth.spi.KeycloakClient;
+import org.jboss.pnc.bacon.common.exception.FatalException;
+import org.junit.jupiter.api.Test;
+
+import static org.junit.jupiter.api.Assertions.*;
+
+class DirectKeycloakClientImplTest {
+
+    @Test
+    void testGetServiceAccountFatalExceptionThrownOnTLSCertException() {
+        KeycloakClient keycloakClient = new DirectKeycloakClientImpl();
+        try {
+            keycloakClient.getCredentialServiceAccount(
+                    "https://self-signed.badssl.com",
+                    "true-love",
+                    "bassackwards",
+                    "only-me");
+        } catch (Exception e) {
+            assertSame(FatalException.class, e.getCause().getClass());
+        }
+    }
+}


### PR DESCRIPTION
Example without this commit:
```
[root@ab92857abab7 ~]# bacon pnc whoami
Enter your password:
[INFO ] - Having difficulty reaching https://secure-sso-newcastle-devel.psi.redhat.com/auth/realms/pncredhat/protocol/openid-connect/token. Retrying again...
[ERROR] - Keycloak authentication failed!, Error: org.jboss.pnc.bacon.auth.KeycloakClientException: kong.unirest.UnirestException: javax.net.ssl.SSLHandshakeException: PKIX path building failed: sun.security.provider.certpath.SunCertPathBuilderException: unable to find valid certification path to requested target
```
The above command took a while to finish due to retries.

Example with this commit:
```
[root@ab92857abab7 ~]# java -jar /tmp/bacon.jar pnc whoami
Enter your password:
[ERROR] - Keycloak authentication failed!, Error: org.jboss.pnc.bacon.auth.KeycloakClientException: org.jboss.pnc.bacon.common.exception.FatalException: Cannot reach the Keycloak server because of missing TLS certificates
```
This command terminated early

### Checklist:

* [x] Have you added a note in the [CHANGELOG wiki](https://github.com/project-ncl/bacon/wiki/Changelog) for your change if user-facing?
* [x] Have you added unit tests for your change?
