### PR TITLE
[NCL-7272] Hide netty debug message about using Unsafe

### DIFF
--- a/cli/src/main/resources/logback.xml
+++ b/cli/src/main/resources/logback.xml
@@ -68,6 +68,11 @@
     <logger name="me.snowdrop.licenses" level="ERROR"/>
     <!-- end from koji-build-finder -->
 
+    <!-- for PNC rest client -->
+    <!-- Get rid of Netty- cannot access class jdk.internal.misc.Unsafe *debug* message when running on J11 -->
+    <logger name="io.netty.util" level="ERROR"/>
+    <!-- end from PNC rest client -->
+
     <root level="info">
         <appender-ref ref="STDERR"/>
     </root>


### PR DESCRIPTION
When running on Java 11, Netty prints a scary *debug* message about not
being able to access the Unsafe APIs. This is normal and just printed as
a debug, but it looks like an error message.

This commit adjusts our logging to only print Netty error messages
instead.

Sources:
- https://stackoverflow.com/questions/64043706/java-lang-illegalaccessexception-class-io-netty-util-internal-platformdependent
- https://github.com/netty/netty/issues/7817#issuecomment-377497310

```
It's not an error, it's a debug message with a stacktrace, change your logger level to something else apart from debug eg. info or warn.
```

### Checklist:

* [ ] Have you added a note in the [CHANGELOG wiki](https://github.com/project-ncl/bacon/wiki/Changelog) for your change if user-facing?
* [ ] Have you added unit tests for your change?
