### PR TITLE
NCL-6053: Prevent .bacon directories being created during tests. Migr…

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -10,8 +10,6 @@ __pycache__
 **/.settings
 .vscode
 
-.bacon
-
 .cache
 
 cli/dependency-reduced-pom.xml

--- a/cli/pom.xml
+++ b/cli/pom.xml
@@ -77,8 +77,8 @@
             <scope>test</scope>
         </dependency>
         <dependency>
-            <groupId>com.github.stefanbirkner</groupId>
-            <artifactId>system-lambda</artifactId>
+            <groupId>uk.org.webcompere</groupId>
+            <artifactId>system-stubs-jupiter</artifactId>
             <scope>test</scope>
         </dependency>
     </dependencies>

--- a/cli/src/test/java/org/jboss/pnc/bacon/cli/AppTest.java
+++ b/cli/src/test/java/org/jboss/pnc/bacon/cli/AppTest.java
@@ -1,9 +1,5 @@
 package org.jboss.pnc.bacon.cli;
 
-import static com.github.stefanbirkner.systemlambda.SystemLambda.restoreSystemProperties;
-import static com.github.stefanbirkner.systemlambda.SystemLambda.tapSystemErr;
-import static com.github.stefanbirkner.systemlambda.SystemLambda.tapSystemOut;
-import static com.github.stefanbirkner.systemlambda.SystemLambda.withEnvironmentVariable;
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 
@@ -13,172 +9,179 @@ import java.util.Arrays;
 import java.util.List;
 
 import org.apache.commons.io.FilenameUtils;
+import org.jboss.pnc.bacon.common.Constant;
 import org.jboss.pnc.bacon.common.ObjectHelper;
 import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.junit.jupiter.api.io.TempDir;
 
+import uk.org.webcompere.systemstubs.environment.EnvironmentVariables;
+import uk.org.webcompere.systemstubs.jupiter.SystemStub;
+import uk.org.webcompere.systemstubs.jupiter.SystemStubsExtension;
+import uk.org.webcompere.systemstubs.properties.SystemProperties;
+import uk.org.webcompere.systemstubs.stream.SystemErr;
+import uk.org.webcompere.systemstubs.stream.SystemOut;
 import ch.qos.logback.classic.Level;
 import ch.qos.logback.core.pattern.color.ANSIConstants;
 
+@ExtendWith(SystemStubsExtension.class)
 class AppTest {
 
     private static final String PNC_TEST_CLASSES = FilenameUtils.separatorsToSystem("pnc/target/test-classes");
 
+    @SystemStub
+    private SystemErr systemErr;
+
     @Test
-    void testHelp() throws Exception {
+    void testHelp(SystemProperties systemProperties, SystemOut systemOut) {
         App app = new App();
-        restoreSystemProperties(() -> {
-            System.setProperty("picocli.ansi", "false");
-            app.run(new String[] { "-h" });
-            String text = tapSystemOut(() -> assertEquals(0, app.run(new String[] { "-h" })));
-            assertThat(text).contains(
-                    "Usage: bacon [-hoqvV] [--no-color] [-p=<configurationFileLocation>]",
-                    "[--profile=<profile>]");
-        });
+        systemProperties.set("picocli.ansi", "false");
+        app.run(new String[] { "-h" });
+        assertEquals(0, app.run(new String[] { "-h" }));
+
+        assertThat(systemOut.getText()).contains(
+                "Usage: bacon [-hoqvV] [--no-color] [-p=<configurationFileLocation>]",
+                "[--profile=<profile>]");
     }
 
     @Test
-    void testNoColor1() throws Exception {
+    void testNoColor1(EnvironmentVariables environmentVariables) {
+        File pncClasses = new File(App.class.getClassLoader().getResource("").getFile());
+        File configYaml = new File(pncClasses.getParentFile().getParentFile().getParentFile(), PNC_TEST_CLASSES);
+        environmentVariables.set("NO_COLOR", "true");
+        App app = new App();
+        assertEquals(
+                1,
+                app.run(
+                        new String[] {
+                                "-p",
+                                configYaml.toString(),
+                                "-v",
+                                "pnc",
+                                "-o",
+                                "build",
+                                "get",
+                                "0" }));
+        assertThat(systemErr.getText()).contains("Reconfiguring logger for NO_COLOR");
+        // The first two lines will have the DEBUG with colour codes until it is reset
+        assertThat(systemErr.getText()).contains(ANSIConstants.ESC_START);
+        List<String> lines = new ArrayList<>(
+                Arrays.asList(systemErr.getText().split(System.lineSeparator())));
+        // Avoid issues debugging in IntelliJ due to classpath loading.
+        lines.removeIf(
+                s -> s.contains(
+                        "Unable to retrieve manifest for class org.jboss.pnc.bacon.common.cli.VersionProvider as location is a directory not a jar"));
+        assertThat(lines.subList(2, 10).toString()).doesNotContain(ANSIConstants.ESC_START);
+    }
+
+    @Test
+    void testNoColor2(EnvironmentVariables environmentVariables) {
         File pncClasses = new File(App.class.getClassLoader().getResource("").getFile());
         File configYaml = new File(pncClasses.getParentFile().getParentFile().getParentFile(), PNC_TEST_CLASSES);
         App app = new App();
-        withEnvironmentVariable("NO_COLOR", "true").execute(() -> {
-            String text = tapSystemErr(
-                    () -> assertEquals(
-                            1,
-                            app.run(
-                                    new String[] {
-                                            "-p",
-                                            configYaml.toString(),
-                                            "-v",
-                                            "pnc",
-                                            "-o",
-                                            "build",
-                                            "get",
-                                            "0" })));
-            assertThat(text).contains("Reconfiguring logger for NO_COLOR");
-            // The first two lines will have the DEBUG with colour codes until it is reset
-            assertThat(text).contains(ANSIConstants.ESC_START);
-            List<String> lines = new ArrayList<>(Arrays.asList(text.split(System.getProperty("line.separator"))));
-            // Avoid issues debugging in IntelliJ due to classpath loading.
-            lines.removeIf(
-                    s -> s.contains(
-                            "Unable to retrieve manifest for class org.jboss.pnc.bacon.common.cli.VersionProvider as location is a directory not a jar"));
-            assertThat(lines.subList(2, 10).toString()).doesNotContain(ANSIConstants.ESC_START);
-        });
+
+        environmentVariables.set("NO_COLOR", "true");
+        assertEquals(
+                1,
+                app.run(new String[] { "-p", configYaml.toString(), "pnc", "-o", "build", "get", "0" }));
+        assertThat(systemErr.getText()).doesNotContain(ANSIConstants.ESC_START);
+        assertThat(System.getProperty("picocli.ansi")).contains("false");
     }
 
     @Test
-    void testNoColor2() throws Exception {
-        File pncClasses = new File(App.class.getClassLoader().getResource("").getFile());
-        File configYaml = new File(pncClasses.getParentFile().getParentFile().getParentFile(), PNC_TEST_CLASSES);
-        App app = new App();
-
-        withEnvironmentVariable("NO_COLOR", "true").execute(() -> {
-            String text = tapSystemErr(
-                    () -> assertEquals(
-                            1,
-                            app.run(new String[] { "-p", configYaml.toString(), "pnc", "-o", "build", "get", "0" })));
-            assertThat(text).doesNotContain(ANSIConstants.ESC_START);
-            assertThat(System.getProperty("picocli.ansi")).contains("false");
-        });
-    }
-
-    @Test
-    void testVerbose() throws Exception {
+    void testVerbose() {
         ObjectHelper.setRootLoggingLevel(Level.INFO);
         ObjectHelper.setLoggingLevel("org.jboss.pnc.client", Level.WARN);
 
-        String text = tapSystemErr(() -> assertEquals(0, new App().run(new String[] { "pnc", "admin", "-h" })));
-        assertThat(text).doesNotContain("Log level set to DEBUG");
-        text = tapSystemErr(() -> assertEquals(0, new App().run(new String[] { "pnc", "-v", "-h" })));
-        assertThat(text).contains("Log level set to DEBUG");
+        assertEquals(0, new App().run(new String[] { "pnc", "admin", "-h" }));
+        assertThat(systemErr.getText()).doesNotContain("Log level set to DEBUG");
+        assertEquals(0, new App().run(new String[] { "pnc", "-v", "-h" }));
+        assertThat(systemErr.getText()).contains("Log level set to DEBUG");
     }
 
     @Test
-    void testExampleUsage() throws Exception {
+    void testExampleUsage(SystemOut systemOut) {
         App app = new App();
-        String text = tapSystemOut(
-                () -> assertEquals(
-                        0,
-                        app.run(new String[] { "--verbose", "pnc", "admin", "maintenance-mode", "activate", "-h" })));
-        assertThat(text).contains("bacon pnc admin maintenance-mode activate \"Switching");
+        assertEquals(
+                0,
+                app.run(new String[] { "--verbose", "pnc", "admin", "maintenance-mode", "activate", "-h" }));
+        assertThat(systemOut.getText()).contains("bacon pnc admin maintenance-mode activate \"Switching");
     }
 
     @Test
-    void testConfigPath() throws Exception {
+    void testConfigPath() {
         String configPath = FilenameUtils.separatorsToSystem("/tmp/123456789");
         String configFile = FilenameUtils.separatorsToSystem(configPath + "/config.yaml");
-        String text = tapSystemErr(
-                () -> assertEquals(
-                        0,
-                        new App().run(new String[] { "-p", configPath, "-v", "pnc", "-o", "build", "-h" })));
-        assertThat(text).contains("Config file set from flag with profile default to " + configFile);
+        assertEquals(
+                0,
+                new App().run(new String[] { "-p", configPath, "-v", "pnc", "-o", "build", "-h" }));
+        assertThat(systemErr.getText()).contains("Config file set from flag with profile default to " + configFile);
     }
 
     @Test
-    void testJSONEnabled1() throws Exception {
+    void testJSONEnabled1() {
         File pncClasses = new File(App.class.getClassLoader().getResource("").getFile());
         File configYaml = new File(pncClasses.getParentFile().getParentFile().getParentFile(), PNC_TEST_CLASSES);
 
-        String text = tapSystemErr(
-                () -> assertEquals(
-                        1,
-                        new App().run(
-                                new String[] { "-p", configYaml.toString(), "-v", "pnc", "-o", "build", "get", "0" })));
-        assertThat(text).contains("JSON command is enabled: true");
-        assertThat(text).contains(ANSIConstants.ESC_START);
-        assertThat(Arrays.asList(text.split(System.getProperty("line.separator"))).subList(2, 10).toString())
-                .contains(ANSIConstants.ESC_START);
+        assertEquals(
+                1,
+                new App().run(
+                        new String[] { "-p", configYaml.toString(), "-v", "pnc", "-o", "build", "get", "0" }));
+        assertThat(systemErr.getText()).contains("JSON command is enabled: true");
+        assertThat(systemErr.getText()).contains(ANSIConstants.ESC_START);
+        assertThat(
+                Arrays.asList(systemErr.getText().split(System.lineSeparator()))
+                        .subList(2, 10)
+                        .toString())
+                                .contains(ANSIConstants.ESC_START);
     }
 
     @Test
-    void testJSONEnabled2() throws Exception {
+    void testJSONEnabled2() {
         File pncClasses = new File(App.class.getClassLoader().getResource("").getFile());
         File configYaml = new File(pncClasses.getParentFile().getParentFile().getParentFile(), PNC_TEST_CLASSES);
 
-        String text = tapSystemErr(
-                () -> assertEquals(
-                        1,
-                        new App().run(
-                                new String[] { "-o", "-p", configYaml.toString(), "-v", "pnc", "build", "get", "0" })));
-        assertThat(text).contains("JSON command is enabled: true");
+        assertEquals(
+                1,
+                new App().run(
+                        new String[] { "-o", "-p", configYaml.toString(), "-v", "pnc", "build", "get", "0" }));
+        assertThat(systemErr.getText()).contains("JSON command is enabled: true");
     }
 
     @Test
-    void testJSONEnabled3() throws Exception {
+    void testJSONEnabled3() {
         File pncClasses = new File(App.class.getClassLoader().getResource("").getFile());
         File configYaml = new File(pncClasses.getParentFile().getParentFile().getParentFile(), PNC_TEST_CLASSES);
 
-        String text = tapSystemErr(
-                () -> assertEquals(
-                        1,
-                        new App().run(
-                                new String[] {
-                                        "--jsonOutput",
-                                        "-p",
-                                        configYaml.toString(),
-                                        "-v",
-                                        "pnc",
-                                        "build",
-                                        "get",
-                                        "0" })));
-        assertThat(text).contains("JSON command is enabled: true");
+        assertEquals(
+                1,
+                new App().run(
+                        new String[] {
+                                "--jsonOutput",
+                                "-p",
+                                configYaml.toString(),
+                                "-v",
+                                "pnc",
+                                "build",
+                                "get",
+                                "0" }));
+        assertThat(systemErr.getText()).contains("JSON command is enabled: true");
+        System.out.println("### GOT TXT " + systemErr.getText());
     }
 
     @Test
-    void testJSONDisabled() throws Exception {
+    void testJSONDisabled() {
         File pncClasses = new File(App.class.getClassLoader().getResource("").getFile());
         File configYaml = new File(pncClasses.getParentFile().getParentFile().getParentFile(), PNC_TEST_CLASSES);
 
-        String text = tapSystemErr(
-                () -> assertEquals(
-                        1,
-                        new App().run(new String[] { "-p", configYaml.toString(), "-v", "pnc", "build", "get", "0" })));
-        assertThat(text).contains("JSON command is enabled: false");
+        assertEquals(
+                1,
+                new App().run(new String[] { "-p", configYaml.toString(), "-v", "pnc", "build", "get", "0" }));
+        assertThat(systemErr.getText()).contains("JSON command is enabled: false");
     }
 
     @Test
-    void testPigTempBuild() throws Exception {
+    void testPigTempBuild(EnvironmentVariables environmentVariables, @TempDir File tempDir) {
         File pncClasses = new File(App.class.getClassLoader().getResource("").getFile());
         File root = pncClasses.getParentFile().getParentFile().getParentFile();
         File buildConfig = new File(
@@ -190,82 +193,80 @@ class AppTest {
         ObjectHelper.setRootLoggingLevel(Level.INFO);
         ObjectHelper.setLoggingLevel("org.jboss.pnc.client", Level.WARN);
 
-        String text = tapSystemErr(
-                () -> assertEquals(
-                        1,
-                        new App().run(
-                                new String[] {
-                                        "-p",
-                                        configYaml.toString(),
-                                        "-v",
-                                        "pig",
-                                        "configure",
-                                        "--releaseStorageUrl",
-                                        "http://www.example.com",
-                                        "--tempBuild",
-                                        buildConfig.toString() })));
-        assertThat(text).contains("Keycloak authentication failed!");
-        assertThat(text).contains("at org.jboss.pnc.bacon.pnc.client.PncClientHelper.getCredential");
-        assertThat(text).doesNotContain("Unknown option: '--tempBuild'");
+        environmentVariables.set(Constant.PIG_CONTEXT_DIR, tempDir.getAbsolutePath());
+        assertEquals(
+                1,
+                new App().run(
+                        new String[] {
+                                "-p",
+                                configYaml.toString(),
+                                "-v",
+                                "pig",
+                                "configure",
+                                "--releaseStorageUrl",
+                                "http://www.example.com",
+                                "--tempBuild",
+                                buildConfig.toString() }));
+        assertThat(systemErr.getText()).contains("Keycloak authentication failed!");
+        assertThat(systemErr.getText()).contains("at org.jboss.pnc.bacon.pnc.client.PncClientHelper.getCredential");
+        assertThat(systemErr.getText()).doesNotContain("Unknown option: '--tempBuild'");
+        System.out.println("### GOT TXT " + systemErr.getText());
     }
 
     @Test
-    void testProfile() throws Exception {
+    void testProfile(SystemProperties systemProperties, SystemOut systemOut) {
         File pncClasses = new File(App.class.getClassLoader().getResource("").getFile());
         File configYaml = new File(pncClasses.getParentFile().getParentFile().getParentFile(), PNC_TEST_CLASSES);
         App app = new App();
 
-        restoreSystemProperties(() -> {
-            System.setProperty("picocli.ansi", "false");
-            String text = tapSystemOut(
-                    () -> assertEquals(
-                            0,
-                            app.run(
-                                    new String[] {
-                                            "--verbose",
-                                            "pnc",
-                                            "--profile",
-                                            "foobar",
-                                            "admin",
-                                            "maintenance-mode",
-                                            "activate",
-                                            "-h" })));
+        systemProperties.set("picocli.ansi", "false");
+        assertEquals(
+                0,
+                app.run(
+                        new String[] {
+                                "--verbose",
+                                "pnc",
+                                "--profile",
+                                "foobar",
+                                "admin",
+                                "maintenance-mode",
+                                "activate",
+                                "-h" }));
 
-            String expected = String.format(
-                    "Usage: bacon pnc admin maintenance-mode activate [-hoqvV] [--no-color]%n"
-                            + "       [-p=<configurationFileLocation>] [--profile=<profile>] <reason>%n"
-                            + "This will disable any new builds from being accepted%n"
-                            + "      <reason>              Reason%n"
-                            + "  -h, --help                Show this help message and exit.%n"
-                            + "      --no-color            Disable color output. Useful when running in a%n"
-                            + "                              non-ANSI environment%n"
-                            + "  -o, --jsonOutput          use json for output (default to yaml)%n"
-                            + "  -p, --configPath=<configurationFileLocation>%n"
-                            + "                            Path to PNC configuration folder%n"
-                            + "      --profile=<profile>   PNC Configuration profile%n"
-                            + "  -q, --quiet               Silent output%n"
-                            + "  -v, --verbose             Verbose output%n"
-                            + "  -V, --version             Print version information and exit.%n" + "%n" + "Example:%n"
-                            + "$ bacon pnc admin maintenance-mode activate \"Switching to maintenance mode for%n"
-                            + "upcoming migration\"%n");
-            assertThat(text).contains(expected);
-        });
+        String expected = String.format(
+                "Usage: bacon pnc admin maintenance-mode activate [-hoqvV] [--no-color]%n"
+                        + "       [-p=<configurationFileLocation>] [--profile=<profile>] <reason>%n"
+                        + "This will disable any new builds from being accepted%n"
+                        + "      <reason>              Reason%n"
+                        + "  -h, --help                Show this help message and exit.%n"
+                        + "      --no-color            Disable color output. Useful when running in a%n"
+                        + "                              non-ANSI environment%n"
+                        + "  -o, --jsonOutput          use json for output (default to yaml)%n"
+                        + "  -p, --configPath=<configurationFileLocation>%n"
+                        + "                            Path to PNC configuration folder%n"
+                        + "      --profile=<profile>   PNC Configuration profile%n"
+                        + "  -q, --quiet               Silent output%n"
+                        + "  -v, --verbose             Verbose output%n"
+                        + "  -V, --version             Print version information and exit.%n" + "%n" + "Example:%n"
+                        + "$ bacon pnc admin maintenance-mode activate \"Switching to maintenance mode for%n"
+                        + "upcoming migration\"%n");
+        assertThat(systemOut.getText()).contains(expected);
 
-        String text2 = tapSystemErr(
-                () -> assertEquals(
-                        0,
-                        app.run(
-                                new String[] {
-                                        "--configPath",
-                                        configYaml.toString(),
-                                        "--verbose",
-                                        "pnc",
-                                        "--profile",
-                                        "foobar",
-                                        "admin",
-                                        "maintenance-mode",
-                                        "activate",
-                                        "-h" })));
-        assertThat(text2).containsOnlyOnce("Config file set from flag with profile foobar to");
+        assertEquals(
+                0,
+                app.run(
+                        new String[] {
+                                "--configPath",
+                                configYaml.toString(),
+                                "--verbose",
+                                "pnc",
+                                "--profile",
+                                "foobar",
+                                "admin",
+                                "maintenance-mode",
+                                "activate",
+                                "-h" }));
+        assertThat(systemErr.getText()).containsOnlyOnce("Config file set from flag with profile foobar to");
+        System.out.println("### GOT TXT " + systemErr.getText());
     }
 }

--- a/common/pom.xml
+++ b/common/pom.xml
@@ -52,8 +52,8 @@
         </dependency>
 
         <dependency>
-            <groupId>com.github.stefanbirkner</groupId>
-            <artifactId>system-lambda</artifactId>
+            <groupId>uk.org.webcompere</groupId>
+            <artifactId>system-stubs-jupiter</artifactId>
             <scope>test</scope>
         </dependency>
     </dependencies>

--- a/common/src/test/java/org/jboss/pnc/bacon/common/ObjectHelperTest.java
+++ b/common/src/test/java/org/jboss/pnc/bacon/common/ObjectHelperTest.java
@@ -1,45 +1,51 @@
 package org.jboss.pnc.bacon.common;
 
-import static com.github.stefanbirkner.systemlambda.SystemLambda.tapSystemOut;
-import static org.junit.jupiter.api.Assertions.*;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertSame;
+import static org.junit.jupiter.api.Assertions.assertTrue;
 
 import java.util.HashMap;
 import java.util.Map;
 
 import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
 
+import uk.org.webcompere.systemstubs.jupiter.SystemStub;
+import uk.org.webcompere.systemstubs.jupiter.SystemStubsExtension;
+import uk.org.webcompere.systemstubs.stream.SystemOut;
 import ch.qos.logback.classic.Level;
 
+@ExtendWith(SystemStubsExtension.class)
 class ObjectHelperTest {
+
+    @SystemStub
+    private SystemOut systemOut;
 
     @Test
     void printJson() throws Exception {
-        String actual = tapSystemOut(() -> {
-            Map<String, String> testSubject = new HashMap<>();
+        Map<String, String> testSubject = new HashMap<>();
 
-            testSubject.put("test", "subject");
+        testSubject.put("test", "subject");
 
-            ObjectHelper.print(true, testSubject);
-        });
+        ObjectHelper.print(true, testSubject);
 
         String expected = String.format("{\"test\":\"subject\"}%n");
 
-        assertEquals(expected, actual);
+        assertEquals(expected, systemOut.getText());
     }
 
     @Test
     void printYaml() throws Exception {
-        String actual = tapSystemOut(() -> {
-            Map<String, String> testSubject = new HashMap<>();
+        Map<String, String> testSubject = new HashMap<>();
 
-            testSubject.put("test", "subject");
+        testSubject.put("test", "subject");
 
-            ObjectHelper.print(false, testSubject);
-        });
+        ObjectHelper.print(false, testSubject);
 
         String expected = String.format("---%ntest: \"subject\"%n%n");
 
-        assertEquals(expected, actual);
+        assertEquals(expected, systemOut.getText());
     }
 
     @Test

--- a/integration-tests/pom.xml
+++ b/integration-tests/pom.xml
@@ -67,6 +67,11 @@
             <groupId>com.github.tomakehurst</groupId>
             <artifactId>wiremock-jre8</artifactId>
         </dependency>
+        <dependency>
+            <groupId>uk.org.webcompere</groupId>
+            <artifactId>system-stubs-jupiter</artifactId>
+            <scope>test</scope>
+        </dependency>
     </dependencies>
 
     <build>

--- a/integration-tests/src/test/java/org/jboss/pnc/bacon/test/AbstractTest.java
+++ b/integration-tests/src/test/java/org/jboss/pnc/bacon/test/AbstractTest.java
@@ -9,6 +9,7 @@ import static com.github.tomakehurst.wiremock.core.WireMockConfiguration.options
 import static org.assertj.core.api.Assertions.assertThat;
 
 import java.util.Base64;
+import java.util.List;
 import java.util.Random;
 
 import org.junit.jupiter.api.AfterAll;
@@ -83,8 +84,8 @@ public class AbstractTest {
         return result.fromYAML(clazz);
     }
 
-    protected ExecutionResult executeAndGetResult(String... args) {
-        return CLIExecutor.runCommand(args);
+    protected ExecutionResult executeAndGetResult(List<String> env, String... args) {
+        return CLIExecutor.runCommand(env, args);
     }
 
 }

--- a/integration-tests/src/test/java/org/jboss/pnc/bacon/test/pig/PigTest.java
+++ b/integration-tests/src/test/java/org/jboss/pnc/bacon/test/pig/PigTest.java
@@ -25,6 +25,7 @@ import java.util.List;
 import java.util.stream.Collectors;
 import java.util.stream.Stream;
 
+import org.jboss.pnc.bacon.common.Constant;
 import org.jboss.pnc.bacon.test.AbstractTest;
 import org.jboss.pnc.bacon.test.ExecutionResult;
 import org.jboss.pnc.bacon.test.TestType;
@@ -44,6 +45,7 @@ import org.junit.jupiter.api.Tag;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.TestInstance;
 import org.junit.jupiter.api.TestMethodOrder;
+import org.junit.jupiter.api.io.TempDir;
 
 /**
  *
@@ -69,7 +71,7 @@ class PigTest extends AbstractTest {
 
     @Test
     @Order(1)
-    void shouldCreateProduct() throws IOException {
+    void shouldCreateProduct(@TempDir Path contextDir) throws Exception {
         final Path configFile = CONFIG_LOCATION;
         replaceSuffixInConfigFile(configFile.resolve("build-config.yaml"));
 
@@ -146,7 +148,11 @@ class PigTest extends AbstractTest {
                 .post(GROUP_CONFIG_BUILD_CONFIGS.apply(UNIVERSAL_ID))
                 .then()
                 .getEntity(GROUP_CONFIG, groupConfigWithBuildConfig);
-        ExecutionResult output = executeAndGetResult("pig", "configure", configFile.toString());
+        ExecutionResult output = executeAndGetResult(
+                List.of(Constant.PIG_CONTEXT_DIR + "=" + contextDir.toString()),
+                "pig",
+                "configure",
+                configFile.toString());
         assertThat(output.getOutput()).contains("name: \"Product Foobar " + SUFFIX + "\"");
     }
 

--- a/integration-tests/src/test/java/org/jboss/pnc/bacon/test/pnc/ProductTest.java
+++ b/integration-tests/src/test/java/org/jboss/pnc/bacon/test/pnc/ProductTest.java
@@ -125,9 +125,9 @@ class ProductTest extends AbstractTest {
 
         wmock.get(PRODUCT, productId);
 
-        ExecutionResult er = executeAndGetResult("pnc", "product", "get", productId);
+        ExecutionResult er = executeAndGetResult(Collections.emptyList(), "pnc", "product", "get", productId);
 
-        assertEquals(er.getRetval(), 1);
+        assertEquals(1, er.getRetval());
         assertTrue(er.getError().contains("HTTP 404 Not Found"));
     }
 }

--- a/pom.xml
+++ b/pom.xml
@@ -771,9 +771,9 @@
                 <scope>test</scope>
             </dependency>
             <dependency>
-                <groupId>com.github.stefanbirkner</groupId>
-                <artifactId>system-lambda</artifactId>
-                <version>1.2.1</version>
+                <groupId>uk.org.webcompere</groupId>
+                <artifactId>system-stubs-jupiter</artifactId>
+                <version>2.1.7</version>
                 <scope>test</scope>
             </dependency>
             <dependency>


### PR DESCRIPTION
…ate testing library

Closes #459.

As #459 / NCL-6053 was never merged this provides an updated fix. This also migrates the test support library from system-lambda to https://github.com/webcompere/system-stubs 