### PR TITLE
Fix get-gav error when there is no result found

### DIFF
--- a/pnc/src/main/java/org/jboss/pnc/bacon/pnc/ArtifactCli.java
+++ b/pnc/src/main/java/org/jboss/pnc/bacon/pnc/ArtifactCli.java
@@ -9,6 +9,7 @@ import org.jboss.pnc.bacon.common.cli.JSONCommandHandler;
 import org.jboss.pnc.bacon.pnc.common.ClientCreator;
 import org.jboss.pnc.client.ArtifactClient;
 import org.jboss.pnc.client.ClientException;
+import org.jboss.pnc.client.RemoteCollection;
 import org.jboss.pnc.client.RemoteResourceException;
 import org.jboss.pnc.dto.Artifact;
 import org.jboss.pnc.dto.Build;
@@ -17,6 +18,7 @@ import picocli.CommandLine.Command;
 import picocli.CommandLine.Option;
 
 import java.util.Collection;
+import java.util.Collections;
 import java.util.Optional;
 import java.util.concurrent.Callable;
 
@@ -94,14 +96,13 @@ public class ArtifactCli {
             identifier = transformIdentifierIfGAV(identifier);
 
             try (ArtifactClient client = CREATOR.newClient()) {
-                ObjectHelper.print(
-                        getJsonOutput(),
-                        client.getAll(
-                                null,
-                                null,
-                                null,
-                                Optional.empty(),
-                                Optional.ofNullable("identifier==" + identifier)).iterator().next());
+                RemoteCollection<Artifact> result = client
+                        .getAll(null, null, null, Optional.empty(), Optional.ofNullable("identifier==" + identifier));
+                if (result.size() == 0) {
+                    ObjectHelper.print(getJsonOutput(), Collections.emptySet());
+                } else {
+                    ObjectHelper.print(getJsonOutput(), result.iterator().next());
+                }
                 return 0;
             }
         }


### PR DESCRIPTION
It's throwing iterator error when result is empty. Better solution didn't come to my mind, open to suggestions.