### PR TITLE
Remove maven-embedder to fix dependency issue for licenses generator

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -77,7 +77,7 @@
         <jackson.version>2.13.1</jackson.version>
         <jaxb.version>2.2.11</jaxb.version>
         <junit.version>5.8.2</junit.version>
-        <maven-core.version>3.8.4</maven-core.version>
+        <maven-core.version>3.6.3</maven-core.version>
         <maven.compiler.source>11</maven.compiler.source>
         <maven.compiler.target>11</maven.compiler.target>
 
@@ -416,41 +416,6 @@
                     <exclusion>
                         <groupId>javax.inject</groupId>
                         <artifactId>javax.inject</artifactId>
-                    </exclusion>
-                    <exclusion>
-                        <groupId>org.slf4j</groupId>
-                        <artifactId>slf4j-api</artifactId>
-                    </exclusion>
-                </exclusions>
-            </dependency>
-            <dependency>
-                <groupId>org.apache.maven</groupId>
-                <artifactId>maven-embedder</artifactId>
-                <version>${maven-core.version}</version>
-                <exclusions>
-                    <exclusion>
-                        <groupId>org.sonatype.plexus</groupId>
-                        <artifactId>plexus-sec-dispatcher</artifactId>
-                    </exclusion>
-                    <exclusion>
-                        <groupId>org.sonatype.plexus</groupId>
-                        <artifactId>plexus-cipher</artifactId>
-                    </exclusion>
-                    <exclusion>
-                        <groupId>javax.annotation</groupId>
-                        <artifactId>jsr250-api</artifactId>
-                    </exclusion>
-                    <exclusion>
-                        <groupId>javax.inject</groupId>
-                        <artifactId>javax.inject</artifactId>
-                    </exclusion>
-                    <exclusion>
-                        <groupId>javax.enterprise</groupId>
-                        <artifactId>cdi-api</artifactId>
-                    </exclusion>
-                    <exclusion>
-                        <groupId>org.checkerframework</groupId>
-                        <artifactId>checker-qual</artifactId>
                     </exclusion>
                     <exclusion>
                         <groupId>org.slf4j</groupId>


### PR DESCRIPTION
### Checklist:
licenses-generator uses org.jenkins-ci.lib:lib-jenkins-maven-embedder dependency which I would call obsolete, if there is no other suggestion how to solve this we need to dedicate time to upgrade licenses generator to use maven-embedder from apache or not upgrade above mvn 3.6.x as there is breaking change in ArtifactRepository (I believe) 