### PR TITLE
Make excludeArtifacts for resolve only resolution

### DIFF
--- a/pig/src/main/java/org/jboss/pnc/bacon/pig/impl/repo/RepoManager.java
+++ b/pig/src/main/java/org/jboss/pnc/bacon/pig/impl/repo/RepoManager.java
@@ -303,6 +303,11 @@ public class RepoManager extends DeliverableManager<RepoGenerationData, Reposito
         if (!isTestMode) {
             RepositoryUtils.removeCommunityArtifacts(targetRepoContentsDir);
             RepositoryUtils.removeIrrelevantFiles(targetRepoContentsDir);
+
+            // Delete excluded artifacts in the maven-repository. Needed for resolve only generation where filtering
+            // can't be done before download
+            List<String> excludeArtifacts = pigConfiguration.getFlow().getRepositoryGeneration().getExcludeArtifacts();
+            RepositoryUtils.removeExcludedArtifacts(targetRepoContentsDir, excludeArtifacts);
         }
         addMissingSources();
 

--- a/pig/src/test/java/org/jboss/pnc/bacon/pig/impl/repo/RepositoryUtilsTest.java
+++ b/pig/src/test/java/org/jboss/pnc/bacon/pig/impl/repo/RepositoryUtilsTest.java
@@ -1,0 +1,55 @@
+package org.jboss.pnc.bacon.pig.impl.repo;
+
+import org.junit.jupiter.api.Test;
+
+import java.io.File;
+import java.io.IOException;
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.nio.file.Paths;
+
+import static org.junit.jupiter.api.Assertions.*;
+
+class RepositoryUtilsTest {
+
+    @Test
+    void testRecursivelyDeleteEmptyFolder() throws IOException {
+        // temp dirs created
+        // <tmpdir>/<test1>/<test2>/<test4>
+        // <tmpdir>/<test3>
+
+        // when running recursivelyDeleteEmptyFolder applied on test2, nothing should be deleted
+        // when running recursivelyDeleteEmptyFolder applied on test4, only folders test1, test2 and test4 should be
+        // deleted
+        Path tmpDir = Files.createTempDirectory("tmpDir");
+        File test1 = new File(Paths.get(tmpDir.toFile().getAbsolutePath(), "test1").toAbsolutePath().toString());
+        File test2 = new File(
+                Paths.get(tmpDir.toFile().getAbsolutePath(), "test1", "test2").toAbsolutePath().toString());
+        File test3 = new File(Paths.get(tmpDir.toFile().getAbsolutePath(), "test3").toAbsolutePath().toString());
+        File test4 = new File(
+                Paths.get(tmpDir.toFile().getAbsolutePath(), "test1", "test2", "test4").toAbsolutePath().toString());
+        test3.mkdirs();
+        test4.mkdirs();
+        RepositoryUtils.recursivelyDeleteEmptyFolder(test2);
+        assertTrue(test2.exists());
+
+        RepositoryUtils.recursivelyDeleteEmptyFolder(test4);
+        assertFalse(test1.exists());
+        assertFalse(test2.exists());
+        assertFalse(test4.exists());
+        assertTrue(tmpDir.toFile().exists());
+        assertTrue(test3.exists());
+    }
+
+    @Test
+    void testConvertMavenIdentifierToPath() {
+        String identifier = "test.me.here:letmego:tar:1.2.3";
+        String path = RepositoryUtils.convertMavenIdentifierToPath(identifier);
+        assertEquals(Paths.get("test", "me", "here", "letmego", "1.2.3", "letmego-1.2.3.tar").toFile().getPath(), path);
+
+        String identifierWrong = "test.me.here:letmego:1.2.3";
+        assertThrows(
+                IllegalArgumentException.class,
+                () -> RepositoryUtils.convertMavenIdentifierToPath(identifierWrong));
+    }
+}


### PR DESCRIPTION
The `excludeArtifacts` in the maven repository section for PiG works for
most maven repository generation except for RESOLVE_ONLY. This commit
adds the ability to use `excludeArtifacts` with RESOLVE_ONLY

The implementation works by first generating the final maven repository
from the bom specified, then deleting the artifacts in
`excludeArtifacts` from that maven repository.

The artifacts are specified in "Maven Identifier" format (aka
`<group-id>:<artifact-id>:<packaging>:<version>`). We convert that Maven
identifier into a filesystem path inside the maven repository folder and
delete it. Regexes are supported.

The other option was to generate the maven repository with the excluded
artifacts specified as exclusions. But I couldn't find any way to do
that using the Maven Resolver object.

### Checklist:

* [ ] Have you added a note in the [CHANGELOG wiki](https://github.com/project-ncl/bacon/wiki/Changelog) for your change if user-facing?
* [x] Have you added unit tests for your change?
