### PR TITLE
Update source generation to use consistent format for directory structure

### DIFF
--- a/pig/src/main/java/org/jboss/pnc/bacon/pig/impl/sources/SourcesGenerator.java
+++ b/pig/src/main/java/org/jboss/pnc/bacon/pig/impl/sources/SourcesGenerator.java
@@ -111,6 +111,18 @@ public class SourcesGenerator {
             log.info("Removing builds from sources generation " + sourcesGenerationData.getExcludeSourceBuilds());
             additionalBuildsForSources.keySet().removeAll(sourcesGenerationData.getExcludeSourceBuilds());
         }
+
+        // Set the name of the build to be more consistent, relying on user specified BC names yields some odd names
+        // in source directories. These attributes should be set but are BEST EFFORT and not guaranteed to be set
+        // for non-maven builds.
+        for (PncBuild build : additionalBuildsForSources.values()) {
+            String brewBuildName = build.getAttributes().get("BREW_BUILD_NAME");
+            String brewBuildVersion = build.getAttributes().get("BREW_BUILD_VERSION");
+            if (brewBuildName != null && brewBuildVersion != null) {
+                build.setName(brewBuildName.replaceAll(":", "-") + "-" + brewBuildVersion);
+            }
+        }
+
         downloadSourcesFromBuilds(additionalBuildsForSources, workDir, contentsDir);
 
         if (sourcesGenerationData.getStrategy() == SourcesGenerationStrategy.GENERATE_EXTENDED || sourcesGenerationData
@@ -137,8 +149,7 @@ public class SourcesGenerator {
                     try {
                         String buildName = a.getBuild().getBuildConfigRevision().getName();
                         PncBuild pncBuild = new PncBuild(a.getBuild());
-                        pncBuild.setName(pncBuild.getName().replaceAll("-AUTOBUILD", ""));
-                        completeBuilds.put(buildName, pncBuild);
+                        completeBuilds.put(pncBuild.getName(), pncBuild);
                     } catch (NullPointerException e) {
                         log.warn("Artifact " + a.getIdentifier() + " does not have build assigned! No sources added.");
                     }


### PR DESCRIPTION
Update the source generation so directory naming is more consistent, because its derived from the build config there are inconsistencies in how people name them. For example, one directory is simply called `2.2.0` without any reference to the groupId or artifactId.

This PR updates the naming to be derived from the BREW_BUILD_NAME and BREW_BUILD_VERSION which to my knowledge should be available as its automatically set, and I have double checked numerous builds including some gradle ones and it was, but if they aren't set it will leave them as is.

### Checklist:

* [ ] Have you added a note in the [CHANGELOG wiki](https://github.com/project-ncl/bacon/wiki/Changelog) for your change if user-facing?
* [ ] Have you added unit tests for your change?
