### PR TITLE
[NCLSUP-679] Bacon is excluding too many artifacts

### DIFF
--- a/pig/src/test/java/org/jboss/pnc/bacon/pig/impl/repo/RepositoryUtilsTest.java
+++ b/pig/src/test/java/org/jboss/pnc/bacon/pig/impl/repo/RepositoryUtilsTest.java
@@ -7,6 +7,7 @@ import java.io.IOException;
 import java.nio.file.Files;
 import java.nio.file.Path;
 import java.nio.file.Paths;
+import java.util.regex.Pattern;
 
 import static org.junit.jupiter.api.Assertions.*;
 
@@ -42,20 +43,35 @@ class RepositoryUtilsTest {
     }
 
     @Test
-    void testConvertMavenIdentifierToPath() {
+    void testConvertMavenIdentifierToPathRegex() {
         String identifier = "test.me.here:letmego:tar:1.2.3";
-        String path = RepositoryUtils.convertMavenIdentifierToPath(identifier);
-        assertEquals(Paths.get("test", "me", "here", "letmego", "1.2.3", "letmego-1.2.3.tar").toFile().getPath(), path);
+        String pathRegex = RepositoryUtils.convertMavenIdentifierToPathRegex(identifier);
+        assertTrue(
+                Pattern.matches(
+                        pathRegex,
+                        Paths.get("test", "me", "here", "letmego", "1.2.3", "letmego-1.2.3.tar").toFile().getPath()));
 
         identifier = "test.me.here:letmego:zip:1.2.3:docs";
-        path = RepositoryUtils.convertMavenIdentifierToPath(identifier);
-        assertEquals(
-                Paths.get("test", "me", "here", "letmego", "1.2.3", "letmego-1.2.3-docs.zip").toFile().getPath(),
-                path);
+        pathRegex = RepositoryUtils.convertMavenIdentifierToPathRegex(identifier);
+        assertTrue(
+                Pattern.matches(
+                        pathRegex,
+                        Paths.get("test", "me", "here", "letmego", "1.2.3", "letmego-1.2.3-docs.zip")
+                                .toFile()
+                                .getPath()));
 
         String identifierWrong = "test.me.here:letmego:1.2.3";
         assertThrows(
                 IllegalArgumentException.class,
-                () -> RepositoryUtils.convertMavenIdentifierToPath(identifierWrong));
+                () -> RepositoryUtils.convertMavenIdentifierToPathRegex(identifierWrong));
+
+        // Test for NCLSUP-679
+        String identifierPathShouldNotMatch = "org/kie/server/kie-server-wars/5.0.0.Final/kie-server-wars-5.0.0.Final.pom";
+        String identifierPathShouldMatch = "org/kie/server/kie-server/5.0.0.Final/kie-server-wars-5.0.0.Final.war";
+        pathRegex = RepositoryUtils.convertMavenIdentifierToPathRegex(".*:.*:war:.*");
+
+        System.out.println(pathRegex);
+        assertFalse(Pattern.matches(pathRegex, identifierPathShouldNotMatch));
+        assertTrue(Pattern.matches(pathRegex, identifierPathShouldMatch));
     }
 }


### PR DESCRIPTION
Some build-config.yaml use this style for exclude artifacts:
```
.*:.*:war:.*
```

In Bacon, we do 2 rounds of filtering out the excluded artifacts. The
first round tries to match the excludeArtifacts with an artifact's GAPV
(group-id artifact-id packaging version).

The second round scans through the generated maven repository folder to
exclude files which have a path of format:

```
<group id>/<artifact id>/<version>/<artifact id>-<version>.war
```

In the example used above, the path to exclude becomes:
```
.*/.*/.*/.*-.*.war
```

Unfortunately this path to exclude matches with paths like:
```
org/kie/server/kie-server-wars/1.2.3.Final/kie-server-wars-1.2.3.Final.pom
```
even though the original intension is to match any file with extension 'war'.

The fix for this is to refine the excluded path generated to properly
match the extension. In our case, it should be:
```
.*/.*/.*/.*-.*\\.war$
```

(double back-slash because of how Java regex works, and '$' so that it
matches the end of the filename)

There is also a fix on the generation part to not replace '.' with a
file separator for the group id in case the group id is '.*', which is
the catch-all regex.

### Checklist:

* [ ] Have you added a note in the [CHANGELOG wiki](https://github.com/project-ncl/bacon/wiki/Changelog) for your change if user-facing?
* [x] Have you added unit tests for your change?
