### PR TITLE
Upgrade to Domino 0.0.92 and Quarkus 2.16.7.Final

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -75,7 +75,7 @@
 
     <properties>
         <compiler.plugin.version>3.8.1</compiler.plugin.version>
-        <domino.version>0.0.86</domino.version>
+        <domino.version>0.0.92</domino.version>
         <jackson.version>2.13.1</jackson.version>
         <jaxb.version>2.2.11</jaxb.version>
         <junit.version>5.8.2</junit.version>
@@ -91,7 +91,7 @@
         <pnc.version>2.5.0-SNAPSHOT</pnc.version>
 
         <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
-        <quarkus.resolver.version>2.16.6.Final</quarkus.resolver.version>
+        <quarkus.resolver.version>2.16.7.Final</quarkus.resolver.version>
         <tagSuffix />
     </properties>
 


### PR DESCRIPTION
Fixes Domino Gradle plugin dependency resolution when analyzing Gradle projects, among other things.

FYI @janinko 

### Checklist:

* [ ] Have you added a note in the [CHANGELOG wiki](https://github.com/project-ncl/bacon/wiki/Changelog) for your change if user-facing?
* [ ] Have you added unit tests for your change?
