### PR TITLE
Fix RepositoryUtils.isCommunity(file)

### DIFF
--- a/pig/src/main/java/org/jboss/pnc/bacon/pig/impl/repo/RepositoryUtils.java
+++ b/pig/src/main/java/org/jboss/pnc/bacon/pig/impl/repo/RepositoryUtils.java
@@ -265,9 +265,35 @@ public class RepositoryUtils {
         }
     }
 
-    private static boolean isCommunity(File f) {
-        String absolutePath = f.getAbsolutePath();
-        return !absolutePath.contains("redhat-") && !absolutePath.contains("eap-runtime-artifacts");
+    /**
+     * Returns true if a file does not represent a Red Hat (re)build of an upstream Maven artifact. The current
+     * implementation checks whether the parent (the version) directory of the file contains the {@code redhat-} string.
+     * <p>
+     * The parent directory check is performed to catch files such as {@code 7.4.0.redhat-00001/_remote.repositories}.
+     *
+     * @param f file to check
+     * @return true, if the file is recognized as a Maven artifact (re)built by Red Hat, otherwise - false
+     */
+    static boolean isCommunity(File f) {
+        final String absolutePath = f.getAbsolutePath();
+        // look for <version>/<artifact-file-name> subpath
+        int index = absolutePath.lastIndexOf(File.separatorChar);
+        if (index < 0) {
+            // this is not a Maven artifact path
+            return true;
+        }
+        index = absolutePath.lastIndexOf(File.separatorChar, index - 1);
+        if (index < 0) {
+            // this is not a Maven artifact path
+            return true;
+        }
+        index = absolutePath.indexOf("redhat-", index + 1);
+        if (index >= 0) {
+            // the version contains redhat-
+            return false;
+        }
+        // this looks like a hack that should be removed
+        return !absolutePath.contains("eap-runtime-artifacts");
     }
 
     private static void removeMatchingCondition(File element, Function<File, Boolean> condition) {

--- a/pig/src/test/java/org/jboss/pnc/bacon/pig/impl/repo/RepositoryUtilsTest.java
+++ b/pig/src/test/java/org/jboss/pnc/bacon/pig/impl/repo/RepositoryUtilsTest.java
@@ -55,4 +55,27 @@ class RepositoryUtilsTest {
         identifier = RepositoryUtils.convertArtifactPathToIdentifier(path);
         assertEquals("test-me-here:let-me-go:zip:1.2.3-some:nice-docs", identifier);
     }
+
+    @Test
+    void testIsCommunity() {
+
+        // this tests that "redhat-" string appearing somewhere besides the file name does not get reported as an
+        // artifact built by Red Hat
+        assertTrue(
+                RepositoryUtils.isCommunity(
+                        new File(
+                                "rhaf-camel-4.8.0.redhat-00008-for-quarkus-3.15.0.CQ2-maven-repository/maven-repository/com/hierynomus/smbj/0.13.0/smbj-0.13.0.jar")));
+        assertTrue(
+                RepositoryUtils.isCommunity(
+                        new File(
+                                "rhaf-camel-4.8.0.redhat-00008-for-quarkus-3.15.0.CQ2-maven-repository/maven-repository/com/hierynomus/smbj/0.13.0/_remote.repositories")));
+        assertFalse(
+                RepositoryUtils.isCommunity(
+                        new File(
+                                "rhaf-camel-4.8.0.redhat-00008-for-quarkus-3.15.0.CQ2-maven-repository/maven-repository/com/hierynomus/smbj/0.13.0.redhat-00001/smbj-0.13.0.redhat-00001.jar")));
+        assertFalse(
+                RepositoryUtils.isCommunity(
+                        new File(
+                                "rhaf-camel-4.8.0.redhat-00008-for-quarkus-3.15.0.CQ2-maven-repository/maven-repository/com/hierynomus/smbj/0.13.0.redhat-00001/_remote.repositories")));
+    }
 }


### PR DESCRIPTION
Fixes an issue when upstream Maven artifact versions end up in generated Maven repo ZIPs. For example [1]

This is caused by the current implementation of `RepositoryUtils.isCommunity(file)` that looks for `redhat-` in the complete absolute path of a file, which recognizes artifacts such as
```
/tmp/deliverable-generation15171812937701886995/rhaf-camel-4.8.0.redhat-00008-for-quarkus-3.15.0.CQ2-maven-repository/maven-repository/com/hierynomus/smbj/0.13.0/smbj-0.13.0.jar
```
as being Red Hat rebuilds due to the `rhaf-camel-4.8.0.redhat-00008-for-quarkus-3.15.0.CQ2-maven-repository` part.

FYI @svkcemk 

[1] https://download.eng.bos.redhat.com/rcm-guest/staging/rhaf/camel-extensions-for-quarkus-3.15.0.CQ1/extras/repository-artifact-list.txt

### Checklist:

* [ ] Have you added a note in the [CHANGELOG wiki](https://github.com/project-ncl/bacon/wiki/Changelog) for your change if user-facing?
* [x] Have you added unit tests for your change?
