### PR TITLE
[AB] Fix detecting exact match for -redhat versions

### DIFF
--- a/experimental/src/main/java/org/jboss/bacon/experimental/impl/generator/BuildConfigGenerator.java
+++ b/experimental/src/main/java/org/jboss/bacon/experimental/impl/generator/BuildConfigGenerator.java
@@ -221,6 +221,8 @@ public class BuildConfigGenerator {
                 .useEnvironmentName(useEnvironmentName)
                 .build();
         BuildConfig buildConfig = BuildConfigMapping.toBuildConfig(bc, bcr, opts);
+        String copyMessage = "# Autobuilder copied this Build Config from BC #" + bcr.getId() + " rev " + bcr.getRev();
+        buildConfig.setBuildScript(copyMessage + "\n" + buildConfig.getBuildScript());
         String scmUrl = processScmUrl(buildConfig.getScmUrl());
         if (scmUrl == null) {
             setPlaceholderSCM(name, buildConfig);

--- a/experimental/src/main/java/org/jboss/bacon/experimental/impl/projectfinder/ProjectFinder.java
+++ b/experimental/src/main/java/org/jboss/bacon/experimental/impl/projectfinder/ProjectFinder.java
@@ -109,8 +109,9 @@ public class ProjectFinder {
     }
 
     private boolean isExactVersion(String query, String found) {
-        String suffixless = found.replaceFirst("[.-]redhat-[0-9]+$", "");
-        return query.equals(suffixless);
+        String suffixlessQuery = query.replaceFirst("[.-]redhat-[0-9]+$", "");
+        String suffixlessFound = found.replaceFirst("[.-]redhat-[0-9]+$", "");
+        return suffixlessQuery.equals(suffixlessFound);
     }
 
     private boolean validateBuild(Set<GAV> gavs, Build build) {


### PR DESCRIPTION
Also adds a message to builds script from what build config revision was a generated build config copied from.

### Checklist:

* [ ] Have you added a note in the [CHANGELOG wiki](https://github.com/project-ncl/bacon/wiki/Changelog) for your change if user-facing?
* [ ] Have you added unit tests for your change?
