### PR TITLE
Upgrade to Domino 0.0.86 and Quarkus 2.16.6.Final

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -75,7 +75,7 @@
 
     <properties>
         <compiler.plugin.version>3.8.1</compiler.plugin.version>
-        <domino.version>0.0.79</domino.version>
+        <domino.version>0.0.86</domino.version>
         <jackson.version>2.13.1</jackson.version>
         <jaxb.version>2.2.11</jaxb.version>
         <junit.version>5.8.2</junit.version>
@@ -89,7 +89,7 @@
         <pnc.version>2.5.0-SNAPSHOT</pnc.version>
 
         <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
-        <quarkus.resolver.version>2.16.4.Final</quarkus.resolver.version>
+        <quarkus.resolver.version>2.16.6.Final</quarkus.resolver.version>
         <tagSuffix />
     </properties>
 


### PR DESCRIPTION
This upgrade brings in the following changes
* a fix in the HACBS SCM locator related to ordering of recipe repos in the configuration
* when a project BOM is specified for dependency analysis and top project artifacts **are not configured**, previously the groupId of the BOM would be used to select the top project artifacts found in the BOM, even if artifact inclusion patterns were configured. This version of Domino will default to the BOM groupId only if top project artifacts were not configured and no artifact inclusion patterns were configured. If inclusion patterns were configured, they would be used instead of using the BOM groupId.
* the default value of `includeNonManaged` was changed to `true`.

FYI @janinko 

### Checklist:

* [ ] Have you added a note in the [CHANGELOG wiki](https://github.com/project-ncl/bacon/wiki/Changelog) for your change if user-facing?
* [ ] Have you added unit tests for your change?
