### PR TITLE
Rework bacon to redirect auth to SSO and not deal with passwords

### DIFF
--- a/auth/pom.xml
+++ b/auth/pom.xml
@@ -23,6 +23,11 @@
             <artifactId>lombok</artifactId>
         </dependency>
 
+        <dependency>
+            <groupId>org.keycloak</groupId>
+            <artifactId>keycloak-installed-adapter</artifactId>
+        </dependency>
+
         <!-- logging -->
         <dependency>
             <groupId>org.slf4j</groupId>

--- a/auth/src/main/java/org/jboss/pnc/bacon/auth/model/Credential.java
+++ b/auth/src/main/java/org/jboss/pnc/bacon/auth/model/Credential.java
@@ -47,7 +47,7 @@ public class Credential {
         if (!isValid()) {
             return true;
         } else {
-            return Instant.now().until(accessTokenExpiresIn, ChronoUnit.HOURS) < 20;
+            return Instant.now().until(accessTokenExpiresIn, ChronoUnit.MINUTES) < 1;
         }
     }
 

--- a/auth/src/test/java/org/jboss/pnc/bacon/auth/KeycloakClientImplTest.java
+++ b/auth/src/test/java/org/jboss/pnc/bacon/auth/KeycloakClientImplTest.java
@@ -6,11 +6,11 @@ import org.junit.jupiter.api.Test;
 
 import static org.junit.jupiter.api.Assertions.*;
 
-class DirectKeycloakClientImplTest {
+class KeycloakClientImplTest {
 
     @Test
     void testGetServiceAccountFatalExceptionThrownOnTLSCertException() {
-        KeycloakClient keycloakClient = new DirectKeycloakClientImpl();
+        KeycloakClient keycloakClient = new KeycloakClientImpl();
         try {
             keycloakClient.getCredentialServiceAccount(
                     "https://self-signed.badssl.com",

--- a/cli/src/test/java/org/jboss/pnc/bacon/cli/AppTest.java
+++ b/cli/src/test/java/org/jboss/pnc/bacon/cli/AppTest.java
@@ -189,26 +189,7 @@ class AppTest {
         ObjectHelper.setRootLoggingLevel(Level.INFO);
         ObjectHelper.setLoggingLevel("org.jboss.pnc.client", Level.WARN);
 
-        String text;
-        text = tapSystemErr(
-                () -> assertEquals(
-                        1,
-                        new App().run(
-                                new String[] {
-                                        "-p",
-                                        configYaml.toString(),
-                                        "pig",
-                                        "configure",
-                                        "--releaseStorageUrl",
-                                        "http://www.example.com",
-                                        "--tempBuild",
-                                        buildConfig.toString() })));
-
-        assertThat(text).contains("Keycloak authentication failed!");
-        assertThat(text).doesNotContain("at org.jboss.pnc.bacon.pnc.client.PncClientHelper.getBearerToken");
-        assertThat(text).doesNotContain("Unknown option: '--tempBuild'");
-
-        text = tapSystemErr(
+        String text = tapSystemErr(
                 () -> assertEquals(
                         1,
                         new App().run(

--- a/pnc/src/main/java/org/jboss/pnc/bacon/pnc/client/PncClientHelper.java
+++ b/pnc/src/main/java/org/jboss/pnc/bacon/pnc/client/PncClientHelper.java
@@ -18,8 +18,7 @@
 package org.jboss.pnc.bacon.pnc.client;
 
 import lombok.extern.slf4j.Slf4j;
-import org.jboss.pnc.bacon.auth.DirectKeycloakClientImpl;
-import org.jboss.pnc.bacon.auth.KeycloakClientException;
+import org.jboss.pnc.bacon.auth.KeycloakClientImpl;
 import org.jboss.pnc.bacon.auth.model.Credential;
 import org.jboss.pnc.bacon.auth.spi.KeycloakClient;
 import org.jboss.pnc.bacon.common.exception.FatalException;
@@ -111,7 +110,7 @@ public class PncClientHelper {
 
         try {
 
-            KeycloakClient client = new DirectKeycloakClientImpl();
+            KeycloakClient client = new KeycloakClientImpl();
 
             Credential credential;
 
@@ -127,11 +126,12 @@ public class PncClientHelper {
                         keycloakConfig.getRealm(),
                         keycloakConfig.getClientId(),
                         keycloakConfig.getUsername());
+
             }
 
             return credential.getAccessToken();
 
-        } catch (KeycloakClientException e) {
+        } catch (Exception e) {
             throw new FatalException("Keycloak authentication failed!", e);
         }
     }
@@ -147,7 +147,7 @@ public class PncClientHelper {
                     log.warn("***********************");
                 }
             } catch (RemoteResourceException e) {
-                log.error(e.getMessage());
+                log.error("Could not get announcements: " + e);
             }
 
             bannerChecked = true;

--- a/pom.xml
+++ b/pom.xml
@@ -193,6 +193,12 @@
                 <artifactId>jline-console</artifactId>
                 <version>3.21.0</version>
             </dependency>
+
+            <dependency>
+                <groupId>org.keycloak</groupId>
+                <artifactId>keycloak-installed-adapter</artifactId>
+                <version>21.1.2</version>
+            </dependency>
             <!-- I need this, otherwise the snowdrop dependency overrides the version and it messes things up -->
             <dependency>
                 <groupId>org.jboss.resteasy</groupId>


### PR DESCRIPTION
Firstly I created new client but by the point I got service account working it was either reusing existing logic or being too complicated so I threw it away and reused old stuff for service accounts and just used different client to redirect user auth to keycloak.