### PR TITLE
No auth while waiting for build to finish

### DIFF
--- a/pig/src/main/java/org/jboss/pnc/bacon/pig/impl/pnc/PncBuilder.java
+++ b/pig/src/main/java/org/jboss/pnc/bacon/pig/impl/pnc/PncBuilder.java
@@ -163,7 +163,8 @@ public class PncBuilder implements Closeable {
         // log set to info for CPaaS to detect infinite loop
         log.info("Checking if group build {} is successfully finished", groupBuildId);
         try {
-            GroupBuild groupBuild = groupBuildClient.getSpecific(groupBuildId);
+            GroupBuildClient anonymousGroupBuildClient = new GroupBuildClient(getPncConfiguration(false));
+            GroupBuild groupBuild = anonymousGroupBuildClient.getSpecific(groupBuildId);
             switch (groupBuild.getStatus()) {
                 case BUILDING:
                     return false;


### PR DESCRIPTION
When waiting for a group build to finish in `PncBuilder`, get a new anonymous GroupBuildClient to know the state of the group build.

If we use the regular groupBuildClient, its access token might have already expired and we'll get a 401 error eventually.

### Checklist:

* [ ] Have you added a note in the [CHANGELOG wiki](https://github.com/project-ncl/bacon/wiki/Changelog) for your change if user-facing?
* [ ] Have you added unit tests for your change?
