### PR TITLE
Add a new CamelRuntimeDependenciesToAlignTree which can determine fir…

### DIFF
--- a/pig/src/main/java/org/jboss/pnc/bacon/pig/impl/addons/AddOnFactory.java
+++ b/pig/src/main/java/org/jboss/pnc/bacon/pig/impl/addons/AddOnFactory.java
@@ -17,6 +17,7 @@
  */
 package org.jboss.pnc.bacon.pig.impl.addons;
 
+import org.jboss.pnc.bacon.pig.impl.addons.camel.CamelRuntimeDependenciesToAlignTree;
 import org.jboss.pnc.bacon.pig.impl.addons.camel.RuntimeDependenciesToAlignTree;
 import org.jboss.pnc.bacon.pig.impl.addons.microprofile.MicroProfileSmallRyeCommunityDepAnalyzer;
 import org.jboss.pnc.bacon.pig.impl.addons.quarkus.QuarkusCommunityDepAnalyzer;
@@ -54,6 +55,7 @@ public class AddOnFactory {
         resultList.add(new RuntimeDependenciesAnalyzer(pigConfiguration, builds, releasePath, extrasPath));
         resultList.add(new ExtraDeliverableDownloader(pigConfiguration, builds, releasePath, extrasPath));
         resultList.add(new BomVerifierAddon(pigConfiguration, builds, releasePath, extrasPath));
+        resultList.add(new CamelRuntimeDependenciesToAlignTree(pigConfiguration, builds, releasePath, extrasPath));
         resultList.add(new RuntimeDependenciesToAlignTree(pigConfiguration, builds, releasePath, extrasPath));
         resultList.add(new NotYetAlignedFromDependencyTree(pigConfiguration, builds, releasePath, extrasPath));
         resultList

--- a/pig/src/main/java/org/jboss/pnc/bacon/pig/impl/addons/camel/CamelRuntimeDependenciesToAlignTree.java
+++ b/pig/src/main/java/org/jboss/pnc/bacon/pig/impl/addons/camel/CamelRuntimeDependenciesToAlignTree.java
@@ -1,0 +1,143 @@
+/*
+ * JBoss, Home of Professional Open Source. Copyright 2022 Red Hat, Inc., and individual
+ * contributors as indicated by the @author tags.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except
+ * in compliance with the License. You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software distributed under the License
+ * is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express
+ * or implied. See the License for the specific language governing permissions and limitations under
+ * the License.
+ */
+package org.jboss.pnc.bacon.pig.impl.addons.camel;
+
+import org.jboss.pnc.bacon.pig.impl.addons.AddOn;
+import org.jboss.pnc.bacon.pig.impl.config.PigConfiguration;
+import org.jboss.pnc.bacon.pig.impl.pnc.PncBuild;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+import java.io.PrintWriter;
+import java.nio.charset.StandardCharsets;
+import java.util.ArrayList;
+import java.util.HashSet;
+import java.util.List;
+import java.util.Map;
+import java.util.Set;
+import java.util.regex.Matcher;
+import java.util.regex.Pattern;
+
+/**
+ * @author Tom Cunningham, tcunning@redhat.com <br>
+ * @author Paul Gallagher, pgallagh@redhat.com <br>
+ *         Date: 2018-11-20
+ *
+ *         If you run your builds with 'dependency:tree' then you can use this addon to give you the list of compile
+ *         scope dependencies that are not redhat builds
+ */
+public class CamelRuntimeDependenciesToAlignTree extends AddOn {
+
+    private static final Logger log = LoggerFactory.getLogger(CamelRuntimeDependenciesToAlignTree.class);
+
+    public CamelRuntimeDependenciesToAlignTree(
+            PigConfiguration pigConfiguration,
+            Map<String, PncBuild> builds,
+            String releasePath,
+            String extrasPath) {
+        super(pigConfiguration, builds, releasePath, extrasPath);
+    }
+
+    @Override
+    public String getName() {
+        return "camelRuntimeDependenciesToAlignTree";
+    }
+
+    private int indexOfPattern(String str, String regex) {
+        Pattern pattern = Pattern.compile(regex);
+        Matcher matcher = pattern.matcher(str);
+        if (matcher.find()) {
+            return matcher.start();
+        }
+        return -1;
+    }
+
+    private String parseDependency(String line) {
+        String dependency = line.replace(":runtime", "").replace(":compile", "");
+        dependency = dependency.replace("[INFO] ", "");
+        dependency = dependency.replaceFirst("([+-|\\s]+\\s+)", "");
+        return dependency;
+    }
+
+    @Override
+    public void trigger() {
+        String filename = extrasPath + "DependenciesToAlignTree.txt";
+        String buildFromSourceStatsFileName = extrasPath + "CamelBuildFromSourceStats.txt";
+        log.info("Running CamelDependenciesToAlignTree - report is {}", filename);
+
+        try (PrintWriter file = new PrintWriter(filename, StandardCharsets.UTF_8.name());
+                PrintWriter buildFromSourceStatsFile = new PrintWriter(
+                        buildFromSourceStatsFileName,
+                        StandardCharsets.UTF_8.name())) {
+            for (PncBuild build : builds.values()) {
+                // Make a unique list so we don't get multiples from
+                // sub-module's dependency tree list
+                List<String> bcLog = build.getBuildLog();
+
+                file.print("-------- [" + build.getId() + "] " + build.getName() + " --------\n");
+                buildFromSourceStatsFile.print("-------- [" + build.getId() + "] " + build.getName() + " --------\n");
+
+                List<String> runtimeDeps = new ArrayList<String>();
+                PrintWriter camelBuildFile = new PrintWriter(
+                        new String(extrasPath + build.getName() + "-camelProjectDependencies.txt"),
+                        StandardCharsets.UTF_8.name());
+
+                TreeParser treeparser = new TreeParser();
+                ArrayList<TreeNode> al = treeparser.parse(bcLog);
+
+                ArrayList<String> dependencies = treeparser.collectFirstLevelDependencies(al);
+                Set<String> uniqueDependencies = new HashSet<String>(dependencies);
+                ArrayList<String> filterForScope = new ArrayList<String>();
+                for (String dep : uniqueDependencies) {
+                    if (!dep.endsWith(":test")) {
+                        filterForScope.add(dep);
+                    }
+                }
+
+                // Print the unique first level dependencies out to a file
+                camelBuildFile.println("Unique, first level non-test-scope dependencies");
+                for (String uniqueDep : filterForScope) {
+                    camelBuildFile.println(uniqueDep);
+                }
+                camelBuildFile.flush();
+                camelBuildFile.close();
+
+                buildFromSourceStatsFile.println("Number of unique dependencies: " + filterForScope.size());
+
+                int prodCount = 0;
+                for (String prod : filterForScope) {
+                    if (prod.contains(".redhat")) {
+                        prodCount++;
+                    }
+                }
+
+                // Print out the productization stats
+                buildFromSourceStatsFile.println(
+                        "Found " + prodCount + " unique productized dependencies, " + filterForScope.size()
+                                + " total dependencies\n");
+                float pct = (float) prodCount / filterForScope.size();
+                buildFromSourceStatsFile
+                        .print("Build from source percentage : " + String.format("%.2f", pct * 100) + "%\n");
+            }
+
+            log.info("Finished writing CamelDependenciesToAlignTree - report is {}", filename);
+
+            file.flush();
+            buildFromSourceStatsFile.flush();
+        } catch (Exception e) {
+            log.error("Error while creating RuntimeDependenciesToAlignTree report", e);
+        }
+    }
+}

--- a/pig/src/main/java/org/jboss/pnc/bacon/pig/impl/addons/camel/RuntimeDependenciesToAlignTree.java
+++ b/pig/src/main/java/org/jboss/pnc/bacon/pig/impl/addons/camel/RuntimeDependenciesToAlignTree.java
@@ -1,5 +1,5 @@
 /*
- * JBoss, Home of Professional Open Source. Copyright 2017 Red Hat, Inc., and individual
+ * JBoss, Home of Professional Open Source. Copyright 2022 Red Hat, Inc., and individual
  * contributors as indicated by the @author tags.
  *
  * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except
@@ -12,7 +12,6 @@
  * or implied. See the License for the specific language governing permissions and limitations under
  * the License.
  */
-
 package org.jboss.pnc.bacon.pig.impl.addons.camel;
 
 import org.jboss.pnc.bacon.pig.impl.addons.AddOn;

--- a/pig/src/main/java/org/jboss/pnc/bacon/pig/impl/addons/camel/TreeNode.java
+++ b/pig/src/main/java/org/jboss/pnc/bacon/pig/impl/addons/camel/TreeNode.java
@@ -1,0 +1,179 @@
+/*
+ * JBoss, Home of Professional Open Source. Copyright 2022 Red Hat, Inc., and individual
+ * contributors as indicated by the @author tags.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except
+ * in compliance with the License. You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software distributed under the License
+ * is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express
+ * or implied. See the License for the specific language governing permissions and limitations under
+ * the License.
+ */
+package org.jboss.pnc.bacon.pig.impl.addons.camel;
+
+import java.util.ArrayList;
+import java.util.List;
+
+/**
+ * TreeNode is a tree node datatype containing a dependency name, a parent, and children. Tree nodes can be printed and
+ * a variety of getters and setters are available along with a few methods that classify the dependency.
+ */
+public class TreeNode {
+    private String dependencyName = null;
+    private List<TreeNode> children = new ArrayList<>();
+    private TreeNode parent = null;
+
+    /**
+     * Constructor
+     */
+    public TreeNode() {
+        super();
+    }
+
+    /**
+     * Constructor
+     *
+     * @param dependencyName dependency name
+     */
+    public TreeNode(String dependencyName) {
+        super();
+        this.dependencyName = dependencyName;
+    }
+
+    /**
+     * @return whether or not the dependency is productized - does it contain "\.redhat"?
+     */
+    public boolean isProductized() {
+        return dependencyName.contains(".redhat");
+    }
+
+    /**
+     * @return whether or not the dependency is a jkube group artifact
+     */
+    public boolean isJkube() {
+        return dependencyName.contains("org.eclipse.jkube");
+    }
+
+    /**
+     * @return whether or not the dependency is a fusesource group artifact
+     */
+    public boolean isFuseSource() {
+        return dependencyName.contains("org.fusesource");
+    }
+
+    /**
+     * @return whether or not the dependency is a snowdrop group artifact
+     */
+    public boolean isSnowDrop() {
+        return dependencyName.contains("me.snowdrop");
+    }
+
+    /**
+     * @return whether or not the dependency is camel group artifact
+     */
+    public boolean isCamelArtifact() {
+        return dependencyName.contains("org.apache.camel");
+    }
+
+    /**
+     * @return whether or not the dependency is camel group artifact
+     */
+    public boolean isCXF() {
+        return dependencyName.contains("org.apache.cxf");
+    }
+
+    /**
+     * @return whether or not the dependency is org.springframework
+     */
+    public boolean isSpringBoot() {
+        return dependencyName.contains("org.springframework");
+    }
+
+    /**
+     * Dependency name getter.
+     *
+     * @return the dependency name
+     */
+    public String getDependencyName() {
+        return dependencyName;
+    }
+
+    /**
+     * Dependency name setter.
+     *
+     * @param dependencyName dependency name
+     */
+    public void setDependencyName(String dependencyName) {
+        this.dependencyName = dependencyName;
+    }
+
+    /**
+     * Parent tree node getter.
+     *
+     * @return parent tree node
+     */
+    public TreeNode getParent() {
+        return parent;
+    }
+
+    /**
+     * Parent tree node setter.
+     *
+     * @param parent parent tree node
+     */
+    public void setParent(TreeNode parent) {
+        this.parent = parent;
+    }
+
+    /**
+     * Add a child.
+     *
+     * @param child child to be added
+     */
+    public void addChild(TreeNode child) {
+        child.setParent(this);
+        children.add(child);
+    }
+
+    /**
+     * Getter for a list of tree node children.
+     *
+     * @return list of tree node children
+     */
+    public List<TreeNode> getChildren() {
+        return children;
+    }
+
+    /**
+     * Print the tree node and its children.
+     *
+     * @param tn parent tree node to print
+     * @param depth the depth to distinguish dependency levels
+     */
+    public void printTree(TreeNode tn, int depth) {
+        if (tn != null) {
+            List<TreeNode> childNodes = tn.getChildren();
+            for (int i = 0; i < childNodes.size(); i++) {
+                for (int j = 0; j < depth + 1; j++) {
+                    System.out.print("====");
+                }
+                System.out.println(childNodes.get(i).getDependencyName());
+                printTree(childNodes.get(i), (depth + 1));
+            }
+        }
+        return;
+    }
+
+    /**
+     * Print the tree node and its children.
+     *
+     * @param tn the tree node to print
+     */
+    public void printTree(TreeNode tn) {
+        System.out.println(tn.getDependencyName());
+        printTree(tn, 0);
+    }
+}

--- a/pig/src/main/java/org/jboss/pnc/bacon/pig/impl/addons/camel/TreeParser.java
+++ b/pig/src/main/java/org/jboss/pnc/bacon/pig/impl/addons/camel/TreeParser.java
@@ -1,0 +1,248 @@
+/*
+ * JBoss, Home of Professional Open Source. Copyright 2022 Red Hat, Inc., and individual
+ * contributors as indicated by the @author tags.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except
+ * in compliance with the License. You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software distributed under the License
+ * is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express
+ * or implied. See the License for the specific language governing permissions and limitations under
+ * the License.
+ */
+package org.jboss.pnc.bacon.pig.impl.addons.camel;
+
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+import java.io.BufferedReader;
+import java.io.File;
+import java.io.FileReader;
+import java.util.ArrayList;
+import java.util.HashSet;
+import java.util.List;
+import java.util.Set;
+import java.util.regex.Matcher;
+import java.util.regex.Pattern;
+
+/**
+ * @author Tom Cunningham, tcunning@redhat.com <br>
+ *         Date: 2023-10-02
+ *
+ *         TreeParser is a class that parses mvn:dependency-tree stacks that it finds in logs and allows you to find
+ *         unique first level dependencies with a specific parentage.
+ *
+ *         This is useful because we are interested in finding the number of direct dependencies of org.apache.camel
+ *         that are productized and the number of direct dependencies of org.apache.camel that still need to be.
+ *
+ *         TreeParser is used by CamelRuntimeDependenciesToAlignTree to produce a log with percentages, but it can also
+ *         be used on a PNC build log that has been downloaded.
+ *
+ *         Example : % java -cp cli/target/bacon.jar org.jboss.pnc.bacon.pig.impl.addons.camel.TreeParser
+ *         A3PHDS4K2MYAG_jkube-1.13.1_SUCCESS.txt
+ *
+ */
+public class TreeParser {
+    private static final Logger log = LoggerFactory.getLogger(TreeParser.class);
+
+    private int indexOfPattern(String str, String regex) {
+        Pattern pattern = Pattern.compile(regex);
+        Matcher matcher = pattern.matcher(str);
+        if (matcher.find()) {
+            return matcher.start();
+        }
+        return -1;
+    }
+
+    private String parseDependency(String line) {
+        String dependency = line.replace("[INFO] ", "");
+        dependency = dependency.replaceFirst("([+-|\\s]+\\s+)", "");
+        return dependency;
+    }
+
+    public ArrayList parse(String fileName) throws Exception {
+        File parseFile = new File(fileName);
+        if (!parseFile.exists()) {
+            throw new RuntimeException("Could not find file " + fileName);
+        }
+
+        ArrayList<String> results = new ArrayList<String>();
+        BufferedReader fr = null;
+        fr = new BufferedReader(new FileReader(parseFile));
+        String line = null;
+        while ((line = fr.readLine()) != null) {
+            results.add(line);
+        }
+        fr.close();
+        return parse(results);
+    }
+
+    public ArrayList parse(List<String> fileContents) throws Exception {
+        ArrayList treeList = new ArrayList();
+
+        TreeNode parent = new TreeNode();
+        try {
+            boolean rootNode = false;
+            boolean parsing = false;
+            TreeNode current = new TreeNode();
+            TreeNode currentParent = current;
+            int currentindex = 0;
+            for (String line : fileContents) {
+
+                if (line.contains("Downloading") || (line.contains("Downloaded"))) {
+                    continue;
+                }
+
+                if (line.contains("maven-dependency-plugin:") && line.contains("tree")) {
+                    rootNode = true;
+                    parsing = true;
+                    continue;
+                }
+
+                if (line.trim().endsWith("[INFO]")) {
+                    if (parsing) {
+                        treeList.add(parent);
+                        parent = new TreeNode();
+                        current = new TreeNode();
+                        currentParent = current;
+                        currentindex = 0;
+                        parsing = false;
+                        continue;
+                    }
+                }
+
+                String dep = parseDependency(line);
+                int index = indexOfPattern(line, "- [A-Za-z]");
+
+                if (rootNode) {
+                    rootNode = false;
+                    current.setDependencyName(dep);
+                    current.setParent(parent);
+                    currentParent = current;
+                    parent.addChild(current);
+                    continue;
+                } else if (parsing) {
+                    if (index > currentindex) {
+                        currentParent = current;
+                        TreeNode newnode = new TreeNode(dep);
+                        newnode.setParent(currentParent);
+                        currentParent.addChild(newnode);
+                        currentindex = index;
+                        current = newnode;
+                    } else if (index == currentindex) {
+                        TreeNode newnode = new TreeNode(dep);
+                        newnode.setParent(currentParent);
+                        currentParent.addChild(newnode);
+                        currentindex = index;
+                        current = newnode;
+                    } else {
+                        int diff = (currentindex - index) / 3;
+                        for (int i = 0; i < diff; i++) {
+                            if (currentParent.getParent() != null) {
+                                currentParent = currentParent.getParent();
+                            }
+                        }
+                        TreeNode newnode = new TreeNode(dep);
+                        newnode.setParent(currentParent);
+                        currentParent.addChild(newnode);
+                        current = newnode;
+                        currentindex = index;
+                    }
+                }
+            }
+        } catch (Exception e) {
+            throw e;
+        }
+        return treeList;
+    }
+
+    public ArrayList<String> collectFirstLevelDependencies(ArrayList<TreeNode> treenodes) {
+        ArrayList<String> result = new ArrayList<String>();
+        for (TreeNode tn : treenodes) {
+            if (tn != null) {
+                ArrayList<TreeNode> childNodes = (ArrayList<TreeNode>) tn.getChildren();
+                for (int i = 0; i < childNodes.size(); i++) {
+                    TreeNode node = childNodes.get(i);
+                    // Check that the parent is a org.apache.camel/org.apache.cxf artifact that contains "redhat"
+                    // We are parsing for first level dependencies of camel / cxf artifacts
+                    if ((node.getParent() != null) && (node.getParent().getDependencyName() != null)
+                            && (node.getParent().isCamelArtifact() || node.getParent().isCXF() || node.isFuseSource()
+                                    || node.getParent().isJkube() || node.getParent().isSnowDrop())
+                            && (node.getParent().getDependencyName().contains("redhat"))) {
+                        // If the we're looking at a camel or a CXF artifact, we don't want to add unsupported
+                        // artifacts to our count
+                        if ((node.isCamelArtifact() || node.isCXF())) {
+                            if (node.isProductized()) {
+                                result.add(childNodes.get(i).getDependencyName());
+                            }
+                            // Anything other than a camel or CXF artifact, we want to add it to the count at this point
+                            // Exclude spring-boot, we're not productizing it
+                        } else {
+                            if (!node.isSpringBoot())
+                                result.add(childNodes.get(i).getDependencyName());
+                        }
+                    }
+                    ArrayList<TreeNode> nodeArrayList = new ArrayList<TreeNode>();
+                    nodeArrayList.add(childNodes.get(i));
+
+                    for (String s : collectFirstLevelDependencies(nodeArrayList)) {
+                        result.add(s);
+                    }
+                }
+            }
+        }
+        return result;
+    }
+
+    public static void main(String[] args) {
+        TreeParser treeparser = new TreeParser();
+        try {
+            ArrayList<TreeNode> al = treeparser.parse(args[0]);
+            System.out.println("Size of tree node list : " + al.size());
+            TreeNode tn = (TreeNode) al.get(0);
+
+            ArrayList<String> dependencies = treeparser.collectFirstLevelDependencies(al);
+
+            Set<String> uniqueDependencies = new HashSet<String>(dependencies);
+
+            int counter = 0;
+            int camelCounter = 0;
+            int test = 0;
+            int uniques = 0;
+            for (String prod : uniqueDependencies) {
+
+                if (prod.endsWith(":test")) {
+                    test++;
+                    continue;
+                }
+
+                if (prod.contains(".redhat")) {
+                    counter++;
+                }
+
+                if (prod.contains("org.apache.camel")) {
+                    camelCounter++;
+                }
+
+                if ((args.length > 1) && ("--list".equals(args[1]))) {
+                    System.out.println("dependency " + prod);
+                }
+
+                uniques++;
+
+            }
+            System.out.println("File parsing : " + args[0]);
+            System.out.println("Size : " + dependencies.size());
+            System.out.println("Number of Camel dependencies : " + camelCounter);
+            System.out.println("Number of test dependencies (not counted) : " + test);
+            System.out.println("Number of unique productized dependencies: " + counter);
+            System.out.println("Number of unique dependencies: " + uniques);
+            float pct = (float) counter / uniques;
+            System.out.println("Build from source percentage : " + String.format("%.2f", pct * 100) + "%\n");
+        } catch (Exception e) {
+            e.printStackTrace();
+        }
+    }
+}

--- a/pig/src/test/java/org/jboss/pnc/bacon/pig/impl/addons/camel/TreeNodeTest.java
+++ b/pig/src/test/java/org/jboss/pnc/bacon/pig/impl/addons/camel/TreeNodeTest.java
@@ -1,0 +1,25 @@
+package org.jboss.pnc.bacon.pig.impl.addons.camel;
+
+import org.junit.jupiter.api.Test;
+
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+/**
+ * Unit test for simple App.
+ */
+public class TreeNodeTest {
+    @Test
+    public void testTreeNodes() {
+        TreeNode tn = new TreeNode("foo");
+        TreeNode bar = new TreeNode("bar");
+        TreeNode foobar = new TreeNode("foobar");
+        TreeNode secondLevel = new TreeNode("secondlevel");
+
+        bar.addChild(secondLevel);
+
+        tn.addChild(bar);
+        tn.addChild(foobar);
+
+        assertTrue(tn.getChildren().size() == 2);
+    }
+}

--- a/pig/src/test/java/org/jboss/pnc/bacon/pig/impl/addons/camel/TreeParserTest.java
+++ b/pig/src/test/java/org/jboss/pnc/bacon/pig/impl/addons/camel/TreeParserTest.java
@@ -1,0 +1,54 @@
+package org.jboss.pnc.bacon.pig.impl.addons.camel;
+
+import org.junit.jupiter.api.Test;
+
+import java.io.File;
+import java.util.ArrayList;
+
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+/**
+ * Unit test for simple App.
+ */
+public class TreeParserTest {
+
+    @Test
+    public void testTreeParser() {
+        TreeParser treeparser = new TreeParser();
+
+        try {
+            File file = new File("src/test/resources/camel-build-log.txt");
+            assertTrue(file.exists(), "Could not find file " + file.getName());
+            ArrayList<TreeNode> al = treeparser.parse("src/test/resources/camel-build-log.txt");
+            assertTrue(al.size() == 1, "Expected to find 1 TreeNode, found " + al.size());
+            TreeNode tn = (TreeNode) al.get(0);
+
+            ArrayList<String> dependencies = treeparser.collectFirstLevelDependencies(al);
+            assertTrue(
+                    dependencies.size() == 26,
+                    "Expected to find 26 dependencies, # of dependencies was " + dependencies.size());
+        } catch (Exception e) {
+            e.printStackTrace();
+        }
+    }
+
+    @Test
+    public void testLargerScaleTreeParser() {
+        TreeParser treeparser = new TreeParser();
+
+        try {
+            File file = new File("src/test/resources/camel-build-log.txt");
+            assertTrue(file.exists(), "Could not find file " + file.getName());
+            ArrayList<TreeNode> al = treeparser.parse("src/test/resources/camel-build-log-2.txt");
+            assertTrue(al.size() == 169, "Expected to find 169 tree nodes, found " + al.size());
+            TreeNode tn = (TreeNode) al.get(0);
+
+            ArrayList<String> dependencies = treeparser.collectFirstLevelDependencies(al);
+            assertTrue(
+                    dependencies.size() == 3806,
+                    "Expected to find 3854 dependencies, # of dependencies was " + dependencies.size());
+        } catch (Exception e) {
+            e.printStackTrace();
+        }
+    }
+}

--- a/pig/src/test/resources/camel-build-log.txt
+++ b/pig/src/test/resources/camel-build-log.txt
@@ -1,0 +1,69 @@
+[INFO] --- maven-dependency-plugin:3.2.0:tree (default-cli) @ camel-package-maven-plugin ---
+[INFO] org.apache.camel:camel-package-maven-plugin:maven-plugin:3.18.2.redhat-00002
+[INFO] +- org.apache.camel:camel-util-json:jar:3.18.2.redhat-00002:compile
+[INFO] +- org.apache.camel:camel-tooling-util:jar:3.18.2.redhat-00002:compile
+[INFO] +- org.apache.camel:camel-tooling-model:jar:3.18.2.redhat-00002:compile
+[INFO] +- org.mvel:mvel2:jar:2.4.14.Final:compile
+[INFO] +- org.apache.maven:maven-core:jar:3.1.1:provided
+[INFO] |  +- org.apache.maven:maven-model:jar:3.1.1:provided
+[INFO] |  +- org.apache.maven:maven-settings:jar:3.1.1:provided
+[INFO] |  +- org.apache.maven:maven-settings-builder:jar:3.1.1:provided
+[INFO] |  +- org.apache.maven:maven-repository-metadata:jar:3.1.1:provided
+[INFO] |  +- org.apache.maven:maven-model-builder:jar:3.1.1:provided
+[INFO] |  +- org.apache.maven:maven-aether-provider:jar:3.1.1:provided
+[INFO] |  |  \- org.eclipse.aether:aether-spi:jar:0.9.0.M2:provided
+[INFO] |  +- org.eclipse.aether:aether-impl:jar:0.9.0.M2:provided
+[INFO] |  +- org.eclipse.aether:aether-api:jar:0.9.0.M2:compile
+[INFO] |  +- org.eclipse.aether:aether-util:jar:0.9.0.M2:compile
+[INFO] |  +- org.eclipse.sisu:org.eclipse.sisu.plexus:jar:0.0.0.M5:provided
+[INFO] |  |  +- javax.enterprise:cdi-api:jar:1.0:provided
+[INFO] |  |  |  +- javax.annotation:jsr250-api:jar:1.0:provided
+[INFO] |  |  |  \- javax.inject:javax.inject:jar:1:provided
+[INFO] |  |  +- com.google.guava:guava:jar:20.0:provided
+[INFO] |  |  +- org.sonatype.sisu:sisu-guice:jar:no_aop:3.1.0:provided
+[INFO] |  |  |  \- aopalliance:aopalliance:jar:1.0:provided
+[INFO] |  |  \- org.eclipse.sisu:org.eclipse.sisu.inject:jar:0.0.0.M5:provided
+[INFO] |  +- org.codehaus.plexus:plexus-interpolation:jar:1.19:provided
+[INFO] |  +- org.codehaus.plexus:plexus-classworlds:jar:2.5.1:compile
+[INFO] |  +- org.codehaus.plexus:plexus-component-annotations:jar:1.5.5:compile
+[INFO] |  \- org.sonatype.plexus:plexus-sec-dispatcher:jar:1.3:provided
+[INFO] |     \- org.sonatype.plexus:plexus-cipher:jar:1.4:provided
+[INFO] +- org.apache.maven:maven-artifact:jar:3.1.1:provided
+[INFO] +- org.apache.maven:maven-plugin-api:jar:3.1.1:provided
+[INFO] +- org.apache.maven.plugin-tools:maven-plugin-annotations:jar:3.6.4:compile
+[INFO] +- org.apache.maven:maven-compat:jar:3.1.1:provided
+[INFO] |  \- org.apache.maven.wagon:wagon-provider-api:jar:2.4:provided
+[INFO] +- org.apache.maven.shared:maven-dependency-tree:jar:2.2:compile
+[INFO] +- org.codehaus.plexus:plexus-container-default:jar:1.6.0.redhat-00003:compile
+[INFO] |  +- org.apache.xbean:xbean-reflect:jar:3.7:compile
+[INFO] |  \- com.google.collections:google-collections:jar:1.0:compile
+[INFO] +- org.codehaus.plexus:plexus-utils:jar:3.3.0.redhat-00001:compile
+[INFO] +- org.sonatype.plexus:plexus-build-api:jar:0.0.7:compile
+[INFO] +- commons-io:commons-io:jar:2.11.0.redhat-00001:compile
+[INFO] +- org.apache.commons:commons-text:jar:1.9.0.redhat-00001:compile
+[INFO] |  \- org.apache.commons:commons-lang3:jar:3.11.0.redhat-00001:compile
+[INFO] +- org.jboss.forge.roaster:roaster-api:jar:2.24.0.Final:compile
+[INFO] +- org.jboss.forge.roaster:roaster-jdt:jar:2.24.0.Final:compile
+[INFO] +- org.jboss:jandex:jar:2.4.3.Final-redhat-00001:compile
+[INFO] +- org.ow2.asm:asm-tree:jar:8.0.1:compile
+[INFO] |  \- org.ow2.asm:asm:jar:8.0.1:compile
+[INFO] +- org.apache.camel:spi-annotations:jar:3.18.2.redhat-00002:compile
+[INFO] +- jakarta.xml.bind:jakarta.xml.bind-api:jar:2.3.3:compile
+[INFO] |  \- jakarta.activation:jakarta.activation-api:jar:1.2.2:compile
+[INFO] +- org.snakeyaml:snakeyaml-engine:jar:2.3.0.redhat-00001:compile
+[INFO] +- org.apache.logging.log4j:log4j-slf4j-impl:jar:2.17.2.redhat-00003:test
+[INFO] |  +- org.slf4j:slf4j-api:jar:1.7.36.redhat-00002:test
+[INFO] |  +- org.apache.logging.log4j:log4j-api:jar:2.17.2.redhat-00003:test
+[INFO] |  \- org.apache.logging.log4j:log4j-core:jar:2.17.2.redhat-00003:test
+[INFO] +- org.junit.jupiter:junit-jupiter:jar:5.8.2:test
+[INFO] |  +- org.junit.jupiter:junit-jupiter-api:jar:5.8.2:test
+[INFO] |  |  +- org.opentest4j:opentest4j:jar:1.2.0:test
+[INFO] |  |  +- org.junit.platform:junit-platform-commons:jar:1.8.2:test
+[INFO] |  |  \- org.apiguardian:apiguardian-api:jar:1.1.2:test
+[INFO] |  +- org.junit.jupiter:junit-jupiter-params:jar:5.8.2:test
+[INFO] |  \- org.junit.jupiter:junit-jupiter-engine:jar:5.8.2:test
+[INFO] |     \- org.junit.platform:junit-platform-engine:jar:1.8.2:test
+[INFO] +- org.assertj:assertj-core:jar:3.23.1:test
+[INFO] |  \- net.bytebuddy:byte-buddy:jar:1.12.10:test
+[INFO] \- javax.annotation:javax.annotation-api:jar:1.3.2.redhat-00001:compile
+[INFO]


### PR DESCRIPTION
Add a new CamelRuntimeDependenciesToAlignTree which can determine first-level dependencies and filter out non-supported artifacts.     At the moment it is camel specific and filters artifacts on specific requirements that the Fuse teams have, but I'd like to parameterize it more in the future so that it could be used by other teams.

Added unit tests for new classes.
