### PR TITLE
Add new options to pig export build-config

### DIFF
--- a/pig/src/main/java/org/jboss/pnc/bacon/pig/PigExport.java
+++ b/pig/src/main/java/org/jboss/pnc/bacon/pig/PigExport.java
@@ -7,7 +7,10 @@ import org.jboss.pnc.bacon.pnc.common.ClientCreator;
 import org.jboss.pnc.client.BuildConfigurationClient;
 import org.jboss.pnc.client.ClientException;
 import org.jboss.pnc.dto.BuildConfiguration;
+import org.jboss.pnc.dto.BuildConfigurationRevision;
 import picocli.CommandLine;
+
+import java.util.Optional;
 
 @CommandLine.Command(
         name = "export",
@@ -20,6 +23,21 @@ public class PigExport {
             description = "Export a build-config in a format that can be injected into PiG's build-config.yaml")
     public static class BuildConfigExport extends AbstractGetSpecificCommand<BuildConfig> {
 
+        @CommandLine.Option(
+                names = "--revision",
+                description = "Revision of the build config. By default the current revision is used.")
+        private Integer revision;
+
+        @CommandLine.Option(
+                names = "--environment-by-name",
+                description = "Export config with environment name instead of environment image id.")
+        private boolean envByName = false;
+
+        @CommandLine.Option(
+                names = "--rename",
+                description = "Use this name for the exported build config instead of the original one.")
+        private String rename;
+
         private static final ClientCreator<BuildConfigurationClient> CREATOR = new ClientCreator<>(
                 BuildConfigurationClient::new);
 
@@ -27,7 +45,16 @@ public class PigExport {
         public BuildConfig getSpecific(String id) throws ClientException {
             try (BuildConfigurationClient client = CREATOR.newClient()) {
                 BuildConfiguration bc = client.getSpecific(id);
-                return BuildConfigMapping.toBuildConfig(bc);
+                BuildConfigMapping.GeneratorOptions opts = BuildConfigMapping.GeneratorOptions.builder()
+                        .useEnvironmentName(envByName)
+                        .nameOverride(Optional.ofNullable(rename))
+                        .build();
+                if (revision != null) {
+                    BuildConfigurationRevision bcr = client.getRevision(id, revision);
+                    return BuildConfigMapping.toBuildConfig(bc, bcr, opts);
+                } else {
+                    return BuildConfigMapping.toBuildConfig(bc, opts);
+                }
             }
         }
     }

--- a/pig/src/main/java/org/jboss/pnc/bacon/pig/impl/mapping/BuildConfigMapping.java
+++ b/pig/src/main/java/org/jboss/pnc/bacon/pig/impl/mapping/BuildConfigMapping.java
@@ -1,18 +1,26 @@
 package org.jboss.pnc.bacon.pig.impl.mapping;
 
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Data;
+import lombok.NoArgsConstructor;
 import org.jboss.pnc.bacon.pig.impl.config.BuildConfig;
 import org.jboss.pnc.dto.BuildConfiguration;
+import org.jboss.pnc.dto.BuildConfigurationRevision;
+import org.jboss.pnc.dto.Environment;
 
 import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.HashSet;
 import java.util.Map;
+import java.util.Optional;
 
 public class BuildConfigMapping {
 
-    public static BuildConfig toBuildConfig(BuildConfiguration buildConfiguration) {
+    public static BuildConfig toBuildConfig(BuildConfiguration buildConfiguration, GeneratorOptions options) {
         BuildConfig buildConfig = new BuildConfig();
-        buildConfig.setName(buildConfiguration.getName());
+
+        buildConfig.setName(options.getNameOverride().orElseGet(buildConfiguration::getName));
         buildConfig.setProject(buildConfiguration.getProject().getName());
         buildConfig.setBuildScript(buildConfiguration.getBuildScript());
 
@@ -25,20 +33,54 @@ public class BuildConfigMapping {
         buildConfig.setScmRevision(buildConfiguration.getScmRevision());
         buildConfig.setDescription(buildConfiguration.getDescription());
 
-        // favor systemImageId
-        buildConfig.setSystemImageId(buildConfiguration.getEnvironment().getSystemImageId());
+        setEnvironment(buildConfig, buildConfiguration.getEnvironment(), options);
         buildConfig.setDependencies(new ArrayList<>(buildConfiguration.getDependencies().keySet()));
 
         buildConfig.setBrewPullActive(buildConfiguration.getBrewPullActive());
         buildConfig.setBuildType(buildConfiguration.getBuildType().toString());
 
-        setBuildConfigFieldsBasedOnParameters(buildConfiguration, buildConfig);
+        setBuildConfigFieldsBasedOnParameters(buildConfig, buildConfiguration.getParameters());
         return buildConfig;
     }
 
-    static void setBuildConfigFieldsBasedOnParameters(BuildConfiguration buildConfiguration, BuildConfig buildConfig) {
+    public static BuildConfig toBuildConfig(
+            BuildConfiguration buildConfiguration,
+            BuildConfigurationRevision revision,
+            GeneratorOptions options) {
+        BuildConfig buildConfig = new BuildConfig();
+        buildConfig.setName(options.getNameOverride().orElseGet(revision::getName));
+        buildConfig.setProject(revision.getProject().getName());
+        buildConfig.setBuildScript(revision.getBuildScript());
 
-        Map<String, String> parameters = buildConfiguration.getParameters();
+        if (revision.getScmRepository().getExternalUrl() != null) {
+            buildConfig.setScmUrl(revision.getScmRepository().getExternalUrl());
+        } else {
+            buildConfig.setScmUrl(revision.getScmRepository().getInternalUrl());
+        }
+
+        buildConfig.setScmRevision(revision.getScmRevision());
+        buildConfig.setDescription(buildConfiguration.getDescription());
+
+        setEnvironment(buildConfig, revision.getEnvironment(), options);
+        buildConfig.setDependencies(new ArrayList<>(buildConfiguration.getDependencies().keySet()));
+
+        buildConfig.setBrewPullActive(buildConfiguration.getBrewPullActive());
+        buildConfig.setBuildType(revision.getBuildType().toString());
+
+        setBuildConfigFieldsBasedOnParameters(buildConfig, revision.getParameters());
+        return buildConfig;
+    }
+
+    private static void setEnvironment(BuildConfig buildConfig, Environment environment, GeneratorOptions options) {
+        // favor systemImageId
+        if (options.useEnvironmentName) {
+            buildConfig.setEnvironmentName(environment.getName());
+        } else {
+            buildConfig.setSystemImageId(environment.getSystemImageId());
+        }
+    }
+
+    static void setBuildConfigFieldsBasedOnParameters(BuildConfig buildConfig, Map<String, String> parameters) {
 
         // TODO: could this code be unified with the code in BuildConfig.java?
         if (parameters.containsKey("ALIGNMENT_PARAMETERS")) {
@@ -75,5 +117,14 @@ public class BuildConfigMapping {
         if (!parameters.isEmpty()) {
             buildConfig.setParameters(parameters);
         }
+    }
+
+    @Data
+    @NoArgsConstructor
+    @AllArgsConstructor
+    @Builder
+    public static class GeneratorOptions {
+        private boolean useEnvironmentName = false;
+        private Optional<String> nameOverride = Optional.empty();
     }
 }


### PR DESCRIPTION
--revision to select build config revision to export --environment-by-name to export with environmentName instead of environmentImageID
--rename to set the name of the exported build config

### Checklist:

* [ ] Have you added a note in the [CHANGELOG wiki](https://github.com/project-ncl/bacon/wiki/Changelog) for your change if user-facing?
* [ ] Have you added unit tests for your change?
