### PR TITLE
Fix NotYetAlignedFromDependencyTree

### DIFF
--- a/pig/src/main/java/org/jboss/pnc/bacon/pig/impl/addons/vertx/NotYetAlignedFromDependencyTree.java
+++ b/pig/src/main/java/org/jboss/pnc/bacon/pig/impl/addons/vertx/NotYetAlignedFromDependencyTree.java
@@ -64,8 +64,7 @@ public class NotYetAlignedFromDependencyTree extends AddOn {
                 List<String> bcLog = build.getBuildLog().stream().distinct().collect(Collectors.toList());
                 file.print("-------- [" + build.getId() + "] " + build.getName() + " --------\n");
                 for (String bcLine : bcLog) {
-                    if (bcLine.startsWith("[INFO] +") && (bcLine.endsWith(":runtime") || bcLine.endsWith(":compile"))
-                            && !bcLine.contains("redhat-")) {
+                    if (matchingDependencyLine(bcLine)) {
                         file.print(bcLine + "\n");
                     }
                 }
@@ -74,5 +73,18 @@ public class NotYetAlignedFromDependencyTree extends AddOn {
         } catch (FileNotFoundException | UnsupportedEncodingException e) {
             log.error("Error while creating NotYetAlignedFromDependencyTree report", e);
         }
+    }
+
+    /**
+     * See if the line matches the not yet aligned top-level dependency
+     *
+     * @param bcLine line to analyze
+     * @return whether it matches or not
+     */
+    static boolean matchingDependencyLine(String bcLine) {
+        // clean up the line first
+        bcLine = bcLine.strip();
+        return bcLine.contains("[INFO] +") && (bcLine.endsWith(":runtime") || bcLine.endsWith(":compile"))
+                && !bcLine.contains("redhat-");
     }
 }

--- a/pig/src/test/java/org/jboss/pnc/bacon/pig/impl/addons/vertx/NotYetAlignedFromDependencyTreeTest.java
+++ b/pig/src/test/java/org/jboss/pnc/bacon/pig/impl/addons/vertx/NotYetAlignedFromDependencyTreeTest.java
@@ -1,0 +1,25 @@
+package org.jboss.pnc.bacon.pig.impl.addons.vertx;
+
+import org.junit.jupiter.api.Test;
+
+import static org.junit.jupiter.api.Assertions.*;
+
+class NotYetAlignedFromDependencyTreeTest {
+
+    @Test
+    void testMatchingDependencyLine() {
+        // repeated INFO line
+        String line = "[INFO] [INFO] +- org.apache.kafka:connect-api:jar:3.6.1:compile";
+        // whitespace at the beginning and end
+        String line2 = " [INFO] +- org.apache.kafka:connect-api:jar:3.6.1:runtime    ";
+        // shouldn't match that one since not top-level
+        String nonMatchingLine = "[INFO] |  |  \\- com.fasterxml.jackson.core:jackson-core:jar:2.16.1.redhat-00003:compile";
+        // shouldn't match since it is of type provided
+        String nonMatchingLine2 = "[INFO] +- org.projectlombok:lombok:jar:1.18.32:provided";
+
+        assertTrue(NotYetAlignedFromDependencyTree.matchingDependencyLine(line));
+        assertTrue(NotYetAlignedFromDependencyTree.matchingDependencyLine(line2));
+        assertFalse(NotYetAlignedFromDependencyTree.matchingDependencyLine(nonMatchingLine));
+        assertFalse(NotYetAlignedFromDependencyTree.matchingDependencyLine(nonMatchingLine2));
+    }
+}


### PR DESCRIPTION
This commit fixes the integration between getting logs from Bifrost (via database and not from the final-log feature) and the NotYetAlignedFromDependencyTree.

Previously, the addon 'NotYetAlignedFromDependencyTree' expected the line to analyze to begin with:
```
[INFO] +
```

But Bifrost adds an extra info for some reason. The logs then become:
```
[INFO] [INFO] +
```

which doesn't match the line we want. This commit loosens the requirement to just have the '[INFO] +' line present somewhere.

Unit tests are written to make sure this logic is codified properly also.

### Checklist:

* [ ] Have you added a note in the [CHANGELOG wiki](https://github.com/project-ncl/bacon/wiki/Changelog) for your change if user-facing?
* [x] Have you added unit tests for your change?
