### PR TITLE
Replace config variables used as auto-build configuration scalars

### DIFF
--- a/experimental/src/test/java/org/jboss/bacon/experimental/cli/DependencyGeneratorCommandTest.java
+++ b/experimental/src/test/java/org/jboss/bacon/experimental/cli/DependencyGeneratorCommandTest.java
@@ -1,0 +1,31 @@
+package org.jboss.bacon.experimental.cli;
+
+import org.junit.jupiter.api.Test;
+
+import java.io.File;
+import java.net.URISyntaxException;
+import java.net.URL;
+import java.nio.file.Path;
+import java.nio.file.Paths;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+
+class DependencyGeneratorCommandTest {
+
+    @Test
+    void testLoadConfigWithConfigRefs() throws URISyntaxException {
+        DependencyGeneratorCommand command = new DependencyGeneratorCommand();
+        URL testConfigLoc = getClass().getResource("/config/auto-build-envs.yaml");
+        File configFile = Paths.get(testConfigLoc.toURI()).toFile();
+
+        Path configPath = configFile.toPath();
+        command.config = configPath;
+
+        var generatedConfig = command.loadConfig();
+        var defaults = generatedConfig.getBuildConfigGeneratorConfig().getDefaultValues();
+
+        assertEquals(System.getProperty("user.home"), defaults.getScmRevision());
+        assertEquals(System.getenv("PWD"), defaults.getBuildScript());
+    }
+
+}

--- a/experimental/src/test/resources/config/auto-build-envs.yaml
+++ b/experimental/src/test/resources/config/auto-build-envs.yaml
@@ -1,0 +1,34 @@
+dependencyResolutionConfig:
+    analyzeArtifacts: []
+    excludeArtifacts: []
+    recipeRepos: []
+buildConfigGeneratorConfig:
+    failGeneratedBuildScript: false
+    allowDeprecatedEnvironments: false
+    defaultValues:
+        scmRevision: !SYSPROP ${user.home}
+        environmentName: "OpenJDK 11.0; Mvn 3.5.4"
+        buildScript: !ENV ${PWD}
+    pigTemplate:
+        product:
+            name: My Product
+            abbreviation: my-product
+            stage: GA
+            issueTrackerUrl: http://issues.jboss.org/browse/MYPROD
+        version: 1.0.0
+        milestone: CR1
+        group: my-product-autobuild
+        flow:
+            licensesGeneration:
+                strategy: IGNORE
+            repositoryGeneration:
+                strategy: IGNORE
+            javadocGeneration:
+                strategy: IGNORE
+            sourcesGeneration:
+                strategy: IGNORE
+        outputPrefixes:
+            releaseFile: my-product-autobuild
+            releaseDir: MY-PRODUCT-AUTOBUILD
+        addons:
+            notYetAlignedFromDependencyTree:

--- a/pig/src/main/java/org/jboss/pnc/bacon/pig/impl/config/PigConfiguration.java
+++ b/pig/src/main/java/org/jboss/pnc/bacon/pig/impl/config/PigConfiguration.java
@@ -28,6 +28,7 @@ import org.jboss.pnc.bacon.pig.impl.utils.AlignmentType;
 import org.jboss.pnc.bacon.pig.impl.validation.ListBuildConfigCheck;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
+import org.yaml.snakeyaml.LoaderOptions;
 import org.yaml.snakeyaml.Yaml;
 import org.yaml.snakeyaml.constructor.Constructor;
 
@@ -241,7 +242,7 @@ public class PigConfiguration implements Validate {
             buildVarsOverrides = Collections.emptyMap();
         }
 
-        Yaml yaml = new Yaml(new Constructor(PigConfiguration.class));
+        Yaml yaml = new Yaml(new Constructor(PigConfiguration.class, new LoaderOptions()));
 
         try (InputStream in = preProcess(configStream, buildVarsOverrides)) {
             PigConfiguration pigConfiguration = (PigConfiguration) yaml.load(in);

--- a/pom.xml
+++ b/pom.xml
@@ -84,7 +84,7 @@
         <enforcer.plugin.version>3.4.1</enforcer.plugin.version>
         <glassfish-jaxb.version>2.3.1</glassfish-jaxb.version>
         <glassfish-json.version>1.1.4</glassfish-json.version>
-        <jackson.version>2.13.1</jackson.version>
+        <jackson.version>2.16.0</jackson.version>
         <jaxb.version>4.0.4</jaxb.version>
         <jdk.max.version>17</jdk.max.version>
 
@@ -365,6 +365,12 @@
                 <groupId>org.json</groupId>
                 <artifactId>json</artifactId>
                 <version>20231013</version>
+            </dependency>
+
+            <dependency>
+                <groupId>org.yaml</groupId>
+                <artifactId>snakeyaml</artifactId>
+                <version>2.2</version>
             </dependency>
 
             <!-- jackson -->


### PR DESCRIPTION
This change allows for tagged entries in the experimental autobuild configuration file to reference either system properties or environment variables. The use case I have in mind is where a project POM is missing the `scm` tag section, which currently defaults to `master` for the generated build config. 

Using a variable in the autobuild input configuration would allow for the correct revision to be set from some value, e.g. the git tag or commit hash in a CI process.

### Checklist:

* [ ] Have you added a note in the [CHANGELOG wiki](https://github.com/project-ncl/bacon/wiki/Changelog) for your change if user-facing?
* [x] Have you added unit tests for your change?
