### PR TITLE
Fix 401 error: use anonymous group client for get

### DIFF
--- a/pig/src/test/java/org/jboss/pnc/bacon/pig/impl/pnc/PncBuilderTest.java
+++ b/pig/src/test/java/org/jboss/pnc/bacon/pig/impl/pnc/PncBuilderTest.java
@@ -72,7 +72,11 @@ class PncBuilderTest {
                     }
                 });
 
-        try (PncBuilder builder = new PncBuilder(groupBuildClient, groupConfigurationClient)) {
+        try (PncBuilder builder = new PncBuilder(
+                groupBuildClient,
+                groupBuildClient,
+                groupConfigurationClient,
+                groupConfigurationClient)) {
             assertEquals(buildConfigurations.size(), builder.getCountOfBuildConfigsForGroupBuild(groupBuildId));
         }
     }

--- a/pnc/src/main/java/org/jboss/pnc/bacon/pnc/client/PncClientHelper.java
+++ b/pnc/src/main/java/org/jboss/pnc/bacon/pnc/client/PncClientHelper.java
@@ -80,14 +80,18 @@ public class PncClientHelper {
                 port = uri.getPort();
             }
 
-            Configuration configuration = Configuration.builder()
+            Configuration.ConfigurationBuilder builder = Configuration.builder()
                     .protocol(uri.getScheme())
                     .port(port)
                     .host(uri.getHost())
                     .bearerToken(bearerToken)
                     .pageSize(50)
-                    .addDefaultMdcToHeadersMappings()
-                    .build();
+                    .addDefaultMdcToHeadersMappings();
+
+            if (authenticationNeeded && keycloakConfig != null) {
+                builder = builder.bearerTokenSupplier(() -> getBearerToken(keycloakConfig));
+            }
+            Configuration configuration = builder.build();
 
             printBannerIfNecessary(configuration);
 


### PR DESCRIPTION
If we use the regular group client for a long time, the token it holds might expire after a period of time. When we send the expired token to PNC, it fails with HTTP 401 error.

This change:
- uses anonymous group client so that we don't send any token if there's no need to
- adds the bearerSupplier in PncClientHelper so that we can use it to renew our auth token if necessary.

### Checklist:

* [ ] Have you added a note in the [CHANGELOG wiki](https://github.com/project-ncl/bacon/wiki/Changelog) for your change if user-facing?
* [ ] Have you added unit tests for your change?
