### PR TITLE
Fix check for correct gav formatting

### DIFF
--- a/pig/src/main/java/org/jboss/pnc/bacon/pig/impl/repo/RepoManager.java
+++ b/pig/src/main/java/org/jboss/pnc/bacon/pig/impl/repo/RepoManager.java
@@ -545,7 +545,7 @@ public class RepoManager extends DeliverableManager<RepoGenerationData, Reposito
                     continue;
                 }
                 String[] parts = buffer.split(":");
-                if (parts.length < 2 || parts.length > 5) {
+                if (parts.length < 3 || parts.length > 5) {
                     throw new RuntimeException("Extension text file is not properly formatted");
                 }
 


### PR DESCRIPTION
https://project-ncl.github.io/bacon/guide/build-config.html#maven-repository-generation G:A:V is required but we're testing if at least 2 things are present, creating out of bounds error when user wrongly formatted file

### Checklist:

* [ ] Have you added a note in the [CHANGELOG wiki](https://github.com/project-ncl/bacon/wiki/Changelog) for your change if user-facing?
* [ ] Have you added unit tests for your change?
