### PR TITLE
Upgrade to Domino 0.0.79 and Quarkus 2.16.4.Final

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -75,6 +75,7 @@
 
     <properties>
         <compiler.plugin.version>3.8.1</compiler.plugin.version>
+        <domino.version>0.0.79</domino.version>
         <jackson.version>2.13.1</jackson.version>
         <jaxb.version>2.2.11</jaxb.version>
         <junit.version>5.8.2</junit.version>
@@ -88,7 +89,7 @@
         <pnc.version>2.5.0-SNAPSHOT</pnc.version>
 
         <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
-        <quarkus.resolver.version>2.15.3.Final</quarkus.resolver.version>
+        <quarkus.resolver.version>2.16.4.Final</quarkus.resolver.version>
         <tagSuffix />
     </properties>
 
@@ -444,7 +445,7 @@
             <dependency>
                 <groupId>io.quarkus</groupId>
                 <artifactId>quarkus-domino-api</artifactId>
-                <version>0.0.78</version>
+                <version>${domino.version}</version>
                 <exclusions>
                     <exclusion>
                         <groupId>org.jboss.slf4j</groupId>


### PR DESCRIPTION
* 0.0.79 includes a critical fix when sorting project releases for the build. It is now taking into account *only* the direct dependencies of the artifacts as their appear in their POMs, instead of also those that appear as their direct dependencies in the dependency trees generated for the root project artifacts;
* Quarkus resolver 2.16.4.Final is what Domino is currently using.

### Checklist:

* [ ] Have you added a note in the [CHANGELOG wiki](https://github.com/project-ncl/bacon/wiki/Changelog) for your change if user-facing?
* [ ] Have you added unit tests for your change?
