### PR TITLE
[NCL-8087] Remove check for BC "stealing"

### DIFF
--- a/pig/src/main/java/org/jboss/pnc/bacon/pig/impl/pnc/PncEntitiesImporter.java
+++ b/pig/src/main/java/org/jboss/pnc/bacon/pig/impl/pnc/PncEntitiesImporter.java
@@ -504,7 +504,6 @@ public class PncEntitiesImporter implements Closeable {
 
         List<BuildConfiguration> incompatibleConfigs = currentConfigs.stream()
                 .filter(config -> newConfigsByName.containsKey(config.getName()))
-                .filter(config -> isModifiedInUnsupportedWay(config, newConfigsByName))
                 .collect(Collectors.toList());
         if (!incompatibleConfigs.isEmpty()) {
             throw new RuntimeException(
@@ -513,21 +512,6 @@ public class PncEntitiesImporter implements Closeable {
                             + ". Look above for the cause");
         }
         return incompatibleConfigs;
-    }
-
-    private boolean isModifiedInUnsupportedWay(
-            BuildConfiguration oldConfig,
-            Map<String, BuildConfig> newConfigsByName) {
-        String name = oldConfig.getName();
-        BuildConfig newConfig = newConfigsByName.get(name);
-        ProductVersionRef productVersion = oldConfig.getProductVersion();
-        boolean configMismatch = productVersion == null || !productVersion.getId().equals(version.getId());
-        if (configMismatch) {
-            log.warn(
-                    "Product version in the old config is different than the one in the new config for config {}",
-                    name);
-        }
-        return configMismatch;
     }
 
     private List<BuildConfiguration> getCurrentBuildConfigs() {


### PR DESCRIPTION
If BC was in a product (or was in no product), then adding them to different one would - in some cases - thow an exception. We need to discuss more options for BC sharing between products, but in the meantime, we are removing this check.

### Checklist:

* [ ] Have you added a note in the [CHANGELOG wiki](https://github.com/project-ncl/bacon/wiki/Changelog) for your change if user-facing?
* [ ] Have you added unit tests for your change?
