### PR TITLE
[NCL-7146] Allow lookup of DA alignment versions via a filename

### DIFF
--- a/integration-tests/src/test/java/org/jboss/pnc/bacon/test/da/DAMavenLatestTest.java
+++ b/integration-tests/src/test/java/org/jboss/pnc/bacon/test/da/DAMavenLatestTest.java
@@ -1,0 +1,19 @@
+package org.jboss.pnc.bacon.test.da;
+
+import org.jboss.pnc.bacon.test.CLIExecutor;
+import org.jboss.pnc.bacon.test.ExecutionResult;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.TestInstance;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+@TestInstance(TestInstance.Lifecycle.PER_CLASS)
+public class DAMavenLatestTest {
+
+    @Test
+    void testMavenLatestGAVsSpecified() {
+        ExecutionResult result = CLIExecutor.runCommand("da", "lookup", "maven-latest");
+        assertThat(result.getError()).contains("You didn't specify any GAVs or file!");
+        assertThat(result.getRetval()).isNotZero();
+    }
+}


### PR DESCRIPTION
The Quarkus team would like to automate their productization workflow by
generating a list of dependencies that need to be productized, and
lookup via `bacon da lookup maven-latest` whether those dependencies
already have a productized version or not.

It'll make their life much easier if they can specify the dependencies
(in GAV format) via a file (one dependency per line).

### Checklist:

* [x] Have you added a note in the [CHANGELOG wiki](https://github.com/project-ncl/bacon/wiki/Changelog) for your change if user-facing?
* [ ] Have you added unit tests for your change?
