### PR TITLE
parse both dependency:tree and maven-dependency-plugin:tree

### DIFF
--- a/pig/src/main/java/org/jboss/pnc/bacon/pig/impl/addons/camel/TreeParser.java
+++ b/pig/src/main/java/org/jboss/pnc/bacon/pig/impl/addons/camel/TreeParser.java
@@ -95,7 +95,7 @@ public class TreeParser {
                     continue;
                 }
 
-                if (line.contains("maven-dependency-plugin:") && line.contains("tree")) {
+                if ((line.contains("maven-dependency-plugin:") || line.contains("dependency:")) && line.contains("tree")) {
                     rootNode = true;
                     parsing = true;
                     continue;

--- a/pig/src/test/java/org/jboss/pnc/bacon/pig/impl/addons/camel/TreeParserTest.java
+++ b/pig/src/test/java/org/jboss/pnc/bacon/pig/impl/addons/camel/TreeParserTest.java
@@ -40,7 +40,7 @@ public class TreeParserTest {
             File file = new File("src/test/resources/camel-build-log.txt");
             assertTrue(file.exists(), "Could not find file " + file.getName());
             ArrayList<TreeNode> al = treeparser.parse("src/test/resources/camel-build-log-2.txt");
-            assertTrue(al.size() == 169, "Expected to find 169 tree nodes, found " + al.size());
+            assertTrue(al.size() == 170, "Expected to find 170 tree nodes, found " + al.size());
             TreeNode tn = (TreeNode) al.get(0);
 
             ArrayList<String> dependencies = treeparser.collectFirstLevelDependencies(al);


### PR DESCRIPTION
maven-dependency:tree has started showing up in the logs as dependency:tree rather than the elongated form of maven-dependency-plugin:tree - need to parse for both situations
