### PR TITLE
Make source download name more unique

### DIFF
--- a/pig/src/main/java/org/jboss/pnc/bacon/pig/impl/sources/SourcesGenerator.java
+++ b/pig/src/main/java/org/jboss/pnc/bacon/pig/impl/sources/SourcesGenerator.java
@@ -154,7 +154,7 @@ public class SourcesGenerator {
         builds.values().forEach(build -> {
             URI url = gerritSnapshotDownloadUrl(build.getInternalScmUrl(), build.getScmRevision());
 
-            File targetPath = new File(workDir, build.getName() + ".tar.gz");
+            File targetPath = new File(workDir, build.getName() + "-" + build.getId() + ".tar.gz");
             try (BuildClient client = CREATOR.newClient();
                     Response response = client.getInternalScmArchiveLink(build.getId())) {
                 InputStream in = (InputStream) response.getEntity();


### PR DESCRIPTION
this was failing for existing file when user used mutliple versions built by same build configuration = oss-parent-50-redhat-9 and oss-parent-50-redhat-7
