### PR TITLE
[NCL-7283] Make bacon pig run wait and not run multiple builds of sam…

### DIFF
--- a/pig/src/main/java/org/jboss/pnc/bacon/pig/impl/pnc/PncBuilder.java
+++ b/pig/src/main/java/org/jboss/pnc/bacon/pig/impl/pnc/PncBuilder.java
@@ -118,12 +118,7 @@ public class PncBuilder implements Closeable {
 
     public String cancelRunningGroupBuild(String groupConfigurationId) {
         try {
-            Collection<GroupBuild> groupBuilds = groupConfigClient
-                    .getAllGroupBuilds(
-                            groupConfigurationId,
-                            of("=desc=startTime"),
-                            query("status==%s", BuildStatus.BUILDING))
-                    .getAll();
+            Collection<GroupBuild> groupBuilds = getRunningGroupBuilds(groupConfigurationId);
 
             if (groupBuilds.size() > 1) {
                 return ("Can't cancel, there are multiple GroupBuilds running for single GroupConfiguration name and we can't decide correct one to cancel from build-config.yaml information. Found:"
@@ -137,6 +132,20 @@ public class PncBuilder implements Closeable {
             return "Group build " + running.getId() + " canceled.";
         } catch (RemoteResourceException e) {
             throw new RuntimeException("Failed to get group build info to cancel running build.", e);
+        }
+    }
+
+    public Collection<GroupBuild> getRunningGroupBuilds(String groupConfigurationId) {
+        try {
+            Collection<GroupBuild> groupBuilds = groupConfigClient
+                    .getAllGroupBuilds(
+                            groupConfigurationId,
+                            of("=desc=startTime"),
+                            query("status==%s", BuildStatus.BUILDING))
+                    .getAll();
+            return groupBuilds;
+        } catch (RemoteResourceException e) {
+            throw new RuntimeException("Failed to get group build info.", e);
         }
     }
 

--- a/pig/src/main/java/org/jboss/pnc/bacon/pig/impl/pnc/PncEntitiesImporter.java
+++ b/pig/src/main/java/org/jboss/pnc/bacon/pig/impl/pnc/PncEntitiesImporter.java
@@ -541,7 +541,7 @@ public class PncEntitiesImporter implements Closeable {
         return buildConfigSetId.orElseGet(() -> generateBuildGroup(version));
     }
 
-    private Optional<GroupConfiguration> getBuildGroup() {
+    public Optional<GroupConfiguration> getBuildGroup() {
         try {
             return toStream(
                     groupConfigClient.getAll(empty(), Optional.of("name=='" + pigConfiguration.getGroup() + "'")))


### PR DESCRIPTION
…e configuration in parallel

This is solving part of the problem, it's still possible for user to run multiple builds in parallel by using *pig run* if builds are started before first one enters building phase in pnc. I can't move check for running builds from start of the process to start of the building phase because we don't want to allow configuration change in pnc either. Solution might be to add table to pnc where bacon would send information which GroupConfig it will start build for and block it by reading this table.
