### PR TITLE
Fix for excludeArtifacts on PiG maven repo generation as classifier w…

### DIFF
--- a/pig/src/main/java/org/jboss/pnc/bacon/pig/impl/repo/RepositoryUtils.java
+++ b/pig/src/main/java/org/jboss/pnc/bacon/pig/impl/repo/RepositoryUtils.java
@@ -313,9 +313,10 @@ public class RepositoryUtils {
      */
     public static String convertMavenIdentifierToPath(String identifier) {
         String[] sections = identifier.split(":");
-        if (sections.length != 4) {
+        if (sections.length != 4 && sections.length != 5) {
             throw new IllegalArgumentException(
-                    identifier + " is wrongly formatted! It should be <group-id>:<artifact-id>:<packaging>:<version>");
+                    identifier
+                            + " is wrongly formatted! It should be <group-id>:<artifact-id>:<packaging>:<version>:<classifier>");
         }
         String fileSeparator = System.getProperty("file.separator");
 
@@ -323,8 +324,12 @@ public class RepositoryUtils {
         String artifactId = sections[1];
         String packaging = sections[2];
         String version = sections[3];
+        String classifier = "";
+        if (sections.length == 5) {
+            classifier = "-" + sections[4];
+        }
         return groupId + fileSeparator + artifactId + fileSeparator + version + fileSeparator + artifactId + "-"
-                + version + "." + packaging;
+                + version + classifier + "." + packaging;
     }
 
     private static class RedHatArtifactVersion {

--- a/pig/src/test/java/org/jboss/pnc/bacon/pig/impl/repo/RepositoryUtilsTest.java
+++ b/pig/src/test/java/org/jboss/pnc/bacon/pig/impl/repo/RepositoryUtilsTest.java
@@ -47,6 +47,12 @@ class RepositoryUtilsTest {
         String path = RepositoryUtils.convertMavenIdentifierToPath(identifier);
         assertEquals(Paths.get("test", "me", "here", "letmego", "1.2.3", "letmego-1.2.3.tar").toFile().getPath(), path);
 
+        identifier = "test.me.here:letmego:zip:1.2.3:docs";
+        path = RepositoryUtils.convertMavenIdentifierToPath(identifier);
+        assertEquals(
+                Paths.get("test", "me", "here", "letmego", "1.2.3", "letmego-1.2.3-docs.zip").toFile().getPath(),
+                path);
+
         String identifierWrong = "test.me.here:letmego:1.2.3";
         assertThrows(
                 IllegalArgumentException.class,


### PR DESCRIPTION
…as ignored so no match with converted GAPVC could be made only GAPV was working

### Checklist:

* [ ] Have you added a note in the [CHANGELOG wiki](https://github.com/project-ncl/bacon/wiki/Changelog) for your change if user-facing?
* [ ] Have you added unit tests for your change?
