### PR TITLE
Add tests for methods in GAV class

### DIFF
--- a/pig/src/main/java/org/jboss/pnc/bacon/pig/impl/utils/GAV.java
+++ b/pig/src/main/java/org/jboss/pnc/bacon/pig/impl/utils/GAV.java
@@ -28,7 +28,9 @@ import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 import org.w3c.dom.Element;
 
+import java.util.Arrays;
 import java.util.Comparator;
+import java.util.List;
 import java.util.Map;
 
 import static org.apache.commons.lang3.StringUtils.isBlank;
@@ -51,26 +53,38 @@ public class GAV {
     private String version; // not final for jackson
     private String scope;
     private String classifier;
+    // Extensions with no "standard" format, like having a dot on it
+    List<String> extensionExceptions = Arrays.asList("tar.gz", "tar.bz2");
 
     @Deprecated // for jackson
     public GAV() {
 
     }
 
-    public GAV(String path) {
-        log.debug("parsing artifact path {}", path);
+    public GAV(String artifactPath) {
+        log.debug("parsing artifact path {}", artifactPath);
 
-        path = FilenameUtils.normalizeNoEndSeparator(path, true);
+        final String path = FilenameUtils.normalizeNoEndSeparator(artifactPath, true);
 
         int versionEnd = path.lastIndexOf('/');
         int artifactEnd = path.lastIndexOf('/', versionEnd - 1);
         int groupEnd = path.lastIndexOf('/', artifactEnd - 1);
 
         try {
-            packaging = path.substring(path.lastIndexOf('.') + 1);
+            packaging = extensionExceptions.stream()
+                    .filter(e -> path.endsWith("." + e))
+                    .findFirst()
+                    .orElse(path.substring(path.lastIndexOf('.') + 1));
             version = path.substring(artifactEnd + 1, versionEnd);
             artifactId = path.substring(groupEnd + 1, artifactEnd);
             groupId = path.substring(0, groupEnd).replaceAll("/", ".");
+            try {
+                classifier = path
+                        .substring(path.lastIndexOf(version) + version.length() + 1, path.lastIndexOf(packaging) - 1);
+            } catch (Exception e) {
+                // artifact doesn't have a classifier
+                classifier = null;
+            }
         } catch (StringIndexOutOfBoundsException parsingException) {
             throw new RuntimeException("Unable to parse path " + path + " to artifact", parsingException);
         }
@@ -124,7 +138,11 @@ public class GAV {
     }
 
     public String toGapvc() {
-        return String.format("%s:%s:%s:%s:%s", groupId, artifactId, packaging, version, classifier);
+        if (classifier == null) {
+            return String.format("%s:%s:%s:%s", groupId, artifactId, packaging, version);
+        } else {
+            return String.format("%s:%s:%s:%s:%s", groupId, artifactId, packaging, version, classifier);
+        }
     }
 
     public String toVersionPath() {

--- a/pig/src/test/java/org/jboss/pnc/bacon/pig/impl/utils/GAVTest.java
+++ b/pig/src/test/java/org/jboss/pnc/bacon/pig/impl/utils/GAVTest.java
@@ -36,4 +36,54 @@ class GAVTest {
         assertThat(gav.getScope()).isNull();
         assertThat(gav.getClassifier()).isNull();
     }
+
+    @Test
+    void testGetGavFromPath() {
+        // Artifact with classifier
+        String path = "org/kie/kogito/kogito-ddl-runtimes/1.32.0.Final-redhat-00003/kogito-ddl-runtimes-1.32.0.Final-redhat-00003-db-scripts.zip";
+        GAV gav = new GAV(path);
+
+        assertThat(gav.getGroupId()).isEqualTo("org.kie.kogito");
+        assertThat(gav.getArtifactId()).isEqualTo("kogito-ddl-runtimes");
+        assertThat(gav.getVersion()).isEqualTo("1.32.0.Final-redhat-00003");
+        assertThat(gav.getPackaging()).isEqualTo("zip");
+        assertThat(gav.getClassifier()).isEqualTo("db-scripts");
+
+        // Artifact without classifier
+        path = "com/fasterxml/jackson/core/jackson-databind/2.13.4.2-redhat-00001/jackson-databind-2.13.4.2-redhat-00001.jar";
+        gav = new GAV(path);
+
+        assertThat(gav.getGroupId()).isEqualTo("com.fasterxml.jackson.core");
+        assertThat(gav.getArtifactId()).isEqualTo("jackson-databind");
+        assertThat(gav.getVersion()).isEqualTo("2.13.4.2-redhat-00001");
+        assertThat(gav.getPackaging()).isEqualTo("jar");
+        assertThat(gav.getClassifier()).isNull();
+
+        // Artifact with classifier and extension with a dot (tar.gz)
+        path = "org/kie/kogito/kogito-runtimes/1.32.0.Final-redhat-00003/kogito-runtimes-1.32.0.Final-redhat-00003-project-sources.tar.gz";
+        gav = new GAV(path);
+
+        assertThat(gav.getGroupId()).isEqualTo("org.kie.kogito");
+        assertThat(gav.getArtifactId()).isEqualTo("kogito-runtimes");
+        assertThat(gav.getVersion()).isEqualTo("1.32.0.Final-redhat-00003");
+        assertThat(gav.getPackaging()).isEqualTo("tar.gz");
+        assertThat(gav.getClassifier()).isEqualTo("project-sources");
+    }
+
+    @Test
+    void testGetGapvc() {
+        // Artifact without classifier
+        String gapvc = "com.fasterxml.jackson.core:jackson-databin:jar:2.13.4.2-redhat-00001";
+        String[] sections = gapvc.split(":");
+        GAV gav = new GAV(sections[0], sections[1], sections[3], sections[2]);
+
+        assertThat(gav.toGapvc()).isEqualTo(gapvc);
+
+        // Artifact with classifier
+        gapvc = "org.kie.kogito:kogito-ddl-runtime:zip:1.32.0.Final-redhat-00003:db-scripts";
+        sections = gapvc.split(":");
+        gav = new GAV(sections[0], sections[1], sections[3], sections[2], sections[4]);
+
+        assertThat(gav.toGapvc()).isEqualTo(gapvc);
+    }
 }


### PR DESCRIPTION
- Add tests for GAV(String path) constructor and toGapvc() method
- Fix issue in GAV(String path) constructor which didn't handle packaging with a dot and didn't setup the classifier
- Fix issue in toGapvc() method which returned classifier null when it doesn't exist instead of dropping it from the String

