### PR TITLE
[NCL-5981] Add ability to provide a suffix for deliverables

### DIFF
--- a/pig/src/main/java/org/jboss/pnc/bacon/pig/impl/PigContext.java
+++ b/pig/src/main/java/org/jboss/pnc/bacon/pig/impl/PigContext.java
@@ -115,7 +115,14 @@ public class PigContext {
         initFullVersion(pigConfiguration, releaseStorageUrl);
 
         if (deliverables == null) {
-            prefix = String.format("%s-%s", pigConfiguration.getOutputPrefixes().getReleaseFile(), fullVersion);
+            String suffix = "";
+            // for e.g, zip will become <releaseFile>-<fullVersion>-<suffix>-maven-repository.zip
+            if (pigConfiguration.getOutputSuffix() != null && !pigConfiguration.getOutputSuffix().isBlank()) {
+                suffix = "-" + pigConfiguration.getOutputSuffix();
+            }
+
+            prefix = String
+                    .format("%s-%s%s", pigConfiguration.getOutputPrefixes().getReleaseFile(), fullVersion, suffix);
 
             deliverables = new Deliverables();
 

--- a/pig/src/main/java/org/jboss/pnc/bacon/pig/impl/config/PigConfiguration.java
+++ b/pig/src/main/java/org/jboss/pnc/bacon/pig/impl/config/PigConfiguration.java
@@ -71,6 +71,7 @@ public class PigConfiguration implements Validate {
     private @NotNull BuildConfig defaultBuildParameters = new BuildConfig();
     private @NotEmpty @ListBuildConfigCheck @Valid List<BuildConfig> builds = new ArrayList<>();
     private @NotNull @Valid Output outputPrefixes;
+    private String outputSuffix;
 
     private @NotNull @Valid Flow flow;
     private String majorMinor;
@@ -242,7 +243,12 @@ public class PigConfiguration implements Validate {
     }
 
     public String getTopLevelDirectoryPrefix() {
-        return String.format("%s-%s.%s-", outputPrefixes.getReleaseDir(), version, product.getStage());
+        String finalSuffix = "";
+        // folder name will become <release-dir>-<version>-<stage>-<suffix>-maven-repository
+        if (outputSuffix != null && !outputSuffix.isBlank()) {
+            finalSuffix = "-" + outputSuffix;
+        }
+        return String.format("%s-%s.%s%s-", outputPrefixes.getReleaseDir(), version, product.getStage(), finalSuffix);
     }
 
     @Deprecated

--- a/pig/src/test/java/org/jboss/pnc/bacon/pig/impl/PigContextTest.java
+++ b/pig/src/test/java/org/jboss/pnc/bacon/pig/impl/PigContextTest.java
@@ -1,0 +1,24 @@
+package org.jboss.pnc.bacon.pig.impl;
+
+import org.junit.jupiter.api.Test;
+
+import java.nio.file.Path;
+import java.nio.file.Paths;
+import java.util.Optional;
+
+import static org.junit.jupiter.api.Assertions.*;
+
+class PigContextTest {
+
+    @Test
+    void testPrefixGeneration() {
+        Path resourcesFolderPath = Paths.get("src", "test", "resources");
+        PigContext pigContext = new PigContext();
+        pigContext.initConfig(resourcesFolderPath, "targetPath", Optional.empty(), null);
+        assertTrue(
+                pigContext.getPrefix()
+                        .startsWith(pigContext.getPigConfiguration().getOutputPrefixes().getReleaseFile()));
+        assertTrue(pigContext.getPrefix().endsWith(pigContext.getPigConfiguration().getOutputSuffix()));
+        assertTrue(pigContext.getPrefix().contains(pigContext.getPigConfiguration().getVersion()));
+    }
+}

--- a/pig/src/test/java/org/jboss/pnc/bacon/pig/impl/config/PigConfigurationTest.java
+++ b/pig/src/test/java/org/jboss/pnc/bacon/pig/impl/config/PigConfigurationTest.java
@@ -1,0 +1,48 @@
+package org.jboss.pnc.bacon.pig.impl.config;
+
+import org.jeasy.random.EasyRandom;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+
+import static org.junit.jupiter.api.Assertions.*;
+
+class PigConfigurationTest {
+
+    private PigConfiguration generated;
+
+    @BeforeEach
+    void setup() {
+        EasyRandom easyRandom = new EasyRandom();
+        generated = new EasyRandom().nextObject(PigConfiguration.class);
+    }
+
+    @Test
+    void testSuffixSetInTopLevelDirectory() {
+        String suffix = "laboheme";
+        generated.setOutputSuffix(suffix);
+        assertTrue(generated.getTopLevelDirectoryPrefix().endsWith("-" + suffix + "-"));
+        assertTrue(generated.getTopLevelDirectoryPrefix().contains(generated.getVersion()));
+        assertTrue(generated.getTopLevelDirectoryPrefix().contains(generated.getProduct().getStage()));
+
+        generated.setOutputSuffix("");
+        assertFalse(generated.getTopLevelDirectoryPrefix().endsWith("-" + suffix + "-"));
+        // make sure we don't accidentally put 2 '-' if suffix is empty
+        assertFalse(generated.getTopLevelDirectoryPrefix().endsWith("--"));
+        assertTrue(generated.getTopLevelDirectoryPrefix().contains(generated.getVersion()));
+        assertTrue(generated.getTopLevelDirectoryPrefix().contains(generated.getProduct().getStage()));
+
+        generated.setOutputSuffix(null);
+        assertFalse(generated.getTopLevelDirectoryPrefix().endsWith("-" + suffix + "-"));
+        // make sure we don't accidentally put 2 '-' if suffix is empty
+        assertFalse(generated.getTopLevelDirectoryPrefix().endsWith("--"));
+        assertTrue(generated.getTopLevelDirectoryPrefix().contains(generated.getVersion()));
+        assertTrue(generated.getTopLevelDirectoryPrefix().contains(generated.getProduct().getStage()));
+    }
+
+    @Test
+    void testTopLevelDirectoryGeneration() {
+        assertTrue(generated.getTopLevelDirectoryPrefix().startsWith(generated.getOutputPrefixes().getReleaseDir()));
+        assertTrue(generated.getTopLevelDirectoryPrefix().contains(generated.getVersion()));
+        assertTrue(generated.getTopLevelDirectoryPrefix().contains(generated.getProduct().getStage()));
+    }
+}

--- a/pig/src/test/resources/build-config.yaml
+++ b/pig/src/test/resources/build-config.yaml
@@ -1,0 +1,36 @@
+product:
+  name: mszynkie-demo
+  abbreviation: md
+  stage: GA
+  issueTrackerUrl: http://example.com/demo
+version: 1.0.1
+milestone: DR16
+group: mszynkie demo All
+defaultBuildParameters:
+  project: mszynkie-demo
+  environmentName: "OpenJDK 1.8; Mvn 3.3.9"
+  buildScript: mvn clean deploy -DskipTests -B
+builds:
+  - name: foo-1.0
+    scmUrl: https://github.com/michalszynkiewicz/demo-foo
+    scmRevision: 1.0.1
+  - name: bar-1.0
+    scmUrl: https://github.com/michalszynkiewicz/demo-bar
+    scmRevision: 1.0.1
+    dependencies:
+      - foo-1.0
+
+outputPrefixes:
+  releaseFile: mszynkie-demo
+  releaseDir: mszynkie-demo
+outputSuffix: jms
+flow:
+  # licensesGeneration: gen.downloadFrom 'WildFly-Swarm' matching '.*license\.zip'
+  licensesGeneration:
+    strategy: GENERATE
+  repositoryGeneration:
+    strategy: PACK_ALL
+    sourceBuild: bar-1.0
+
+  javadocGeneration:
+    strategy: IGNORE


### PR DESCRIPTION
In NCL-5981, the user would like to provide a suffix for the
deliverables files and folder inside the zips.

For example: <product>-<version>-<suffix>-maven-repository.zip

This commit adds an additional optional field in the build-config.yaml named
'outputSuffix' that when specified, will be used as the suffix.

Example:
```
outputSuffix: picard
```

### Checklist:

* [x] Have you added a note in the [CHANGELOG wiki](https://github.com/project-ncl/bacon/wiki/Changelog) for your change if user-facing?
* [x] Have you added unit tests for your change?
