### PR TITLE
Update license exception for oss-parent

### DIFF
--- a/pig/src/main/resources/rh-license-exceptions.json
+++ b/pig/src/main/resources/rh-license-exceptions.json
@@ -1354,5 +1354,16 @@
               "url": "http://www.apache.org/licenses/LICENSE-2.0"
           }
       ]
+  },
+  {
+      "groupId": "org.sonatype.oss",
+      "artifactId": "oss-parent",
+      "version-regexp": "7.0.0.redhat-.+",
+      "licenses": [
+          {
+              "name": "Apache License 2.0",
+              "url": "http://www.apache.org/licenses/LICENSE-2.0"
+          }
+      ]
   }
 ]


### PR DESCRIPTION
Add a license exception for oss-parent (one of the Red Hat versions is missing the license).

### Checklist:

* [ ] Have you added a note in the [CHANGELOG wiki](https://github.com/project-ncl/bacon/wiki/Changelog) for your change if user-facing?
* [ ] Have you added unit tests for your change?
