### PR TITLE
Ignore Mac OS X .DS_Store Finder files

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -8,6 +8,7 @@ __pycache__
 **/.factorypath
 **/.project
 **/.settings
+**/.DS_Store
 .vscode
 
 .cache


### PR DESCRIPTION
### Checklist:

minor change - add **/.DS_Store to the .gitignore.    .DS_Store are files generated by Mac OS X's Finder file browser

* [ ] Have you added a note in the [CHANGELOG wiki](https://github.com/project-ncl/bacon/wiki/Changelog) for your change if user-facing?
* [ ] Have you added unit tests for your change?
