### PR TITLE
This PiG addon allows the use of the CPaaS Product Security Scan as a Service

### DIFF
--- a/pig/pom.xml
+++ b/pig/pom.xml
@@ -155,6 +155,11 @@
             <scope>test</scope>
         </dependency>
         <dependency>
+            <groupId>org.junit.jupiter</groupId>
+            <artifactId>junit-jupiter-params</artifactId>
+            <scope>test</scope>
+        </dependency>
+        <dependency>
             <groupId>org.assertj</groupId>
             <artifactId>assertj-core</artifactId>
             <scope>test</scope>

--- a/pig/src/main/java/org/jboss/pnc/bacon/pig/impl/addons/AddOnFactory.java
+++ b/pig/src/main/java/org/jboss/pnc/bacon/pig/impl/addons/AddOnFactory.java
@@ -24,6 +24,7 @@ import org.jboss.pnc.bacon.pig.impl.addons.quarkus.QuarkusPostBuildAnalyzer;
 import org.jboss.pnc.bacon.pig.impl.addons.quarkus.VertxArtifactFinder;
 import org.jboss.pnc.bacon.pig.impl.addons.rhba.OfflineManifestGenerator;
 import org.jboss.pnc.bacon.pig.impl.addons.runtime.RuntimeDependenciesAnalyzer;
+import org.jboss.pnc.bacon.pig.impl.addons.scanservice.PostBuildScanService;
 import org.jboss.pnc.bacon.pig.impl.addons.spring.BomVerifierAddon;
 import org.jboss.pnc.bacon.pig.impl.addons.vertx.NotYetAlignedFromDependencyTree;
 import org.jboss.pnc.bacon.pig.impl.config.PigConfiguration;
@@ -59,6 +60,7 @@ public class AddOnFactory {
         resultList.add(new QuarkusPostBuildAnalyzer(pigConfiguration, builds, releasePath, extrasPath));
         resultList.add(new OfflineManifestGenerator(pigConfiguration, builds, releasePath, extrasPath));
         resultList.add(new VertxArtifactFinder(pigConfiguration, builds, releasePath, extrasPath));
+        resultList.add(new PostBuildScanService(pigConfiguration, builds, releasePath, extrasPath));
         return resultList;
     }
 

--- a/pig/src/main/java/org/jboss/pnc/bacon/pig/impl/addons/scanservice/PostBuildScanService.java
+++ b/pig/src/main/java/org/jboss/pnc/bacon/pig/impl/addons/scanservice/PostBuildScanService.java
@@ -1,0 +1,185 @@
+package org.jboss.pnc.bacon.pig.impl.addons.scanservice;
+
+import com.fasterxml.jackson.core.JsonProcessingException;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import org.jboss.pnc.bacon.config.Validate;
+import org.jboss.pnc.bacon.pig.impl.addons.AddOn;
+import org.jboss.pnc.bacon.pig.impl.addons.scanservice.pssaas.ScanHelper;
+import org.jboss.pnc.bacon.pig.impl.config.PigConfiguration;
+import org.jboss.pnc.bacon.pig.impl.pnc.PncBuild;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+import javax.ws.rs.core.Response;
+
+import java.net.URI;
+import java.net.URISyntaxException;
+import java.util.*;
+import java.util.stream.Collectors;
+
+public class PostBuildScanService extends AddOn implements Validate {
+    private static final Logger log = LoggerFactory.getLogger(PostBuildScanService.class);
+    private static final String ADDON_SCAN_SERVICE_MAP_KEY = "postBuildScanService";
+
+    private static final Set<String> mandatoryItems = new HashSet<>();
+    static {
+        mandatoryItems.add("productID");
+        mandatoryItems.add("serviceUrl");
+        mandatoryItems.add("serviceSecretKey");
+        mandatoryItems.add("serviceSecretValue");
+    }
+
+    private static final Set<String> masterSet = new HashSet<>();
+    static {
+        masterSet.add("productID");
+        masterSet.add("eventId");
+        masterSet.add("isManagedService");
+        masterSet.add("cpaasVersion");
+        masterSet.add("jobUrl");
+        masterSet.add("serviceUrl");
+        masterSet.add("serviceSecretKey");
+        masterSet.add("serviceSecretValue");
+        masterSet.add("brewBuilds");
+        masterSet.add("extraScmUrls");
+        masterSet.add("extraBuilds");
+        masterSet.add("scmUrl");
+        masterSet.add("scmRevision");
+        masterSet.add("name");
+    }
+
+    Map<String, ?> postBuildScanConfigMap;
+
+    public PostBuildScanService(
+            PigConfiguration pigConfiguration,
+            Map<String, PncBuild> builds,
+            String releasePath,
+            String extrasPath) {
+        super(pigConfiguration, builds, releasePath, extrasPath);
+    }
+
+    @Override
+    protected String getName() {
+        return ADDON_SCAN_SERVICE_MAP_KEY;
+    }
+
+    @Override
+    public void trigger() {
+        Map<String, Map<String, ?>> addonsMap = pigConfiguration.getAddons();
+        postBuildScanConfigMap = addonsMap.get(ADDON_SCAN_SERVICE_MAP_KEY);
+        ScanServiceDTO scanServiceDTO = createScanServiceDTO();
+        if (scanServiceDTO == null) {
+            log.error("Unable to create DTO");
+            throw new RuntimeException("Unable to create DTO");
+        }
+        this.validate();
+        sendScanRequest(scanServiceDTO);
+    }
+
+    private void sendScanRequest(ScanServiceDTO scanServiceDTO) {
+        try {
+            ScanHelper pssaasService = new ScanHelper(
+                    this.getServiceSecretKey(),
+                    this.getServiceSecretValue(),
+                    this.getServiceUrl());
+            Response response = pssaasService.client.triggerScan(scanServiceDTO);
+            response.close();
+        } catch (URISyntaxException e) {
+            log.error("Invalid URI: {}", e.getMessage());
+            throw new RuntimeException("sendScanRequest call failed");
+        }
+    }
+
+    void validateMapKeys(Map<String, ?> map) throws ConfigMissingException {
+        for (Map.Entry<String, ?> entry : map.entrySet()) {
+            String key = entry.getKey();
+            if (!masterSet.contains(key)) {
+                Validate.fail("'" + key + "' is not a valid build-config.yaml parameter");
+            }
+            Object value = entry.getValue();
+            if (value instanceof List) {
+                List<?> lst = (List<?>) value;
+                if (lst.get(0) instanceof Map) {
+                    int i = 0;
+                    while (i < lst.size()) {
+                        Map<String, ?> subMap = (Map<String, ?>) lst.get(i);
+                        validateMapKeys(subMap);
+                        i++;
+                    }
+                }
+            } else if (value instanceof Map) {
+                Map<String, ?> subMap = (Map<String, ?>) value;
+                validateMapKeys(subMap);
+            }
+        }
+    }
+
+    void checkPresenceOfMandatoryFields(Map<String, ?> map) throws ConfigMissingException {
+        for (String item : mandatoryItems) {
+            List<String> items = map.keySet()
+                    .stream()
+                    .filter(k -> k.trim().contains(item))
+                    .collect(Collectors.toList());
+            if (items.size() != 1) {
+                Validate.fail(" mandatory field '" + item + "' not provided");
+            }
+        }
+    }
+
+    /* Validate our addon config */
+    @Override
+    public void validate() {
+        validateMapKeys(postBuildScanConfigMap);
+        checkPresenceOfMandatoryFields(postBuildScanConfigMap);
+        Validate.validateUrl((String) postBuildScanConfigMap.get("serviceUrl"), "PSSaaS");
+    }
+
+    private ScanServiceDTO createScanServiceDTO() {
+        String s = postBuildScanConfigMap.get("productID").toString();
+        String productId = s;
+        if (s == null || s.isEmpty()) {
+            log.error("Missing mandatory parameter Product ID");
+            return null;
+        }
+        s = (String) postBuildScanConfigMap.get("EventId");
+        String eventId = (s != null && !s.isEmpty()) ? s : ScanServiceDTO.EVENT_ID_DFT_VALUE;
+
+        s = (String) postBuildScanConfigMap.get("cpaasVersion");
+        String cpaasVersion = (s != null && !s.isEmpty()) ? s : ScanServiceDTO.CPAAS_VERSION_DFT_VALUE;
+
+        s = (String) postBuildScanConfigMap.get("jobUrl");
+        String jobUrl = (s != null && !s.isEmpty()) ? s : ScanServiceDTO.JOB_URL_DFT_VALUE;
+
+        Boolean b = (Boolean) postBuildScanConfigMap.get("isManagedService");
+        Boolean isManagedService = (b != null) ? b : ScanServiceDTO.IS_MANAGED_SERVICE_DFT_VALUE;
+
+        List<Integer> brewBuilds = (List<Integer>) postBuildScanConfigMap.get("brewBuilds");
+
+        List<Map<String, String>> extraSCMURLs = (List<Map<String, String>>) postBuildScanConfigMap.get("extraScmUrls");
+
+        return new ScanServiceDTO(
+                productId,
+                eventId,
+                isManagedService,
+                cpaasVersion,
+                jobUrl,
+                brewBuilds,
+                extraSCMURLs,
+                builds);
+    }
+
+    public static String showDTOfields(ScanServiceDTO ssDTO) throws JsonProcessingException {
+        return new ObjectMapper().writerWithDefaultPrettyPrinter().writeValueAsString(ssDTO);
+    }
+
+    private URI getServiceUrl() throws URISyntaxException {
+        return new URI((String) postBuildScanConfigMap.get("serviceUrl"));
+    }
+
+    private String getServiceSecretKey() {
+        return (String) postBuildScanConfigMap.get("serviceSecretKey");
+    }
+
+    private String getServiceSecretValue() {
+        return (String) postBuildScanConfigMap.get("serviceSecretValue");
+    }
+}

--- a/pig/src/main/java/org/jboss/pnc/bacon/pig/impl/addons/scanservice/ScanServiceDTO.java
+++ b/pig/src/main/java/org/jboss/pnc/bacon/pig/impl/addons/scanservice/ScanServiceDTO.java
@@ -1,0 +1,319 @@
+package org.jboss.pnc.bacon.pig.impl.addons.scanservice;
+
+import com.fasterxml.jackson.annotation.JsonAnyGetter;
+import com.fasterxml.jackson.annotation.JsonAnySetter;
+import com.fasterxml.jackson.annotation.JsonIgnore;
+import com.fasterxml.jackson.annotation.JsonInclude;
+import com.fasterxml.jackson.annotation.JsonProperty;
+import com.fasterxml.jackson.annotation.JsonPropertyDescription;
+import com.fasterxml.jackson.annotation.JsonPropertyOrder;
+import lombok.Getter;
+import lombok.Setter;
+import org.jboss.pnc.bacon.pig.impl.pnc.PncBuild;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+import java.io.UnsupportedEncodingException;
+import java.net.URI;
+import java.net.URISyntaxException;
+import java.net.URLDecoder;
+import java.net.URLEncoder;
+import java.nio.charset.StandardCharsets;
+import java.util.ArrayList;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+import java.util.stream.Collectors;
+
+import static java.lang.String.*;
+
+/**
+ * PSSC scanning container interface
+ * <p>
+ *
+ *
+ */
+@JsonInclude(JsonInclude.Include.NON_NULL)
+@JsonPropertyOrder({ "product-id", "event-id", "is-managed-service", "cpaas-version", "job-url", "component-list" })
+
+public class ScanServiceDTO {
+    private static final Logger log = LoggerFactory.getLogger(ScanServiceDTO.class);
+
+    public static final String EVENT_ID_DFT_VALUE = "dft-event-id";
+    public static final Boolean IS_MANAGED_SERVICE_DFT_VALUE = false;
+    public static final String CPAAS_VERSION_DFT_VALUE = "latest";
+    public static final String JOB_URL_DFT_VALUE = "dft-job-url";
+
+    /* Default Constructor */
+    ScanServiceDTO() {
+        eventId = EVENT_ID_DFT_VALUE;
+        isManagedService = IS_MANAGED_SERVICE_DFT_VALUE;
+        cpaasVersion = CPAAS_VERSION_DFT_VALUE;
+        jobUrl = JOB_URL_DFT_VALUE;
+    }
+
+    /**
+     * For each build the type (brew, pnc or git [scmurl])
+     */
+    public enum buildType {
+        brew, pnc, git
+    }
+
+    /**
+     * The product ID associated with the scan. (Required)
+     *
+     */
+    @JsonProperty("product-id")
+    @JsonPropertyDescription("The product ID associated with the scan")
+    @Getter
+    @Setter
+    private String productId;
+
+    /**
+     * The submission event ID associated with the scan.
+     *
+     */
+    @JsonProperty("event-id")
+    @JsonPropertyDescription("The submission event ID associated with the scan")
+    @Getter
+    @Setter
+    private String eventId;
+
+    /**
+     * Indicates whether or not the product is a managed service. (Required)
+     *
+     */
+    @JsonProperty("is-managed-service")
+    @JsonPropertyDescription("Indicates whether or not the product is a managed service")
+    @Getter
+    @Setter
+    private Boolean isManagedService;
+
+    /**
+     * The version of CPaaS that submitted the scan.
+     *
+     */
+    @JsonProperty("cpaas-version")
+    @JsonPropertyDescription("The version of CPaaS that submitted the scan")
+    @Getter
+    @Setter
+    private String cpaasVersion;
+
+    /**
+     * URL of Jenkins job that submitted the scan
+     *
+     */
+    @JsonProperty("job-url")
+    @JsonPropertyDescription("URL of Jenkins job that submitted the scan")
+    @Getter
+    @Setter
+    private String jobUrl;
+
+    /**
+     * The Additional Builds associated with the scan
+     *
+     */
+    @JsonProperty("component-list")
+    @JsonPropertyDescription("The builds associated with the scan")
+    private List<Object> componentList = new ArrayList<>();
+
+    @JsonIgnore
+    private Map<String, Object> additionalProperties = new HashMap<>();
+
+    /**
+     *
+     * @param productId (mandatory) The product ID as defined in product pages, this is used for sorting generated scan
+     *        reports
+     * @param eventId (optional) CPaaS eventId
+     * @param isManagedService (optional) If the build is from a Managed Service build
+     * @param cpaasVersion (optional) The version of the scan container image to use, this should normally be "latest"
+     * @param jobUrl (optional) The pipeline job submitting the scan request
+     * @param brewBuilds (optional) Extra list of brew builds (by Integer)
+     * @param extraSCMURLs (optional) Extra list of git repos and revisions
+     * @param pncBuilds (optional) Extra list of PncBuilds (stub)
+     *
+     *        For non-provided optional parameters in the build-config.yaml file default values will be passed-in by the
+     *        caller of this constructor.
+     *
+     */
+
+    public ScanServiceDTO(
+            String productId,
+            String eventId,
+            Boolean isManagedService,
+            String cpaasVersion,
+            String jobUrl,
+            List<Integer> brewBuilds,
+            List<Map<String, String>> extraSCMURLs,
+            Map<String, PncBuild> pncBuilds) {
+        super();
+        this.productId = productId;
+        this.eventId = eventId;
+        this.isManagedService = isManagedService;
+        this.cpaasVersion = cpaasVersion;
+        this.jobUrl = jobUrl;
+        this.componentList = fromPncBuilds(pncBuilds);
+        if (brewBuilds != null) {
+            brewBuilds.stream().forEach(b -> this.addBrewBuild(b));
+        }
+        if (extraSCMURLs != null) {
+            extraSCMURLs.stream().forEach(scm -> this.addSCMURLs(scm));
+        }
+    }
+
+    private static String safeURL(String repo, String ref) throws UnsupportedEncodingException {
+        String url = URLDecoder
+                .decode(URLEncoder.encode(repo, StandardCharsets.UTF_8.toString()), StandardCharsets.UTF_8.toString());
+        String fragment = URLEncoder.encode(ref, StandardCharsets.UTF_8.toString());
+        return format("%s#%s", url, fragment);
+    }
+
+    private List<Object> fromPncBuilds(Map<String, PncBuild> builds) {
+        return builds.entrySet().stream().map(b -> new ScanServiceDTO.build(b.getValue())).collect(Collectors.toList());
+    }
+
+    public void addBrewBuilds(List<Integer> builds) {
+        builds.stream().forEach(b -> this.addBrewBuild(b));
+    }
+
+    public void addBrewBuild(Integer build) {
+        this.componentList.add(new ScanServiceDTO.build(build));
+    }
+
+    public void addPncBuilds(Map<String, PncBuild> builds) {
+        this.componentList.addAll(fromPncBuilds(builds));
+    }
+
+    public void addPncBuild(PncBuild build) {
+        this.componentList.add(new ScanServiceDTO.build(build));
+    }
+
+    public void addSCMUrl(String scmURL) {
+        this.componentList.add(new ScanServiceDTO.git(scmURL));
+    }
+
+    public void addSCMUrl(String repo, String ref) {
+        try {
+            this.componentList.add(new git(repo, ref));
+        } catch (UnsupportedEncodingException e) {
+            e.printStackTrace();
+        }
+    }
+
+    public void addSCMURLs(Map<String, String> scmUrls) {
+        this.addSCMUrl(scmUrls.get("scmUrl"), scmUrls.get("scmRevision"));
+    }
+
+    /**
+     * The product ID associated with the scan. (Required)
+     *
+     */
+    public ScanServiceDTO withProductId(String productId) {
+        this.productId = productId;
+        return this;
+    }
+
+    /**
+     * The submission event ID associated with the scan
+     *
+     */
+    public ScanServiceDTO withEventId(String eventId) {
+        this.eventId = eventId;
+        return this;
+    }
+
+    /**
+     * Indicates whether or not the product is a managed service
+     *
+     */
+    public ScanServiceDTO withIsManagedService(Boolean isManagedService) {
+        this.isManagedService = isManagedService;
+        return this;
+    }
+
+    /**
+     * The version of CPaaS that submitted the scan
+     *
+     */
+    public ScanServiceDTO withCpaasVersion(String cpaasVersion) {
+        this.cpaasVersion = cpaasVersion;
+        return this;
+    }
+
+    /**
+     * URL of Jenkins job that submitted the scan
+     *
+     */
+    public ScanServiceDTO withJobUrl(String jobUrl) {
+        this.jobUrl = jobUrl;
+        return this;
+    }
+
+    @JsonAnyGetter
+    public Map<String, Object> getAdditionalProperties() {
+        return this.additionalProperties;
+    }
+
+    @JsonAnySetter
+    public void setAdditionalProperty(String name, Object value) {
+        this.additionalProperties.put(name, value);
+    }
+
+    public ScanServiceDTO withAdditionalProperty(String name, Object value) {
+        this.additionalProperties.put(name, value);
+        return this;
+    }
+
+    private final class build {
+        private build(PncBuild build) {
+            this.type = buildType.pnc;
+            this.buildId = build.getId();
+        }
+
+        private build(Integer brewBuild) {
+            this.type = buildType.brew;
+            this.buildId = brewBuild.toString();
+        }
+
+        @JsonProperty("type")
+        private buildType type;
+
+        @JsonProperty("build-id")
+        private String buildId;
+    }
+
+    private final class git {
+        @JsonProperty("type")
+        private buildType type;
+
+        @JsonProperty("repo")
+        private String repo;
+
+        @JsonProperty("ref")
+        private String ref;
+
+        private git(String repo, String ref) throws UnsupportedEncodingException {
+            this(ScanServiceDTO.safeURL(repo, ref));
+        }
+
+        /*
+         * Constructor for git://github.com/foo/bar.git#2.0.0 style SCMURLs and some kind of validation
+         */
+        private git(String scmUrl) {
+            this.type = buildType.git;
+            try {
+                URI uri = new URI(scmUrl);
+                this.ref = uri.getFragment();
+                // Strip fragment and use original string rather than building a new one from URI
+                int index = scmUrl.indexOf(URLEncoder.encode(this.ref, StandardCharsets.UTF_8.toString()));
+                this.repo = scmUrl.substring(0, index - 1);
+            } catch (URISyntaxException e) {
+                log.error("Invalid scmUrl");
+                throw new RuntimeException(e);
+            } catch (UnsupportedEncodingException e) {
+                log.error("Unsupported encoding in SCMURL");
+                throw new RuntimeException(e);
+            }
+        }
+    }
+}

--- a/pig/src/main/java/org/jboss/pnc/bacon/pig/impl/addons/scanservice/pssaas/AddAuthHeadersRequestFilter.java
+++ b/pig/src/main/java/org/jboss/pnc/bacon/pig/impl/addons/scanservice/pssaas/AddAuthHeadersRequestFilter.java
@@ -1,0 +1,27 @@
+package org.jboss.pnc.bacon.pig.impl.addons.scanservice.pssaas;
+
+import javax.ws.rs.client.ClientRequestContext;
+import javax.ws.rs.client.ClientRequestFilter;
+
+import java.io.IOException;
+import java.util.Map;
+import java.util.TreeMap;
+
+public class AddAuthHeadersRequestFilter implements ClientRequestFilter {
+    private Map<String, String> headers = new TreeMap<String, String>();
+
+    public AddAuthHeadersRequestFilter(Map<String, String> headers) {
+        this.headers = headers;
+    }
+
+    public void addAuthHeader(String key, String value) {
+        this.headers.put(key, value);
+    }
+
+    @Override
+    public void filter(ClientRequestContext requestContext) throws IOException {
+        for (Map.Entry<String, String> entry : this.headers.entrySet()) {
+            requestContext.getHeaders().add(entry.getKey(), entry.getValue());
+        }
+    }
+}

--- a/pig/src/main/java/org/jboss/pnc/bacon/pig/impl/addons/scanservice/pssaas/RedirectAndLog.java
+++ b/pig/src/main/java/org/jboss/pnc/bacon/pig/impl/addons/scanservice/pssaas/RedirectAndLog.java
@@ -1,0 +1,50 @@
+package org.jboss.pnc.bacon.pig.impl.addons.scanservice.pssaas;
+
+import org.apache.commons.io.IOUtils;
+import org.jboss.pnc.bacon.pig.impl.addons.scanservice.PostBuildScanService;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+import javax.ws.rs.client.ClientRequestContext;
+import javax.ws.rs.client.ClientResponseContext;
+import javax.ws.rs.client.ClientResponseFilter;
+import javax.ws.rs.client.Entity;
+
+import java.io.BufferedInputStream;
+import java.io.IOException;
+
+import static org.apache.commons.io.IOUtils.toInputStream;
+
+public class RedirectAndLog implements ClientResponseFilter {
+    private static final Logger log = LoggerFactory.getLogger(PostBuildScanService.class);
+
+    @Override
+    public void filter(ClientRequestContext requestContext, ClientResponseContext responseContext) {
+
+        // 302 redirect as underlying Apache Http client does not handle redirects with POST requests (only get)
+        if (responseContext.getStatus() == 302) {
+            // Make the request again
+            requestContext.getClient()
+                    .target(responseContext.getLocation())
+                    .request()
+                    .headers(requestContext.getHeaders())
+                    .method(requestContext.getMethod(), Entity.json(requestContext.getEntity()));
+
+        }
+
+        // Log all responses, we don't actually need to handle them
+        if (responseContext.hasEntity()) {
+            // Read the output stream of the request object, then write back the string value, if we don#t write it back
+            // the entity wil be null
+            BufferedInputStream stream = new BufferedInputStream(responseContext.getEntityStream());
+            String payload = null;
+            try {
+                payload = IOUtils.toString(stream, "UTF-8");
+                log.info("PSSaaS Service Response: " + payload);
+                responseContext.setEntityStream(toInputStream(payload, "UTF-8"));
+            } catch (IOException e) {
+                log.error(e.toString());
+            }
+        }
+    }
+}

--- a/pig/src/main/java/org/jboss/pnc/bacon/pig/impl/addons/scanservice/pssaas/ScanHelper.java
+++ b/pig/src/main/java/org/jboss/pnc/bacon/pig/impl/addons/scanservice/pssaas/ScanHelper.java
@@ -1,0 +1,23 @@
+package org.jboss.pnc.bacon.pig.impl.addons.scanservice.pssaas;
+
+import org.jboss.resteasy.client.jaxrs.ResteasyClientBuilder;
+
+import java.net.URI;
+import java.util.Map;
+import java.util.TreeMap;
+
+public class ScanHelper {
+
+    public ScanInterface client;
+    private static Map<String, String> authHeaders = new TreeMap<String, String>();
+
+    public ScanHelper(String pssaasSecretKey, String pssaasSecretValue, URI target) {
+        authHeaders.put("PSSC-Secret-Key", pssaasSecretKey);
+        authHeaders.put("PSSC-Secret-Value", pssaasSecretValue);
+        client = new ResteasyClientBuilder().build()
+                .target(target)
+                .register(new AddAuthHeadersRequestFilter(authHeaders))
+                .register(new RedirectAndLog())
+                .proxy(ScanInterface.class);
+    }
+}

--- a/pig/src/main/java/org/jboss/pnc/bacon/pig/impl/addons/scanservice/pssaas/ScanInterface.java
+++ b/pig/src/main/java/org/jboss/pnc/bacon/pig/impl/addons/scanservice/pssaas/ScanInterface.java
@@ -1,0 +1,15 @@
+package org.jboss.pnc.bacon.pig.impl.addons.scanservice.pssaas;
+
+import org.jboss.pnc.bacon.pig.impl.addons.scanservice.ScanServiceDTO;
+
+import javax.ws.rs.*;
+import javax.ws.rs.core.MediaType;
+import javax.ws.rs.core.Response;
+
+public interface ScanInterface {
+
+    @POST
+    @Path("/")
+    @Consumes({ MediaType.APPLICATION_JSON })
+    Response triggerScan(ScanServiceDTO builds);
+}

--- a/pig/src/test/java/org/jboss/pnc/bacon/pig/impl/addons/scanservice/MockScanServiceTest.java
+++ b/pig/src/test/java/org/jboss/pnc/bacon/pig/impl/addons/scanservice/MockScanServiceTest.java
@@ -1,0 +1,215 @@
+package org.jboss.pnc.bacon.pig.impl.addons.scanservice;
+
+import com.fasterxml.jackson.core.JsonProcessingException;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import com.github.tomakehurst.wiremock.WireMockServer;
+import com.github.tomakehurst.wiremock.stubbing.StubMapping;
+import com.github.tomakehurst.wiremock.verification.LoggedRequest;
+import org.jboss.pnc.bacon.pig.impl.addons.scanservice.pssaas.ScanHelper;
+import org.jboss.pnc.bacon.pig.impl.pnc.PncBuild;
+import org.jeasy.random.EasyRandom;
+import org.junit.jupiter.api.*;
+
+import javax.ws.rs.core.Response;
+
+import java.io.IOException;
+import java.net.URI;
+import java.net.URISyntaxException;
+import java.util.List;
+
+import static com.github.tomakehurst.wiremock.client.WireMock.*;
+import static com.github.tomakehurst.wiremock.core.WireMockConfiguration.options;
+import static org.junit.jupiter.api.Assertions.*;
+
+@TestInstance(TestInstance.Lifecycle.PER_CLASS)
+public class MockScanServiceTest {
+
+    private WireMockServer mockServer;
+    private WireMockServer redirectServer;
+
+    // Mock Server information
+    private static final String WIREMOCK_HOST = "http://localhost";
+    private static int WIREMOCK_PORT;
+    private static int REDIRECT_PORT;
+
+    // Secret headers PSSaaS takes, and their values
+    private static final String HEADER_SECRET_KEY = "PSSC-Secret-Key";
+    private static final String HEADER_SECRET_VALUE = "PSSC-Secret-Value";
+
+    private static final String HEADER_CONTENT_TYPE = "Content-Type";
+    private static final String CONTENT_TYPE_JSON = "application/json";
+
+    // Scan Invoke Request Information
+    private static final String SCAN_INVOKE_URL = "/";
+    private static final String SCAN_INVOKE_REQ_BODY_JSON = "{    \"product-id\": \"jochrist-dev-test-hawtio\",    \"is-managed-service\": false,    \"cpaas-version\": \"latest\",    \"component-list\": [        {            \"type\": \"pnc\",            \"build-id\": \"101305\"        }    ]}";
+    private static final String SCAN_INVOKE_RESPONSE_BODY = "{\"eventListener\":\"pssc-scan-listener\",\"namespace\":\"pssaas-service\",\"eventListenerUID\":\"d67eafe1-d0dc-4b37-9395-a574afbae1f7\",\"eventID\":\"6a730728-8226-4c02-bc04-bb4c66b9d9c4\"}";
+    private static final int SCAN_INVOKE_RESPONSE_STATUS = 202;
+
+    // For PNC Build dummy data
+    static EasyRandom easyRandom = new EasyRandom();
+
+    @BeforeAll
+    private void startMockService() {
+        mockServer = new WireMockServer(options().dynamicPort());
+        mockServer.start();
+        WIREMOCK_PORT = mockServer.port();
+        redirectServer = new WireMockServer(options().dynamicPort());
+        redirectServer.start();
+        REDIRECT_PORT = redirectServer.port();
+        System.out.println("Wiremock ports: Main->" + mockServer.port() + " Redirect->" + redirectServer.port());
+    }
+
+    @BeforeEach
+    private void clearStubs() {
+        // remove stubs before each test
+        mockServer.resetAll();
+        redirectServer.resetAll();
+    }
+
+    private void stubForScanInvocation(WireMockServer mockServer) {
+        // Stub for invoking a scan with PSSaaS
+        StubMapping scanInvokeStubMapping = mockServer.stubFor(
+                post(urlEqualTo(SCAN_INVOKE_URL)).withHeader(HEADER_SECRET_KEY, matching(".*?"))
+                        .withHeader(HEADER_SECRET_VALUE, matching(".*?"))
+                        .withRequestBody(equalToJson(SCAN_INVOKE_REQ_BODY_JSON, true, true)) // checks if valid json and
+                        // contains all expected
+                        // elements, extra elements
+                        // can exist, order can
+                        // differ
+                        .withRequestBody(matchingJsonPath("$.product-id")) // does product-id property exist in the
+                        // request body?
+                        .withRequestBody(matchingJsonPath("$.component-list[?(@.type)]")) // Do type and build-id exist
+                        // in the request body?
+                        .withRequestBody(matchingJsonPath("$.component-list[?(@.build-id)]"))
+                        .willReturn(
+                                aResponse().withBody(SCAN_INVOKE_RESPONSE_BODY)
+                                        .withStatus(SCAN_INVOKE_RESPONSE_STATUS)
+                                        .withHeader(HEADER_CONTENT_TYPE, CONTENT_TYPE_JSON)));
+        // System.out.println(scanInvokeStubMapping.toString()); // To check if stub correctly mapped
+        System.out.println("Scanner invoke stub has been set up");
+    }
+
+    private void stubUnauthorized() {
+        mockServer.stubFor(
+                post(urlMatching(SCAN_INVOKE_URL)).willReturn(aResponse().withStatus(401).withBody("Unauthorized")));
+        System.out.println("Unauthorized stub has been set up");
+    }
+
+    private void stubTemporaryRedirect() {
+        stubForScanInvocation(redirectServer);
+        mockServer.stubFor(
+                post(urlMatching(SCAN_INVOKE_URL)).willReturn(temporaryRedirect(WIREMOCK_HOST + ":" + REDIRECT_PORT)));
+        System.out.println("Temporary redirect stub has been set up");
+    }
+
+    private void stubServiceUnavailable() {
+        mockServer.stubFor(
+                post(urlMatching(SCAN_INVOKE_URL))
+                        .willReturn(aResponse().withStatus(503).withBody("Service Unavailable")));
+        System.out.println("Service unavailable stub has been set up");
+    }
+
+    @AfterAll
+    private void shutDownMockService() {
+        System.out.println("Unmatched requests for main Wiremock:");
+        logAllUnmatchedRequests(mockServer); // log unmatched requests made to mock service if any before closing up
+        System.out.println("Unmatched requests for redirect Wiremock:");
+        logAllUnmatchedRequests(redirectServer);
+        mockServer.stop();
+        redirectServer.stop();
+    }
+
+    private Response makeRequestWithRESTClient(String url) {
+        PncBuild b = easyRandom.nextObject(PncBuild.class);
+        b.setId("101305");
+        b.setInternalScmUrl("https://github.com/michalszynkiewicz/demo-bar");
+        b.setScmRevision("1.0.1");
+
+        ScanServiceDTO ss = ScanServiceDTOTest.dummyScanService();
+        ss.setProductId("jochrist-dev-test-hawtio");
+        ss.addPncBuild(b);
+
+        ScanHelper sh = null;
+        Response response = null;
+        try {
+            sh = new ScanHelper("PSSC-Secret-Key", "PSSC-Secret-Value", new URI(url));
+            response = sh.client.triggerScan(ss);
+        } catch (URISyntaxException e) {
+            e.printStackTrace();
+        }
+        return response;
+    }
+
+    @Test
+    void testScanningServiceInvocation() throws IOException {
+
+        stubForScanInvocation(mockServer);
+
+        Response response = makeRequestWithRESTClient(WIREMOCK_HOST + ":" + WIREMOCK_PORT);
+
+        verifyCorrectRequestMadeForScanInvocation(mockServer);
+
+        String responseBody = response.readEntity(String.class);
+        assertEquals(SCAN_INVOKE_RESPONSE_STATUS, response.getStatus());
+        assertEquals(CONTENT_TYPE_JSON, response.getHeaderString(HEADER_CONTENT_TYPE));
+        try {
+            Assertions.assertTrue(
+                    twoJsonStringsAreEqual(SCAN_INVOKE_RESPONSE_BODY, responseBody),
+                    "Response body is not the expected one");
+        } catch (JsonProcessingException e) {
+            assertTrue(false, "Json Parsing Error: Please check the format of the response body");
+        }
+    }
+
+    @Test
+    void testTemporaryRedirect() {
+        stubTemporaryRedirect();
+        Response response = makeRequestWithRESTClient(WIREMOCK_HOST + ":" + WIREMOCK_PORT);
+        assertEquals(302, response.getStatus());
+        // verify that a request was sent to the redirect server after getting a 302 from the main one
+        verifyCorrectRequestMadeForScanInvocation(redirectServer);
+    }
+
+    @Test
+    void testUnauthorized() {
+        stubUnauthorized();
+        Response response = makeRequestWithRESTClient(WIREMOCK_HOST + ":" + WIREMOCK_PORT);
+        assertEquals(401, response.getStatus());
+    }
+
+    @Test
+    void testServiceUnavailable() {
+        stubServiceUnavailable();
+        Response response = makeRequestWithRESTClient(WIREMOCK_HOST + ":" + WIREMOCK_PORT);
+        assertEquals(503, response.getStatus());
+    }
+
+    // For feedback in case something goes wrong, we can verify here if the request made was matching
+    // the requirements of the mock service. Though this causes almost duplicate code with the stubs
+    private void verifyCorrectRequestMadeForScanInvocation(WireMockServer mockServer) {
+        mockServer.verify(
+                postRequestedFor(urlEqualTo(SCAN_INVOKE_URL)).withHeader(HEADER_SECRET_KEY, matching(".*?"))
+                        .withHeader(HEADER_SECRET_VALUE, matching(".*?"))
+                        .withRequestBody(matchingJsonPath("$.product-id"))
+                        .withRequestBody(equalToJson(SCAN_INVOKE_REQ_BODY_JSON, true, true))
+                        .withRequestBody(matchingJsonPath("$.component-list[?(@.type)]"))
+                        .withRequestBody(matchingJsonPath("$.component-list[?(@.build-id)]")));
+    }
+
+    // gives an opportunity to see all unmatched requests made to the mock service for debugging
+    private void logAllUnmatchedRequests(WireMockServer wireMockServer) {
+        List<LoggedRequest> unmatchedRequests = wireMockServer.findAllUnmatchedRequests();
+        if (unmatchedRequests.isEmpty())
+            System.out.println("No unmatched requests found");
+        else
+            System.out.println("Unmatched requests made to mock service: ");
+        for (int i = 0; i < unmatchedRequests.size(); i++)
+            System.out.println(unmatchedRequests.get(i).toString());
+    }
+
+    private boolean twoJsonStringsAreEqual(String json1, String json2) throws JsonProcessingException {
+        ObjectMapper mapper = new ObjectMapper();
+        return mapper.readTree(json1).equals(mapper.readTree(json2));
+    }
+
+}

--- a/pig/src/test/java/org/jboss/pnc/bacon/pig/impl/addons/scanservice/ScanServiceDTOTest.java
+++ b/pig/src/test/java/org/jboss/pnc/bacon/pig/impl/addons/scanservice/ScanServiceDTOTest.java
@@ -1,0 +1,173 @@
+package org.jboss.pnc.bacon.pig.impl.addons.scanservice;
+
+import com.fasterxml.jackson.core.JsonProcessingException;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import org.jboss.pnc.bacon.pig.impl.pnc.PncBuild;
+import org.jeasy.random.EasyRandom;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+
+import java.util.*;
+import java.util.stream.Collectors;
+import java.util.stream.Stream;
+
+import static org.junit.jupiter.api.Assertions.*;
+
+public class ScanServiceDTOTest {
+
+    // private PncBuild pncBuild;
+    private Map<String, PncBuild> builds;
+    static EasyRandom easyRandom = new EasyRandom();
+
+    @BeforeEach
+    public void init() {
+        builds = new HashMap<>();
+
+        for (int i = 0; i < 5; i++) {
+            PncBuild b = easyRandom.nextObject(PncBuild.class);
+            b.setInternalScmUrl("https://github.com/michalszynkiewicz/demo-bar");
+            b.setScmRevision("1.0.1");
+            builds.put(easyRandom.nextObject(String.class), b);
+        }
+
+    }
+
+    public String getSerializedDTO(ScanServiceDTO ss) throws JsonProcessingException {
+        return new ObjectMapper().writeValueAsString(ss);
+    }
+
+    public static ScanServiceDTO dummyScanService() {
+
+        ScanServiceDTO ss = new ScanServiceDTO();
+        ss.setProductId("23");
+        ss.setEventId(ScanServiceDTO.EVENT_ID_DFT_VALUE);
+        ss.setIsManagedService(ScanServiceDTO.IS_MANAGED_SERVICE_DFT_VALUE);
+        ss.setCpaasVersion(ScanServiceDTO.CPAAS_VERSION_DFT_VALUE);
+        ss.setJobUrl(ScanServiceDTO.JOB_URL_DFT_VALUE);
+        return ss;
+    }
+
+    @Test
+    public void fromPncBuild() {
+        ScanServiceDTO ss = new ScanServiceDTO(
+                "productId",
+                "eventId",
+                true,
+                "cpaasVersion",
+                "jobUrl",
+                null,
+                null,
+                builds);
+        try {
+            String jsonDTO = getSerializedDTO(ss);
+            System.out.println("Test fromPncBuild: " + jsonDTO);
+        } catch (JsonProcessingException e) {
+            fail("ScanSerivce can't be instantiated as json");
+        }
+    }
+
+    @Test
+    public void fromPncBrewGit() {
+        List<Integer> brewBuilds = Arrays.asList(easyRandom.nextInt(10000), easyRandom.nextInt(10000));
+        Map<String, String> scmUrls = Stream
+                .of(
+                        new String[][] {
+                                { "scmUrl", "https://github.com/michalszynkiewicz/demo-bar" },
+                                { "scmRevision", "1.0.1" }, })
+                .collect(Collectors.toMap(data -> (String) data[0], data -> (String) data[1]));
+
+        ArrayList<Map<String, String>> scmUrlsL = new ArrayList<>();
+        scmUrlsL.add(scmUrls);
+
+        ScanServiceDTO ss = new ScanServiceDTO(
+                "productId",
+                "eventId",
+                true,
+                "cpaasVersion",
+                "jobUrl",
+                brewBuilds,
+                scmUrlsL,
+                builds);
+        try {
+            String jsonDTO = getSerializedDTO(ss);
+            System.out.println("Test fromPncBuild: " + jsonDTO);
+        } catch (JsonProcessingException e) {
+            fail("ScanSerivce can't be instantiated as json");
+        }
+    }
+
+    @Test
+    public void brewID() {
+        ScanServiceDTO ss = ScanServiceDTOTest.dummyScanService();
+        ss.addBrewBuild(easyRandom.nextInt(10000));
+    }
+
+    /*
+     * @Test public void brewIDs() { ScanServiceDTO ss = this.dummyScanService(); ss.addBrewBuild(1234); }
+     */
+
+    @Test
+    public void scmURL() {
+        ScanServiceDTO ss = ScanServiceDTOTest.dummyScanService();
+        ss.addSCMUrl("https://github.com/michalszynkiewicz/demo-bar#1.0.1");
+        ss.addSCMUrl("https://github.com/michalszynkiewicz/demo-bar.git", "1.0.1");
+        try {
+            String jsonDTO = getSerializedDTO(ss);
+            System.out.println("Test scmURL: " + jsonDTO);
+        } catch (JsonProcessingException e) {
+            fail("Cant produce json from SCMURL or repo/ref strings");
+        }
+    }
+
+    @Test
+    public void pncBrewAndGit() {
+        ScanServiceDTO ss = ScanServiceDTOTest.dummyScanService();
+        ss.addBrewBuild(easyRandom.nextInt(10000));
+        ss.addPncBuilds(builds);
+        ss.addSCMUrl("https://github.com/michalszynkiewicz/demo-bar.git", "1.0.1");
+        try {
+            String jsonDTO = getSerializedDTO(ss);
+            System.out.println("Test pncBrewAndGit: " + jsonDTO);
+        } catch (JsonProcessingException e) {
+            fail("Cant produce json from combined component list");
+        }
+    }
+
+    @Test
+    public void fromSCMUrl() {
+        ScanServiceDTO ss = ScanServiceDTOTest.dummyScanService();
+        ss.addSCMUrl("https://github.com/michalszynkiewicz/demo-bar.git#1.0.1");
+        try {
+            String jsonDTO = getSerializedDTO(ss);
+            System.out.println("Test SCMURL: " + jsonDTO);
+        } catch (JsonProcessingException e) {
+            fail("Cant produce json from combined component list");
+        }
+    }
+
+    @Test
+    public void fromWeirdSCMUrl() {
+        ScanServiceDTO ss = ScanServiceDTOTest.dummyScanService();
+        try {
+            ss.addSCMUrl("https://github.com/michalszynkiewicz/demo-bar.git#1.0.1#22");
+            fail("Expected an exception to be thrown for multiple url fragments");
+        } catch (RuntimeException e) {
+            assertNotNull(e);
+        }
+    }
+
+    @Test
+    public void fromWeirdSCMRev() {
+        ScanServiceDTO ss = ScanServiceDTOTest.dummyScanService();
+        try {
+            ss.addSCMUrl("https://github.com/michalszynkiewicz/demo-bar.git", "1.0.1#22");
+        } catch (RuntimeException e) {
+            fail("We should handle # (URL fragment) in SCM + Rev constructor");
+        }
+    }
+
+    @Test
+    void dumpDTO() throws JsonProcessingException {
+        System.out.println(PostBuildScanService.showDTOfields(ScanServiceDTOTest.dummyScanService()));
+    }
+}

--- a/pig/src/test/java/org/jboss/pnc/bacon/pig/impl/addons/scanservice/ValidationTest.java
+++ b/pig/src/test/java/org/jboss/pnc/bacon/pig/impl/addons/scanservice/ValidationTest.java
@@ -1,0 +1,104 @@
+package org.jboss.pnc.bacon.pig.impl.addons.scanservice;
+
+import org.jboss.pnc.bacon.config.Validate;
+import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.CsvSource;
+
+import java.util.*;
+
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+class ValidationTest {
+
+    PostBuildScanService scanService = new PostBuildScanService(null, null, null, null);
+
+    private static final Map<String, ?> benchmarkScanServiceConfigMap = new LinkedHashMap<>();
+    static {
+        benchmarkScanServiceConfigMap.put("productID", null);
+        benchmarkScanServiceConfigMap.put("eventId", null);
+        benchmarkScanServiceConfigMap.put("isManagedService", null);
+        benchmarkScanServiceConfigMap.put("cpaasVersion", null);
+        benchmarkScanServiceConfigMap.put("jobUrl", null);
+        benchmarkScanServiceConfigMap.put("serviceUrl", null);
+        benchmarkScanServiceConfigMap.put("serviceSecretKey", null);
+        benchmarkScanServiceConfigMap.put("serviceSecretValue", null);
+        benchmarkScanServiceConfigMap.put("brewBuilds", null);
+        benchmarkScanServiceConfigMap.put("scmUrl", null);
+        benchmarkScanServiceConfigMap.put("scmRevision", null);
+        benchmarkScanServiceConfigMap.put("extraScmUrls", null);
+        benchmarkScanServiceConfigMap.put("extraBuilds", null);
+        benchmarkScanServiceConfigMap.put("name", null);
+    }
+
+    private static final Map<String, ?> minimalConfigMap = new LinkedHashMap<>();
+    static {
+        minimalConfigMap.put("productID", null);
+        minimalConfigMap.put("serviceUrl", null);
+        minimalConfigMap.put("serviceSecretKey", null);
+        minimalConfigMap.put("serviceSecretValue", null);
+    }
+
+    @Test
+    void positiveKeywordsTest() {
+        showMap(benchmarkScanServiceConfigMap);
+        scanService.validateMapKeys(benchmarkScanServiceConfigMap);
+    }
+
+    @ParameterizedTest(name = "{index} => validKey={0}, invalidKey={1}")
+    @CsvSource({
+            "productID, product-id",
+            "eventId, eventID",
+            "isManagedService, _isManagedService_",
+            "cpaasVersion, CpaasVersion",
+            "jobUrl, xyz",
+            "serviceUrl, service-url",
+            "serviceSecretKey, serviceSecretkey",
+            "serviceSecretValue, servicesecretValue",
+            "brewBuilds, brewbuilds",
+            "scmUrl, SCMURL",
+            "scmRevision, scm-revision",
+            "extraScmUrls, _xtraScmUrls",
+            "extraBuilds, extraBuilds_" })
+    void negativeKeywordsTest(String validKey, String invalidKey) {
+        HashMap<String, Object> testMap = new LinkedHashMap<>(benchmarkScanServiceConfigMap);
+        testMap.remove(validKey);
+        testMap.put(invalidKey, null);
+        Assertions.assertThrows(Validate.ConfigMissingException.class, () -> scanService.validateMapKeys(testMap));
+    }
+
+    @Test
+    void positiveMandatoryKeywordsTest() {
+        HashMap<String, Object> map = new HashMap<>();
+        map.put("productID", 111);
+        map.put("serviceUrl", "http://someurl.com:8080");
+        map.put("serviceSecretKey", "pig");
+        map.put("serviceSecretValue", "sometoken");
+        scanService.checkPresenceOfMandatoryFields(map);
+    }
+
+    @Test
+    void negativeMandatoryKeywordsTest() {
+
+        for (String mk : minimalConfigMap.keySet()) {
+            HashMap<String, Object> map = new HashMap<>(minimalConfigMap);
+            map.remove(mk);
+            Exception e = Assertions.assertThrows(
+                    Validate.ConfigMissingException.class,
+                    () -> scanService.checkPresenceOfMandatoryFields(map));
+            assertTrue(e.getMessage().contains("mandatory field '" + mk));
+        }
+    }
+
+    void showMap(Map<String, ?> mapToShow) {
+        try {
+            for (Map.Entry<String, ?> entry : mapToShow.entrySet()) {
+                System.out.printf("%30s : %s%n", entry.getKey(), entry.getValue());
+            }
+            System.out.println(new String(new char[5]).replace("\0", "========="));
+        } catch (Exception e) {
+            System.out.println(e.getMessage());
+        }
+    }
+}

--- a/pom.xml
+++ b/pom.xml
@@ -460,6 +460,12 @@
                 <scope>test</scope>
             </dependency>
             <dependency>
+                <groupId>org.junit.jupiter</groupId>
+                <artifactId>junit-jupiter-params</artifactId>
+                <version>${junit.version}</version>
+                <scope>test</scope>
+            </dependency>
+            <dependency>
                 <groupId>org.assertj</groupId>
                 <artifactId>assertj-core</artifactId>
                 <version>3.21.0</version>


### PR DESCRIPTION
### Checklist:

* [ ] Have you added a note in the [CHANGELOG wiki](https://github.com/project-ncl/bacon/wiki/Changelog) for your change if user-facing?
* [ x] Have you added unit tests for your change?
* 

This PiG addon allows the use of the CPaaS Product Security Scan as a Service, by default this addon, once configured, will send pnc builds in the context of the current pig build-config.yaml to the service which will then checkout and scan the code.
Usage and documentation are a WIP
