### PR TITLE
Remove maven-metadata.xml from checksums and GAV(path) fixes

### DIFF
--- a/pig/src/main/java/org/jboss/pnc/bacon/pig/impl/utils/GAV.java
+++ b/pig/src/main/java/org/jboss/pnc/bacon/pig/impl/utils/GAV.java
@@ -78,19 +78,19 @@ public class GAV {
         int groupEnd = path.lastIndexOf('/', artifactEnd - 1);
 
         try {
-            packaging = extensionExceptions.stream()
-                    .filter(e -> path.endsWith("." + e))
-                    .findFirst()
-                    .orElse(path.substring(path.lastIndexOf('.') + 1));
             version = path.substring(artifactEnd + 1, versionEnd);
             artifactId = path.substring(groupEnd + 1, artifactEnd);
             groupId = path.substring(0, groupEnd).replaceAll("/", ".");
-            try {
-                classifier = path
-                        .substring(path.lastIndexOf(version) + version.length() + 1, path.lastIndexOf(packaging) - 1);
-            } catch (Exception e) {
-                // artifact doesn't have a classifier
-                classifier = null;
+
+            int fileNameVersionEnd = versionEnd + artifactId.length() + version.length() + 2;
+            if (path.charAt(fileNameVersionEnd) == '.') {
+                packaging = path.substring(fileNameVersionEnd + 1);
+            } else {
+                packaging = extensionExceptions.stream()
+                        .filter(e -> path.endsWith("." + e))
+                        .findFirst()
+                        .orElse(path.substring(path.lastIndexOf('.') + 1));
+                classifier = path.substring(fileNameVersionEnd + 1, path.length() - packaging.length() - 1);
             }
         } catch (StringIndexOutOfBoundsException parsingException) {
             throw new RuntimeException("Unable to parse path " + path + " to artifact", parsingException);

--- a/pig/src/test/java/org/jboss/pnc/bacon/pig/impl/utils/GAVTest.java
+++ b/pig/src/test/java/org/jboss/pnc/bacon/pig/impl/utils/GAVTest.java
@@ -68,6 +68,16 @@ class GAVTest {
         assertThat(gav.getVersion()).isEqualTo("1.32.0.Final-redhat-00003");
         assertThat(gav.getPackaging()).isEqualTo("tar.gz");
         assertThat(gav.getClassifier()).isEqualTo("project-sources");
+
+        // Artifact with classifier matching the version
+        path = "io/quarkus/quarkus-bom-quarkus-platform-descriptor/3.8.5.redhat-00004/quarkus-bom-quarkus-platform-descriptor-3.8.5.redhat-00004-3.8.5.redhat-00004.json";
+        gav = new GAV(path);
+
+        assertThat(gav.getGroupId()).isEqualTo("io.quarkus");
+        assertThat(gav.getArtifactId()).isEqualTo("quarkus-bom-quarkus-platform-descriptor");
+        assertThat(gav.getVersion()).isEqualTo("3.8.5.redhat-00004");
+        assertThat(gav.getPackaging()).isEqualTo("json");
+        assertThat(gav.getClassifier()).isEqualTo("3.8.5.redhat-00004");
     }
 
     @Test


### PR DESCRIPTION
1. Remove `maven-metadata.xml` from the constant that represents checksum extensions `RepoDescriptor.CHECKSUM_EXTENSIONS` (while it's used by some methods to identify checksum files, in other places it appears to be misused to filter out non-artifact files)
2. Fixed artifact filtering in `RepoDescriptor.listGavs(File dir)`, it doesn't filter out `_remote.repositories` as a non-artifact file (since it relied on `RepoDescriptor.CHECKSUM_EXTENSIONS`) which results in parsing it as
```
System.out.println(new GAV("org/jboss/jboss-parent/38/_remote.repositories").toGapvc());
```
```
org.jboss:jboss-parent:repositories:38:_remote
```
and including it in the results

3. Added a method `RepoDescriptor.listArtifacts(Path m2RepoDirectory)` that allows collecting complete artifact coordinates (instead of only GAVs as `listGavs(File dir)` does) allowing `m2RepoDirectory` to be either a directory or a ZIP file

4. Fixed parsing of a classifier in `GAV` and avoid generating stacktraces when a classifier is empty, which makes it more efficient.

### Checklist:

* [ ] Have you added a note in the [CHANGELOG wiki](https://github.com/project-ncl/bacon/wiki/Changelog) for your change if user-facing?
* [ ] Have you added unit tests for your change?
