### PR TITLE
Ignore blank skippedAddon

### DIFF
--- a/pig/src/main/java/org/jboss/pnc/bacon/pig/PigFacade.java
+++ b/pig/src/main/java/org/jboss/pnc/bacon/pig/PigFacade.java
@@ -467,7 +467,7 @@ public final class PigFacade {
                 .collect(Collectors.toList());
 
         for (String skippedAddon : skippedAddons) {
-            if (!existingAddons.contains(skippedAddon)) {
+            if (!skippedAddon.isBlank() && !existingAddons.contains(skippedAddon)) {
                 log.error("Addon '{}' doesn't exist", skippedAddon);
                 skippedAddonsValidated = false;
             }


### PR DESCRIPTION
For some reason, picocli sets the array that contains the skippedAddon
as size 1 with content `['']` if there are no skippedAddon specified in
the CLI.

We need to add a blank string check to filter out those blank string and
ignore them

### Checklist:

* [ ] Have you added a note in the [CHANGELOG wiki](https://github.com/project-ncl/bacon/wiki/Changelog) for your change if user-facing?
* [ ] Have you added unit tests for your change?
