### PR TITLE
[NCLSUP-624] Run `beforeCommand` for pig run command

### DIFF
--- a/pig/src/main/java/org/jboss/pnc/bacon/pig/PigFacade.java
+++ b/pig/src/main/java/org/jboss/pnc/bacon/pig/PigFacade.java
@@ -155,6 +155,7 @@ public final class PigFacade {
             boolean strictDownloadSource,
             Path configurationDirectory) {
 
+        beforeCommand(false);
         PigContext context = context();
 
         ImportResult importResult;


### PR DESCRIPTION
This is needed to properly set the full version of the product.
Otherwise Bacon PiG fails later with the full version not being set.

This is thanks to a bug report from @lbossis !

### Checklist:

* [ ] Have you added a note in the [CHANGELOG wiki](https://github.com/project-ncl/bacon/wiki/Changelog) for your change if user-facing?
* [ ] Have you added unit tests for your change?
