### PR TITLE
Update the license exception for zstd-jni to be regex based

### DIFF
--- a/pig/src/main/resources/rh-license-exceptions.json
+++ b/pig/src/main/resources/rh-license-exceptions.json
@@ -1199,7 +1199,7 @@
   {
     "groupId": "com.github.luben",
     "artifactId": "zstd-jni",
-    "version": "1.5.0.2-redhat-00003",
+    "version": "1\\.5\\..+",
     "licenses": [
       {
         "name": "BSD 2-clause \"Simplified\" License",


### PR DESCRIPTION
Update the license exception for com.github.luben:zstd-jni to be regex based

### Checklist:

* [ ] Have you added a note in the [CHANGELOG wiki](https://github.com/project-ncl/bacon/wiki/Changelog) for your change if user-facing?
* [ ] Have you added unit tests for your change?
