### PR TITLE
use repository.jboss.org for GNU licenses

### DIFF
--- a/licenses-generator/src/main/resources/rh-license-names.json
+++ b/licenses-generator/src/main/resources/rh-license-names.json
@@ -54,12 +54,14 @@
   },
   {
     "name": "GNU Lesser General Public License, Version 3",
+    "textUrl": "https://repository.jboss.org/licenses/lgpl-3.0.txt",
     "url": "http://www.gnu.org/licenses/lgpl-3.0-standalone.html",
     "aliases": [
       "GNU Lesser General Public License, Version 3",
       "The GNU Lesser General Public License, version 3"
     ],
     "urlAliases": [
+      "https://repository.jboss.org/licenses/lgpl-3.0.txt",
       "https://www.gnu.org/licenses/lgpl-3.0-standalone.html",
       "http://www.gnu.org/licenses/lgpl-3.0-standalone.html",
       "https://www.gnu.org/licenses/lgpl.html",
@@ -70,12 +72,14 @@
   },
   {
     "name": "GNU General Public License v2.0 only",
+    "textUrl": "https://repository.jboss.org/licenses/gpl-2.0.txt",
     "url": "https://www.gnu.org/licenses/old-licenses/gpl-2.0-standalone.html",
     "aliases": [
       "GNU General Public License v2.0 only",
       "The GNU General Public License, Version 2"
     ],
     "urlAliases": [
+      "https://repository.jboss.org/licenses/gpl-2.0.txt",
       "https://www.gnu.org/licenses/old-licenses/gpl-2.0-standalone.html",
       "http://www.gnu.org/licenses/old-licenses/gpl-2.0-standalone.html",
       "https://www.gnu.org/licenses/old-licenses/gpl-2.0.html",

--- a/pig/src/main/resources/rh-license-exceptions.json
+++ b/pig/src/main/resources/rh-license-exceptions.json
@@ -882,7 +882,7 @@
         "licenses": [
             {
                 "name": "GNU Lesser General Public License v3.0 or later",
-                "url": "https://www.gnu.org/licenses/lgpl-3.0.txt"
+                "url": "https://repository.jboss.org/licenses/lgpl-3.0.txt"
             },
             {
                 "name": "Apache License 2.0",
@@ -1270,7 +1270,7 @@
             },
             {
                 "name": "GNU General Public License v2.0 only",
-                "url": "https://www.gnu.org/licenses/old-licenses/gpl-2.0-standalone.html"
+                "url": "https://repository.jboss.org/licenses/gpl-2.0.txt"
             },
             {
                 "name": "BSD 3-clause \"New\" or \"Revised\" License",


### PR DESCRIPTION
We have been getting "too many requests" error when generating licenses using bacon. This happens only for the gnu license. it's likely that the server is throttling or limiting the number of requests from an IP. Use repository.jboss.org instead.