### PR TITLE
Fix generated label typo

### DIFF
--- a/experimental/src/main/java/org/jboss/bacon/experimental/impl/generator/BuildConfigGenerator.java
+++ b/experimental/src/main/java/org/jboss/bacon/experimental/impl/generator/BuildConfigGenerator.java
@@ -101,7 +101,7 @@ public class BuildConfigGenerator {
         buildConfig.setEnvironmentName(config.getDefaultValues().getEnvironmentName());
         buildConfig.setName(name);
         buildConfig.setProject(gav.getGroupId() + "-" + gav.getArtifactId());
-        buildConfig.setDescription("Autobuild genearted config for " + gav);
+        buildConfig.setDescription("Autobuild generated config for " + gav);
         String scmUrl = processScmUrl(project.getSourceCodeURL());
         if (scmUrl == null) {
             setPlaceholderSCM(name, buildConfig);


### PR DESCRIPTION
Minor label change - "genearated" -> "generated"
