### PR TITLE
Revert "added --skipJsonOutput which if set turns off all the JSON output at …"

### DIFF
--- a/pig/src/main/java/org/jboss/pnc/bacon/pig/Pig.java
+++ b/pig/src/main/java/org/jboss/pnc/bacon/pig/Pig.java
@@ -127,12 +127,6 @@ public class Pig {
         private int downloadAttempts;
 
         @Option(
-                names = "--skipJsonOutput",
-                defaultValue = "false",
-                description = "Stop all the build output JSON going to stdout")
-        private boolean skipJsonOutput;
-
-        @Option(
                 names = "--targetPath",
                 defaultValue = "target",
                 description = "The directory where the deliverables will be put")
@@ -165,12 +159,7 @@ public class Pig {
 
             PigContext.init(clean || isStartingPoint(), Paths.get(configDir), targetPath, releaseStorageUrl, overrides);
             PigContext.get().setTempBuild(tempBuild);
-            if (skipJsonOutput) {
-                doExecute();
-            } else {
-                ObjectHelper.print(getJsonOutput(), doExecute());
-            }
-
+            ObjectHelper.print(getJsonOutput(), doExecute());
             return 0;
         }
 


### PR DESCRIPTION
Reverts project-ncl/bacon#965

redirect to /dev/null solves the problem so not needed `> /dev/null`