### PR TITLE
[NCL-7238] Generate proper download url for GAV

### DIFF
--- a/pig/src/main/java/org/jboss/pnc/bacon/pig/impl/utils/GAV.java
+++ b/pig/src/main/java/org/jboss/pnc/bacon/pig/impl/utils/GAV.java
@@ -46,6 +46,13 @@ public class GAV {
     private static final Logger log = LoggerFactory.getLogger(GAV.class);
 
     public static final Comparator<GAV> gapvcComparator = Comparator.comparing(GAV::toGapvc);
+    /**
+     * See NCL-7238. Some gavs have no packaging due to weird Maven behaviour. In PNC, we need to specify a packaging to
+     * generate a valid PURL and to avoid duplicates of artifacts. Therefore we chose to use the "empty" packaging.
+     *
+     * Also specified in repository-driver
+     */
+    public static final String FILE_NO_EXTENSION_PACKAGING = "empty";
 
     private String packaging; // not final for jackson
     private String groupId; // not final for jackson
@@ -154,10 +161,18 @@ public class GAV {
     }
 
     public String toFileName() {
-        if (classifier == null) {
-            return String.format("%s-%s.%s", artifactId, version, packaging);
+        if (FILE_NO_EXTENSION_PACKAGING.equals(packaging)) {
+            if (classifier == null) {
+                return String.format("%s-%s", artifactId, version);
+            } else {
+                return String.format("%s-%s-%s", artifactId, version, classifier);
+            }
         } else {
-            return String.format("%s-%s-%s.%s", artifactId, version, classifier, packaging);
+            if (classifier == null) {
+                return String.format("%s-%s.%s", artifactId, version, packaging);
+            } else {
+                return String.format("%s-%s-%s.%s", artifactId, version, classifier, packaging);
+            }
         }
     }
 

--- a/pig/src/test/java/org/jboss/pnc/bacon/pig/impl/utils/GAVTest.java
+++ b/pig/src/test/java/org/jboss/pnc/bacon/pig/impl/utils/GAVTest.java
@@ -86,4 +86,26 @@ class GAVTest {
 
         assertThat(gav.toGapvc()).isEqualTo(gapvc);
     }
+
+    /**
+     * This test is related to NCL-7238: when an artifact has no packaging, we just set the packaging to string "empty"
+     * to generate proper PURL and to avoid artifact duplicates. Unfortunately this affects how the GAV uri is generated
+     * <p/>
+     * This is a test to make sure we handle it properly
+     */
+    @Test
+    void testEmptyPackagingUri() {
+        String gapvc = "com.fasterxml.jackson.core:jackson-databin:pom:2.13.4";
+        GAV gav = GAV.fromColonSeparatedGAPV(gapvc);
+        assertThat(gav.toFileName()).isEqualTo("jackson-databin-2.13.4.pom");
+        assertThat(gav.toUri())
+                .isEqualTo("com/fasterxml/jackson/core/jackson-databin/2.13.4/jackson-databin-2.13.4.pom");
+
+        // with empty packaging, there should be no extension in the filename or url
+        String gapvcEmpty = "com.fasterxml.jackson.core:jackson-databin:empty:2.13.4";
+        GAV gavEmpty = GAV.fromColonSeparatedGAPV(gapvcEmpty);
+        assertThat(gavEmpty.toFileName()).isEqualTo("jackson-databin-2.13.4");
+        assertThat(gavEmpty.toUri())
+                .isEqualTo("com/fasterxml/jackson/core/jackson-databin/2.13.4/jackson-databin-2.13.4");
+    }
 }


### PR DESCRIPTION
Do this when the packaging is 'empty'. We set the packaging to 'empty' in PNC when there are no packaging to generate proper purl and to avoid artifact duplicates

### Checklist:

* [ ] Have you added a note in the [CHANGELOG wiki](https://github.com/project-ncl/bacon/wiki/Changelog) for your change if user-facing?
* [ ] Have you added unit tests for your change?
