### PR TITLE
Use license txt content for files without extension

### DIFF
--- a/licenses-generator/src/main/resources/offline-license-mirror/www.apache.org/licenses/LICENSE-2.0
+++ b/licenses-generator/src/main/resources/offline-license-mirror/www.apache.org/licenses/LICENSE-2.0
@@ -1,534 +1,202 @@
-<!DOCTYPE html>
-<html lang="en">
-<head>
-  <meta charset="utf-8">
-  <meta http-equiv="X-UA-Compatible" content="IE=edge">
-  <meta name="viewport" content="width=device-width, initial-scale=1">
-  <meta name="description" content="Home page of The Apache Software Foundation">
-  <link rel="apple-touch-icon" sizes="57x57" href="/favicons/apple-touch-icon-57x57.png">
-  <link rel="apple-touch-icon" sizes="60x60" href="/favicons/apple-touch-icon-60x60.png">
-  <link rel="apple-touch-icon" sizes="72x72" href="/favicons/apple-touch-icon-72x72.png">
-  <link rel="apple-touch-icon" sizes="76x76" href="/favicons/apple-touch-icon-76x76.png">
-  <link rel="apple-touch-icon" sizes="114x114" href="/favicons/apple-touch-icon-114x114.png">
-  <link rel="apple-touch-icon" sizes="120x120" href="/favicons/apple-touch-icon-120x120.png">
-  <link rel="apple-touch-icon" sizes="144x144" href="/favicons/apple-touch-icon-144x144.png">
-  <link rel="apple-touch-icon" sizes="152x152" href="/favicons/apple-touch-icon-152x152.png">
-  <link rel="apple-touch-icon" sizes="180x180" href="/favicons/apple-touch-icon-180x180.png">
-  <link rel="icon" type="image/png" href="/favicons/favicon-32x32.png" sizes="32x32">
-  <link rel="icon" type="image/png" href="/favicons/favicon-194x194.png" sizes="194x194">
-  <link rel="icon" type="image/png" href="/favicons/favicon-96x96.png" sizes="96x96">
-  <link rel="icon" type="image/png" href="/favicons/android-chrome-192x192.png" sizes="192x192">
-  <link rel="icon" type="image/png" href="/favicons/favicon-16x16.png" sizes="16x16">
-  <link rel="manifest" href="/favicons/manifest.json">
-  <link rel="shortcut icon" href="/favicons/favicon.ico">
-  <meta name="msapplication-TileColor" content="#603cba">
-  <meta name="msapplication-TileImage" content="/favicons/mstile-144x144.png">
-  <meta name="msapplication-config" content="/favicons/browserconfig.xml">
-  <meta name="theme-color" content="#282661">
 
-  <title>Apache License, Version 2.0</title>
-  <link href="/css/Montserrat-300-600.css" rel="stylesheet">
-  <link href="/css/min.bootstrap.css" rel="stylesheet">
-  <link href="/css/styles.css" rel="stylesheet">
-  <link href="/css/new-ui.css" rel="stylesheet">
-  <script src="https://www.apachecon.com/event-images/snippet.js"></script>
-  <style>
-.headerlink {
-  visibility: hidden;
-}
-dt:hover > .headerlink, p:hover > .headerlink, td:hover > .headerlink, h1:hover > .headerlink, h2:hover > .headerlink, h3:hover > .headerlink, h4:hover > .headerlink, h5:hover > .headerlink, h6:hover > .headerlink {
-  visibility: visible
-}  </style>
+                                 Apache License
+                           Version 2.0, January 2004
+                        http://www.apache.org/licenses/
 
-  <!-- pagefind search -->
-  <link href="/_pagefind/pagefind-ui.css" rel="stylesheet">
-  <script src="/_pagefind/pagefind-ui.js" type="text/javascript"></script>
-  <script>
-    window.addEventListener('DOMContentLoaded', (event) => {
-        new PagefindUI({ element: "#pagefind-search" });
-    });
-    var pageTitle = 'Apache License, Version 2.0';
-    if(pageTitle === '404'){
-      window.addEventListener('DOMContentLoaded', (event) => {
-          new PagefindUI({ element: "#page-404-search" });
-      });
-    }
-  </script>
-  
+   TERMS AND CONDITIONS FOR USE, REPRODUCTION, AND DISTRIBUTION
 
-<!-- https://www.apache.org/licenses/LICENSE-2.0 -->  <!-- Matomo -->
-  <script>
-    var pageTitle = 'Apache License, Version 2.0';
-    var _paq = window._paq = window._paq || [];
-    /* tracker methods like "setCustomDimension" should be called before
-"trackPageView" */
-    /* We explicitly disable cookie tracking to avoid privacy issues */
-    _paq.push(['disableCookies']);
-    if(pageTitle === '404'){
-      /* Track 404 page hits */
-      _paq.push(['setDocumentTitle',  '404/URL = ' +  encodeURIComponent(document.location.pathname+document.location.search) + '/From = ' + encodeURIComponent(document.referrer)]);
-    }
-    /* Measure a visit to flink.apache.org and nightlies.apache.org/flink
-as the same visit */
-    _paq.push(['trackPageView']);
-    _paq.push(['enableLinkTracking']);
-    (function() {
-      var u="//analytics.apache.org/";
-      _paq.push(['setTrackerUrl', u+'matomo.php']);
-      _paq.push(['setSiteId', '37']);
-      var d=document, g=d.createElement('script'),
-s=d.getElementsByTagName('script')[0];
-      g.async=true; g.src=u+'matomo.js'; s.parentNode.insertBefore(g,s);
-    })();
-  </script>
-  <!-- End Matomo Code -->
+   1. Definitions.
 
-</head>
+      "License" shall mean the terms and conditions for use, reproduction,
+      and distribution as defined by Sections 1 through 9 of this document.
 
-<body >
-  <!-- Navigation -->
-  <header>
-	<div id="skiptocontent">
-		<a href="#maincontent">Skip to Main Content</a>
-	</div>
-    <nav class="navbar navbar-inverse navbar-fixed-top mainmenu">
-      
-      <div class="container">
-        <div class="navbar-header">
-          <button class="navbar-toggle" type="button" data-toggle="collapse" data-target="#mainnav-collapse">
-            <span class="sr-only">Toggle navigation</span>
-            <span class="icon-bar"></span>
-            <span class="icon-bar"></span>
-            <span class="icon-bar"></span>
-          </button>
-        </div>
-        <div class="collapse navbar-collapse" id="mainnav-collapse">
-          <div class="upper-nav">
-            <div class="header-social-icons">
-              <a target="_blank" href="https://infra.apache.org/slack.html"><img src="/images/slack-icon.svg" alt="slack icon"></a>
-              <a target="_blank" href="https://github.com/apache"><img src="/images/github-mark-white.svg" alt="github icon"></a>
-              <a target="_blank" href="https://www.linkedin.com/company/the-apache-software-foundation/"><img src="/images/linkedin-icon.png" alt="linkedIn icon"></a>
-              <a target="_blank" href="https://www.youtube.com/c/TheApacheFoundation"><img src="/images/youtube-icon.svg" alt="youtube icon"></a>
-              <a target="_blank" href="https://twitter.com/TheASF"><img src="/images/x-icon.svg" alt="X icon"></a>
-            </div>
-            <a href="https://donate.apache.org/48ff" target="_blank" class="btn btn-default" onclick="_paq.push(['trackEvent', 'click', 'SponsorASF Button']);">Donate</a>
-          </div>
-          <ul class="nav navbar-nav navbar-justified n-navbar-padding">
-            <li class="dropdown">
-              <a href="#" class="dropdown-toggle" data-toggle="dropdown" role="button">Community&nbsp;<span class="caret"></span></a>
-              <ul class="dropdown-menu" role="menu">
-                <li><a href="https://community.apache.org/" target="_blank">Contributor Getting Started</a></li>
-                <li><a href="https://community.apache.org/contributors/" target="_blank">Becoming a Committer</a></li>
-                <li><a href="/foundation/policies/conduct">Code of Conduct</a></li>
-                <li><a href="/community-resources/">Community Resources</a></li>
-                <li><a href="https://communityovercode.org/" target="_blank">Community Over Code</a></li>
-                <li><a href="https://events.apache.org/" target="_blank">Events</a></li>
-              </ul>
-            </li>
-            <li class="dropdown">
-              <a href="#" class="dropdown-toggle" data-toggle="dropdown" role="button">Projects&nbsp;<span class="caret"></span></a>
-              <ul class="dropdown-menu" role="menu">
-                <li><a href="/projects">Projects</a></li>
-                <li><a href="https://incubator.apache.org/" target="_blank">Incubator Projects</a></li>
-                <li><a href="https://projects.apache.org/" target="_blank">Projects Directory </a></li>
-                <li><a href="/foundation/mailinglists">Mailing Lists </a></li>
-                <li><a href="/security">Report a Vulnerability</a></li>
-              </ul>
-            </li>
-            <li class="dropdown">
-              <a href="#" class="dropdown-toggle" data-toggle="dropdown" role="button">Downloads&nbsp;<span class="caret"></span></a>
-              <ul class="dropdown-menu" role="menu">
-                <li><a href="https://downloads.apache.org/" target="_blank">Distributions</a></li>
-                <li><a href="https://projects.apache.org/releases.html" target="_blank">Releases</a></li>
-                <li><a href="https://status.apache.org/" target="_blank">Infrastructure Status</a></li>
-                <li><a href="https://infra-reports.apache.org/#uptime" target="_blank">Infrastructure Statistics</a></li>
-              </ul>
-            </li>
-            <li class="dropdown">
-              <a href="#" class="dropdown-toggle" data-toggle="dropdown" role="button">Learn&nbsp;<span class="caret"></span></a>
-              <ul class="dropdown-menu" role="menu">
-                <li><a href="https://news.apache.org/" target="_blank">Blog</a></li>
-                <li><a href="/foundation/how-it-works">How the ASF Works</a></li>
-                <li><a href="/theapacheway/">The Apache Way</a></li>
-                <li><a href="/legal/">Legal &amp; Trademark</a></li>
-                <li><a href="/licenses">Licenses</a></li>
-                <li><a href="/foundation/glossary">Glossary</a></li>
-                <li><a href="/foundation/faq">FAQ</a></li>
-              </ul>
-            </li>
-            <li class="dropdown">
-              <a href="#" class="dropdown-toggle" data-toggle="dropdown" role="button">Resources &amp; Tools&nbsp;<span class="caret"></span></a>
-              <ul class="dropdown-menu" role="menu">
-                <li><a href="/dev/">Developer Information</a></li>
-                <li><a href="https://cwiki.apache.org/" target="_blank" >Wiki</a></li>
-                <li><a href="https://issues.apache.org/" target="_blank" >Issues</a></li>
-                <li><a href="https://infra.apache.org/slack.html" target="_blank" >Slack</a></li>
-                <li><a href="https://selfserve.apache.org/" target="_blank" >Self Serve Portal</a></li>
-                <li><a href="https://infra.apache.org/" target="_blank" >Infrastructure</a></li>
-                <li><a href="https://whimsy.apache.org/" target="_blank" >Whimsy</a></li>
-                <li><a href="/foundation/press/kit/">Brand Guidelines</a></li>
-                <li><a href="/logos/">Project Logos</a></li>
-              </ul>
-            </li>
-            <li class="dropdown">
-              <a href="#" class="dropdown-toggle" data-toggle="dropdown" role="button">About&nbsp;<span class="caret"></span></a>
-              <ul class="dropdown-menu" role="menu">
-                <li><a href="/foundation/">About</a></li>
-                <li><a href="/foundation/sponsors">Our Sponsors</a></li>
-		<li><a href="/foundation/sponsorship">Corporate Sponsorship</a></li>
-                <li><a href="/foundation/individual-supporters">Individual Supporters</a></li>
-                <li><a href="/foundation/leadership">Leadership</a></li>
-                <li><a href="/foundation/members">Members</a></li>
-                <li><a href="https://diversity.apache.org/" target="_blank">Diversity & Inclusion</a></li>
-                <li><a href="/press/">Newsroom</a></li>
-                <li><a href="/foundation/contact">Contact</a></li>
-              </ul>
-            </li>
-            
-           
-            
-            <li class="dropdown">
-              <a href="#" class="dropdown-toggle hidden-xs" data-toggle="dropdown" role="button"><span class="glyphicon glyphicon-search"
-                  aria-hidden="true"></span><span class="sr-only">Search</span></a>
-              <ul class="dropdown-menu search-form" role="search">
-                <li>
-                  <div id="pagefind-search" class="input-group" style="width: 100%; padding: 0 5px;"></div>
-                </li>
-              </ul>
-            </li>
-          </ul>
-        </div>
-      </div>
-    </nav>
-  </header>
-     <!-- Script is to make the input field ready as soon as user click the search button-->
-      <!-- script could be simplyfy and shorten in length bootstrap framework  -->
-     <script>
-   document.addEventListener('DOMContentLoaded', function () {
-    // Using Bootstrap's event system for dropdowns
-    $(document).on('shown.bs.dropdown', '.dropdown', function () {
-        // Check if this is the search dropdown
-        if ($(this).find('.glyphicon-search').length > 0) {
-            // Find and focus the search input
-            setTimeout(function() {
-                $('.pagefind-ui__search-input').focus();
-            }, 50); // Small delay to ensure input is ready
-        }
-    });
-});
-  </script>
-  <!-- / Navigation -->
-  <header id="main-header" class="container">
-    <div class="sideImg">
-      <a class="acevent visible-home" data-format="square"></a>
-      <a class="hidden-home" href="/"><img class="img-responsive" src="/img/asf-estd-1999-logo.jpg" alt="The Apache Software Foundation"></a>
-    </div>
-    <div class="main">
-      <img class="img-responsive center-block visible-home" src="/img/asf-estd-1999-logo.jpg" alt="Apache 20th Anniversary Logo">
+      "Licensor" shall mean the copyright owner or entity authorized by
+      the copyright owner that is granting the License.
 
-    </div>
- 
-  </header>
-  <main id="maincontent">
-<div class="container">    <h1 id="apache-license-version-20">Apache License, Version 2.0<a class="headerlink" href="#apache-license-version-20" title="Permalink">&para;</a></h1>
-<ul>
-<li>Text version: <a href="LICENSE-2.0.txt">https://www.apache.org/licenses/LICENSE-2.0.txt</a></li>
-<li>SPDX short identifier: <a href="https://spdx.org/licenses/Apache-2.0.html">Apache-2.0</a></li>
-<li>OSI Approved License: <a href="https://opensource.org/licenses/Apache-2.0">https://opensource.org/licenses/Apache-2.0</a></li>
-</ul>
-<p>The 2.0 version of the Apache License, approved by the ASF in 2004, helps us achieve our goal of providing
-reliable and long-lived software products through collaborative, open-source software development.</p>
-<p>All packages produced by the ASF are implicitly licensed under the Apache
-License, Version 2.0, unless otherwise explicitly stated.</p>
-<div style="margin: 3em 10%; font-family:serif;text-align:justify; border: 1px solid black; padding: 2em;   box-shadow: 4px 8px #888888;">
-<p style="text-align:center">
-<strong>Apache License<br/>Version 2.0, January 2004<br/></strong>
-<strong><a href="http://www.apache.org/licenses/">http://www.apache.org/licenses/</a></strong>
-</p>
-<p>TERMS AND CONDITIONS FOR USE, REPRODUCTION, AND DISTRIBUTION</p>
-<p><strong><a name="definitions">1. Definitions</a></strong>.</p>
-<div style="margin-left: 1em;">
-<p>"<strong>License</strong>" shall mean the terms and conditions for use, reproduction, and
-distribution as defined by Sections 1 through 9 of this document.</p>
-<p>"<strong>Licensor</strong>" shall mean the copyright owner or entity authorized by the
-copyright owner that is granting the License.</p>
-<p>"<strong>Legal Entity</strong>" shall mean the union of the acting entity and all other
-entities that control, are controlled by, or are under common control with
-that entity. For the purposes of this definition, "<strong>control</strong>" means (i) the
-power, direct or indirect, to cause the direction or management of such
-entity, whether by contract or otherwise, or (ii) ownership of fifty
-percent (50%) or more of the outstanding shares, or (iii) beneficial
-ownership of such entity.</p>
-<p>"<strong>You</strong>" (or "<strong>Your</strong>") shall mean an individual or Legal Entity exercising
-permissions granted by this License.</p>
-<p>"<strong>Source</strong>" form shall mean the preferred form for making modifications,
-including but not limited to software source code, documentation source,
-and configuration files.</p>
-<p>"<strong>Object</strong>" form shall mean any form resulting from mechanical transformation
-or translation of a Source form, including but not limited to compiled
-object code, generated documentation, and conversions to other media types.</p>
-<p>"<strong>Work</strong>" shall mean the work of authorship, whether in Source or Object form,
-made available under the License, as indicated by a copyright notice that
-is included in or attached to the work (an example is provided in the
-Appendix below).</p>
-<p>"<strong>Derivative Works</strong>" shall mean any work, whether in Source or Object form,
-that is based on (or derived from) the Work and for which the editorial
-revisions, annotations, elaborations, or other modifications represent, as
-a whole, an original work of authorship. For the purposes of this License,
-Derivative Works shall not include works that remain separable from, or
-merely link (or bind by name) to the interfaces of, the Work and Derivative
-Works thereof.</p>
-<p>"<strong>Contribution</strong>" shall mean any work of authorship, including the original
-version of the Work and any modifications or additions to that Work or
-Derivative Works thereof, that is intentionally submitted to Licensor for
-inclusion in the Work by the copyright owner or by an individual or Legal
-Entity authorized to submit on behalf of the copyright owner. For the
-purposes of this definition, "<strong>submitted</strong>" means any form of electronic,
-verbal, or written communication sent to the Licensor or its
-representatives, including but not limited to communication on electronic
-mailing lists, source code control systems, and issue tracking systems that
-are managed by, or on behalf of, the Licensor for the purpose of discussing
-and improving the Work, but excluding communication that is conspicuously
-marked or otherwise designated in writing by the copyright owner as "<strong>Not a
-Contribution.</strong>"</p>
-<p>"<strong>Contributor</strong>" shall mean Licensor and any individual or Legal Entity on
-behalf of whom a Contribution has been received by Licensor and
-subsequently incorporated within the Work.</p>
-</div>
-<p><strong><a name="copyright">2. Grant of Copyright License</a></strong>. Subject to the
-terms and conditions of this License, each Contributor hereby grants to You
-a perpetual, worldwide, non-exclusive, no-charge, royalty-free, irrevocable
-copyright license to reproduce, prepare Derivative Works of, publicly
-display, publicly perform, sublicense, and distribute the Work and such
-Derivative Works in Source or Object form.</p>
-<p><strong><a name="patent">3. Grant of Patent License</a></strong>. Subject to the terms
-and conditions of this License, each Contributor hereby grants to You a
-perpetual, worldwide, non-exclusive, no-charge, royalty-free, irrevocable
-(except as stated in this section) patent license to make, have made, use,
-offer to sell, sell, import, and otherwise transfer the Work, where such
-license applies only to those patent claims licensable by such Contributor
-that are necessarily infringed by their Contribution(s) alone or by
-combination of their Contribution(s) with the Work to which such
-Contribution(s) was submitted. If You institute patent litigation against
-any entity (including a cross-claim or counterclaim in a lawsuit) alleging
-that the Work or a Contribution incorporated within the Work constitutes
-direct or contributory patent infringement, then any patent licenses
-granted to You under this License for that Work shall terminate as of the
-date such litigation is filed.</p>
-<p><strong><a name="redistribution">4. Redistribution</a></strong>. You may reproduce and
-distribute copies of the Work or Derivative Works thereof in any medium,
-with or without modifications, and in Source or Object form, provided that
-You meet the following conditions:</p>
-<ol style="list-style: lower-latin;">
-<li>You must give any other recipients of the Work or Derivative Works a
-copy of this License; and</li>
-<li>You must cause any modified files to carry prominent notices stating
-that You changed the files; and</li>
-<li>You must retain, in the Source form of any Derivative Works that You
-distribute, all copyright, patent, trademark, and attribution notices from
-the Source form of the Work, excluding those notices that do not pertain to
-any part of the Derivative Works; and</li>
-<li>If the Work includes a "<strong>NOTICE</strong>" text file as part of its distribution,
-then any Derivative Works that You distribute must include a readable copy
-of the attribution notices contained within such NOTICE file, excluding
-those notices that do not pertain to any part of the Derivative Works, in
-at least one of the following places: within a NOTICE text file distributed
-as part of the Derivative Works; within the Source form or documentation,
-if provided along with the Derivative Works; or, within a display generated
-by the Derivative Works, if and wherever such third-party notices normally
-appear. The contents of the NOTICE file are for informational purposes only
-and do not modify the License. You may add Your own attribution notices
-within Derivative Works that You distribute, alongside or as an addendum to
-the NOTICE text from the Work, provided that such additional attribution
-notices cannot be construed as modifying the License.
-</li>
-</ol>
-<p>You may add Your own copyright statement to Your modifications and may
-provide additional or different license terms and conditions for use,
-reproduction, or distribution of Your modifications, or for any such
-Derivative Works as a whole, provided Your use, reproduction, and
-distribution of the Work otherwise complies with the conditions stated in
-this License.</p>
-<p><strong><a name="contributions">5. Submission of Contributions</a></strong>. Unless You
-explicitly state otherwise, any Contribution intentionally submitted for
-inclusion in the Work by You to the Licensor shall be under the terms and
-conditions of this License, without any additional terms or conditions.
-Notwithstanding the above, nothing herein shall supersede or modify the
-terms of any separate license agreement you may have executed with Licensor
-regarding such Contributions.</p>
-<p><strong><a name="trademarks">6. Trademarks</a></strong>. This License does not grant
-permission to use the trade names, trademarks, service marks, or product
-names of the Licensor, except as required for reasonable and customary use
-in describing the origin of the Work and reproducing the content of the
-NOTICE file.</p>
-<p><strong><a name="no-warranty">7. Disclaimer of Warranty</a></strong>. Unless required by
-applicable law or agreed to in writing, Licensor provides the Work (and
-each Contributor provides its Contributions) on an "AS IS" BASIS, WITHOUT
-WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied, including,
-without limitation, any warranties or conditions of TITLE,
-NON-INFRINGEMENT, MERCHANTABILITY, or FITNESS FOR A PARTICULAR PURPOSE. You
-are solely responsible for determining the appropriateness of using or
-redistributing the Work and assume any risks associated with Your exercise
-of permissions under this License.</p>
-<p><strong><a name="no-liability">8. Limitation of Liability</a></strong>. In no event and
-under no legal theory, whether in tort (including negligence), contract, or
-otherwise, unless required by applicable law (such as deliberate and
-grossly negligent acts) or agreed to in writing, shall any Contributor be
-liable to You for damages, including any direct, indirect, special,
-incidental, or consequential damages of any character arising as a result
-of this License or out of the use or inability to use the Work (including
-but not limited to damages for loss of goodwill, work stoppage, computer
-failure or malfunction, or any and all other commercial damages or losses),
-even if such Contributor has been advised of the possibility of such
-damages.</p>
-<p><strong><a name="additional">9. Accepting Warranty or Additional Liability</a></strong>.
-While redistributing the Work or Derivative Works thereof, You may choose
-to offer, and charge a fee for, acceptance of support, warranty, indemnity,
-or other liability obligations and/or rights consistent with this License.
-However, in accepting such obligations, You may act only on Your own behalf
-and on Your sole responsibility, not on behalf of any other Contributor,
-and only if You agree to indemnify, defend, and hold each Contributor
-harmless for any liability incurred by, or claims asserted against, such
-Contributor by reason of your accepting any such warranty or additional
-liability.</p>
-<p>END OF TERMS AND CONDITIONS</p>
-</div>
-<h2 id="apply">How to apply the Apache License to your work<a class="headerlink" href="#apply" title="Permalink">&para;</a></h2>
-<p>Include a copy of the Apache License, typically in a file called
-LICENSE, in your work, and consider also including a NOTICE file that references the License.</p>
-<p>To apply the Apache License to specific files in your work, attach the following boilerplate
-declaration, replacing the fields enclosed by brackets "[]" with your own
-identifying information. (Don't include the brackets!) Enclose the text in the appropriate comment syntax for the file format. We also
-recommend that you include a file or class name and description of purpose on the same "printed page" as the copyright notice for easier
-identification within third-party archives.</p>
-<pre><code>Copyright [yyyy] [name of copyright owner]
+      "Legal Entity" shall mean the union of the acting entity and all
+      other entities that control, are controlled by, or are under common
+      control with that entity. For the purposes of this definition,
+      "control" means (i) the power, direct or indirect, to cause the
+      direction or management of such entity, whether by contract or
+      otherwise, or (ii) ownership of fifty percent (50%) or more of the
+      outstanding shares, or (iii) beneficial ownership of such entity.
 
-Licensed under the Apache License, Version 2.0 (the "License");
-you may not use this file except in compliance with the License.
-You may obtain a copy of the License at
+      "You" (or "Your") shall mean an individual or Legal Entity
+      exercising permissions granted by this License.
 
-    http://www.apache.org/licenses/LICENSE-2.0
+      "Source" form shall mean the preferred form for making modifications,
+      including but not limited to software source code, documentation
+      source, and configuration files.
 
-Unless required by applicable law or agreed to in writing, software
-distributed under the License is distributed on an "AS IS" BASIS,
-WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
-See the License for the specific language governing permissions and
-limitations under the License.
-</code></pre>
+      "Object" form shall mean any form resulting from mechanical
+      transformation or translation of a Source form, including but
+      not limited to compiled object code, generated documentation,
+      and conversions to other media types.
 
-</div>  </main>
+      "Work" shall mean the work of authorship, whether in Source or
+      Object form, made available under the License, as indicated by a
+      copyright notice that is included in or attached to the work
+      (an example is provided in the Appendix below).
 
-  <!-- Footer -->
-  <footer class="bg-primary">
-    <div class="container">
-      <div class="row">
-        <br />
-        <div class="col-sm-2">
-          <h5 class="white">Community</h5>
-          <ul class="list-unstyled white" role="menu">
-            <li><a href="https://community.apache.org/" target="_blank">Contributor Getting Started</a></li>
-            <li><a href="https://community.apache.org/contributors/" target="_blank">Becoming a Committer</a></li>
-            <li><a href="/foundation/policies/conduct">Code of Conduct</a></li>
-            <li><a href="/community-resources/">Community Resources</a></li>
-            <li><a href="https://communityovercode.org/" target="_blank">Community Over Code</a></li>
-            <li><a href="https://events.apache.org/" target="_blank">Events</a></li>
-          </ul>
-        </div>
+      "Derivative Works" shall mean any work, whether in Source or Object
+      form, that is based on (or derived from) the Work and for which the
+      editorial revisions, annotations, elaborations, or other modifications
+      represent, as a whole, an original work of authorship. For the purposes
+      of this License, Derivative Works shall not include works that remain
+      separable from, or merely link (or bind by name) to the interfaces of,
+      the Work and Derivative Works thereof.
 
-        <div class="col-sm-2">
-          <h5 class="white">Projects</h5>
-          <ul class="list-unstyled white" role="menu">
-              <li><a href="/projects">Projects</a></li>
-              <li><a href="https://incubator.apache.org/" target="_blank">Incubator Projects</a></li>
-              <li><a href="https://projects.apache.org/" target="_blank">Projects Directory </a></li>
-              <li><a href="/foundation/mailinglists">Mailing Lists </a></li>
-              <li><a href="/security">Report a Vulnerability</a></li>
-          </ul>
-        </div>
-        <div class="col-sm-2">
-          <h5 class="white">Downloads</h5>
-          <ul class="list-unstyled white" role="menu">
-            <li><a href="https://downloads.apache.org/" target="_blank">Distributions</a></li>
-            <li><a href="https://projects.apache.org/releases.html" target="_blank">Releases</a></li>
-            <li><a href="https://status.apache.org/" target="_blank">Infrastructure Status</a></li>
-            <li><a href="https://infra-reports.apache.org/#uptime" target="_blank">Infrastructure Statistics</a></li>
-          </ul>
-        </div>
+      "Contribution" shall mean any work of authorship, including
+      the original version of the Work and any modifications or additions
+      to that Work or Derivative Works thereof, that is intentionally
+      submitted to Licensor for inclusion in the Work by the copyright owner
+      or by an individual or Legal Entity authorized to submit on behalf of
+      the copyright owner. For the purposes of this definition, "submitted"
+      means any form of electronic, verbal, or written communication sent
+      to the Licensor or its representatives, including but not limited to
+      communication on electronic mailing lists, source code control systems,
+      and issue tracking systems that are managed by, or on behalf of, the
+      Licensor for the purpose of discussing and improving the Work, but
+      excluding communication that is conspicuously marked or otherwise
+      designated in writing by the copyright owner as "Not a Contribution."
 
-        <div class="col-sm-2">
-          <h5 class="white">Learn</h5>
-          <ul class="list-unstyled white" role="menu">
-            <li><a href="https://news.apache.org/" target="_blank">Blog</a></li>
-            <li><a href="/foundation/how-it-works">How the ASF Works</a></li>
-            <li><a href="/theapacheway/">The Apache Way</a></li>
-            <li><a href="/legal/">Legal &amp; Trademark</a></li>
-            <li><a href="/licenses">Licenses</a></li>
-            <li><a href="/foundation/glossary">Glossary</a></li>
-            <li><a href="/foundation/faq">FAQ</a></li>
-          </ul>
-        </div>
+      "Contributor" shall mean Licensor and any individual or Legal Entity
+      on behalf of whom a Contribution has been received by Licensor and
+      subsequently incorporated within the Work.
 
-        <div class="col-sm-2">
-          <h5 class="white">Resources &amp; Tools</h5>
-          <ul class="list-unstyled white" role="menu">
-              <li><a href="/dev/">Developer Information</a></li>
-              <li><a href="https://cwiki.apache.org/" target="_blank" >Wiki</a></li>
-              <li><a href="https://issues.apache.org/" target="_blank" >Issues</a></li>
-              <li><a href="https://infra.apache.org/slack.html" target="_blank" >Slack</a></li>
-              <li><a href="https://selfserve.apache.org/" target="_blank" >Self Serve Portal</a></li>
-              <li><a href="https://infra.apache.org/" target="_blank" >Infrastructure</a></li>
-              <li><a href="https://whimsy.apache.org/" target="_blank" >Whimsy</a></li>
-              <li><a href="/foundation/press/kit/">Brand Guidelines</a></li>
-              <li><a href="/logos/">Project Logos</a></li>
-          </ul>
-        </div>
+   2. Grant of Copyright License. Subject to the terms and conditions of
+      this License, each Contributor hereby grants to You a perpetual,
+      worldwide, non-exclusive, no-charge, royalty-free, irrevocable
+      copyright license to reproduce, prepare Derivative Works of,
+      publicly display, publicly perform, sublicense, and distribute the
+      Work and such Derivative Works in Source or Object form.
 
-        <div class="col-sm-2">
-          <h5 class="white">About</h5>
-          <ul class="list-unstyled white" role="menu">
-            <li><a href="/foundation/">About</a></li>
-            <li><a href="/foundation/sponsors">Our Sponsors</a></li>
-	    <li><a href="/foundation/sponsorship">Corporate Sponsorship</a></li>
-            <li><a href="/foundation/individual-supporters">Individual Supporters</a></li>
-            <li><a href="/foundation/leadership">Leadership</a></li>
-            <li><a href="/foundation/members">Members</a></li>
-            <li><a href="https://diversity.apache.org/" target="_blank">Diversity & Inclusion</a></li>
-            <li><a href="/press/">Newsroom</a></li>
-            <li><a href="/foundation/contact">Contact</a></li>
-            <li><a href="https://privacy.apache.org/policies/privacy-policy-public.html" target="_blank">Privacy Policy</a></li>
-          </ul>
-        </div>
+   3. Grant of Patent License. Subject to the terms and conditions of
+      this License, each Contributor hereby grants to You a perpetual,
+      worldwide, non-exclusive, no-charge, royalty-free, irrevocable
+      (except as stated in this section) patent license to make, have made,
+      use, offer to sell, sell, import, and otherwise transfer the Work,
+      where such license applies only to those patent claims licensable
+      by such Contributor that are necessarily infringed by their
+      Contribution(s) alone or by combination of their Contribution(s)
+      with the Work to which such Contribution(s) was submitted. If You
+      institute patent litigation against any entity (including a
+      cross-claim or counterclaim in a lawsuit) alleging that the Work
+      or a Contribution incorporated within the Work constitutes direct
+      or contributory patent infringement, then any patent licenses
+      granted to You under this License for that Work shall terminate
+      as of the date such litigation is filed.
 
+   4. Redistribution. You may reproduce and distribute copies of the
+      Work or Derivative Works thereof in any medium, with or without
+      modifications, and in Source or Object form, provided that You
+      meet the following conditions:
 
-      </div>
-      <hr class="col-lg-12 hr-white" />
-      <div class="row">
-        <div class="col-lg-12">
-          <p class="text-center">Copyright &#169; 2025 The Apache Software Foundation, Licensed under the <a class="white" href="/licenses/LICENSE-2.0">Apache License, Version 2.0</a>.</p>
-          <p class="text-center">Apache and the Apache feather logo are trademarks of The Apache Software Foundation. </p>
-        </div>
-      </div>
-    </div>
+      (a) You must give any other recipients of the Work or
+          Derivative Works a copy of this License; and
 
-  </footer>
+      (b) You must cause any modified files to carry prominent notices
+          stating that You changed the files; and
 
-  <!-- / Footer -->
+      (c) You must retain, in the Source form of any Derivative Works
+          that You distribute, all copyright, patent, trademark, and
+          attribution notices from the Source form of the Work,
+          excluding those notices that do not pertain to any part of
+          the Derivative Works; and
 
-  <script src="/js/jquery.min.js"></script>
-  <script src="/js/bootstrap.js"></script>
-  <script src="/js/slideshow.js"></script>
-  <script>
-    (function($){
-      $(document).ready(function(){
-        $('ul.dropdown-menu [data-toggle=dropdown]').on('click', function(event) {
-          event.preventDefault();
-          event.stopPropagation();
-          $(this).parent().siblings().removeClass('open');
-          $(this).parent().toggleClass('open');
-          console.log('WOrked');
-        });
-      });
-    })(jQuery);
-  </script>
-</body>
-</html>
+      (d) If the Work includes a "NOTICE" text file as part of its
+          distribution, then any Derivative Works that You distribute must
+          include a readable copy of the attribution notices contained
+          within such NOTICE file, excluding those notices that do not
+          pertain to any part of the Derivative Works, in at least one
+          of the following places: within a NOTICE text file distributed
+          as part of the Derivative Works; within the Source form or
+          documentation, if provided along with the Derivative Works; or,
+          within a display generated by the Derivative Works, if and
+          wherever such third-party notices normally appear. The contents
+          of the NOTICE file are for informational purposes only and
+          do not modify the License. You may add Your own attribution
+          notices within Derivative Works that You distribute, alongside
+          or as an addendum to the NOTICE text from the Work, provided
+          that such additional attribution notices cannot be construed
+          as modifying the License.
+
+      You may add Your own copyright statement to Your modifications and
+      may provide additional or different license terms and conditions
+      for use, reproduction, or distribution of Your modifications, or
+      for any such Derivative Works as a whole, provided Your use,
+      reproduction, and distribution of the Work otherwise complies with
+      the conditions stated in this License.
+
+   5. Submission of Contributions. Unless You explicitly state otherwise,
+      any Contribution intentionally submitted for inclusion in the Work
+      by You to the Licensor shall be under the terms and conditions of
+      this License, without any additional terms or conditions.
+      Notwithstanding the above, nothing herein shall supersede or modify
+      the terms of any separate license agreement you may have executed
+      with Licensor regarding such Contributions.
+
+   6. Trademarks. This License does not grant permission to use the trade
+      names, trademarks, service marks, or product names of the Licensor,
+      except as required for reasonable and customary use in describing the
+      origin of the Work and reproducing the content of the NOTICE file.
+
+   7. Disclaimer of Warranty. Unless required by applicable law or
+      agreed to in writing, Licensor provides the Work (and each
+      Contributor provides its Contributions) on an "AS IS" BASIS,
+      WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or
+      implied, including, without limitation, any warranties or conditions
+      of TITLE, NON-INFRINGEMENT, MERCHANTABILITY, or FITNESS FOR A
+      PARTICULAR PURPOSE. You are solely responsible for determining the
+      appropriateness of using or redistributing the Work and assume any
+      risks associated with Your exercise of permissions under this License.
+
+   8. Limitation of Liability. In no event and under no legal theory,
+      whether in tort (including negligence), contract, or otherwise,
+      unless required by applicable law (such as deliberate and grossly
+      negligent acts) or agreed to in writing, shall any Contributor be
+      liable to You for damages, including any direct, indirect, special,
+      incidental, or consequential damages of any character arising as a
+      result of this License or out of the use or inability to use the
+      Work (including but not limited to damages for loss of goodwill,
+      work stoppage, computer failure or malfunction, or any and all
+      other commercial damages or losses), even if such Contributor
+      has been advised of the possibility of such damages.
+
+   9. Accepting Warranty or Additional Liability. While redistributing
+      the Work or Derivative Works thereof, You may choose to offer,
+      and charge a fee for, acceptance of support, warranty, indemnity,
+      or other liability obligations and/or rights consistent with this
+      License. However, in accepting such obligations, You may act only
+      on Your own behalf and on Your sole responsibility, not on behalf
+      of any other Contributor, and only if You agree to indemnify,
+      defend, and hold each Contributor harmless for any liability
+      incurred by, or claims asserted against, such Contributor by reason
+      of your accepting any such warranty or additional liability.
+
+   END OF TERMS AND CONDITIONS
+
+   APPENDIX: How to apply the Apache License to your work.
+
+      To apply the Apache License to your work, attach the following
+      boilerplate notice, with the fields enclosed by brackets "[]"
+      replaced with your own identifying information. (Don't include
+      the brackets!)  The text should be enclosed in the appropriate
+      comment syntax for the file format. We also recommend that a
+      file or class name and description of purpose be included on the
+      same "printed page" as the copyright notice for easier
+      identification within third-party archives.
+
+   Copyright [yyyy] [name of copyright owner]
+
+   Licensed under the Apache License, Version 2.0 (the "License");
+   you may not use this file except in compliance with the License.
+   You may obtain a copy of the License at
+
+       http://www.apache.org/licenses/LICENSE-2.0
+
+   Unless required by applicable law or agreed to in writing, software
+   distributed under the License is distributed on an "AS IS" BASIS,
+   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+   See the License for the specific language governing permissions and
+   limitations under the License.

--- a/licenses-generator/src/main/resources/offline-license-mirror/www.gnu.org/licenses/agpl-3.0
+++ b/licenses-generator/src/main/resources/offline-license-mirror/www.gnu.org/licenses/agpl-3.0
@@ -1,240 +1,35 @@
-<!DOCTYPE html>
-<html xmlns="http://www.w3.org/1999/xhtml" xml:lang="en" lang="en">
-<head>
-<meta http-equiv="content-type" content="text/html; charset=utf-8" />
-<link rel="author" href="mailto:webmasters@gnu.org" />
-<link rel="icon" type="image/png" href="/graphics/gnu-head-mini.png" />
-<meta name="ICBM" content="42.355469,-71.058627" />
-<link rel="stylesheet" type="text/css" href="/layout.min.css" media="screen" />
-<link rel="stylesheet" type="text/css" href="/print.min.css" media="print" />
+                    GNU AFFERO GENERAL PUBLIC LICENSE
+                       Version 3, 19 November 2007
 
-
-
-<!-- Parent-Version: 1.98 -->
-<!-- This page is derived from /server/standards/boilerplate.html -->
-<title>GNU Affero General Public License
-- GNU Project - Free Software Foundation</title>
-<style type="text/css" media="screen"><!--
-#content .button { margin: 2em 1.5em; }
-@media (max-width:30em) { #content img.imgright { display: none; }}
---></style>
-<link rel="alternate" type="application/rdf+xml"
-      href="/licenses/agpl-3.0.rdf" /> 
-<!-- begin translist file -->
-
-<link rel="alternate" type="text/html" href="/licenses/agpl-3.0.html" hreflang="x-default" />
-<link rel="alternate" type="text/html" lang="en" hreflang="en" href="/licenses/agpl-3.0.en.html" title="English" />
-<link rel="alternate" type="text/html" lang="ca" hreflang="ca" href="/licenses/agpl-3.0.ca.html" title="català" />
-<link rel="alternate" type="text/html" lang="de" hreflang="de" href="/licenses/agpl-3.0.de.html" title="Deutsch" />
-<link rel="alternate" type="text/html" lang="fr" hreflang="fr" href="/licenses/agpl-3.0.fr.html" title="français" />
-<link rel="alternate" type="text/html" lang="ja" hreflang="ja" href="/licenses/agpl-3.0.ja.html" title="日本語" />
-<link rel="alternate" type="text/html" lang="nl" hreflang="nl" href="/licenses/agpl-3.0.nl.html" title="Nederlands" />
-<link rel="alternate" type="text/html" lang="pt-br" hreflang="pt-br" href="/licenses/agpl-3.0.pt-br.html" title="português" />
-<link rel="alternate" type="text/html" lang="ru" hreflang="ru" href="/licenses/agpl-3.0.ru.html" title="русский" />
-<link rel="alternate" type="text/html" lang="tr" hreflang="tr" href="/licenses/agpl-3.0.tr.html" title="Türkçe" />
-<link rel="alternate" type="text/html" lang="uk" hreflang="uk" href="/licenses/agpl-3.0.uk.html" title="українська" />
-<link rel="alternate" type="text/html" lang="zh-cn" hreflang="zh-cn" href="/licenses/agpl-3.0.zh-cn.html" title="简体中文" />
-<!-- end translist file -->
-
-<!-- start of server/banner.html -->
-<!-- start of head-include-2.html -->
-<meta name="viewport" content="width=device-width, initial-scale=1" />
-<!-- end of head-include-2.html -->
-
-</head>
-<body>
-<div class="inner">
-<!-- start of server/body-include-1.html -->
-<div id="top">
-<a class="skip" href="#content"><b>Skip to main text</b></a>
-</div>
-
-<div id="fsf-frame" role="complementary">
-<form id="fssbox" action="https://my.fsf.org/civicrm/profile/create?reset=1&amp;gid=31"
-      method="post">
- <div>
-  <input name="postURL" type="hidden" value="" />
-  <input type="hidden" name="group[25]" value="1" />
-  <input name="cancelURL" type="hidden" value="https://crm.fsf.org/civicrm/profile?reset=1&amp;gid=31" />
-  <input name="_qf_default" type="hidden" value="Edit:cancel" />
-  <label for="frmEmail">
-   <a href="//www.fsf.org/fss">Free Software Supporter</a>:
-  </label>
-  <input type="text" id="frmEmail" name="email-Primary" size="18" maxlength="80"
-         value="email address" onfocus="this.value=''"/>
-  <input type="submit" name="_qf_Edit_next" value="Sign up" />
- </div>
-</form>
-
-<div id="join-fsf" class="button"><a
-href="https://www.fsf.org/associate/support_freedom?referrer=4052">JOIN&nbsp;THE&nbsp;FSF</a>
-</div>
-</div>
-
-<div id="header" role="banner">
-<p id="gnu-banner">
- <a href="/">
- <img src="/graphics/heckert_gnu.transp.small.png" height="48" width="49"
-      alt="&nbsp;[A GNU head]&nbsp;" /><strong>GNU</strong> <span
- class="hide">Operating System</span></a><br />
- <small id="fsf-support">Supported by the
- <a href="#mission-statement">Free Software Foundation</a></small>
-</p>
-
-<div id="switches">
-<!-- begin search button -->
- <div  id="search-button" class="switch">
-  <a href="//www.gnu.org/cgi-bin/estseek.cgi">
-  <img id="search-icon" height="30" width="30"
-       src="/graphics/icons/search.png"
-       alt="&nbsp;[Search www.gnu.org]&nbsp;" /></a>
- </div>
-<!-- end search button -->
-
- <div id="language-button" class="switch">
-  <a href="#language-container">
-  <img id="language-icon" height="30" width="37"
-       src="/graphics/icons/translations.png"
-       alt="&nbsp;[Other languages]&nbsp;" /></a>
- </div>
-
-</div>
-</div>
-<!-- end of server/body-include-1.html -->
-
-<!-- start of server/body-include-2 -->
-
-
-<div style="clear: both"></div>
-
-<div id="navigation" role="navigation">
- <a id="more-links" href="#navigation" title="More...">
-   <span>Site navigation</span></a>
- <a id="less-links" href="#content"><b>Skip</b></a>
- <ul>
-
-   <li id="tabAboutGNU"><a href="/gnu/gnu.html">ABOUT&nbsp;GNU</a></li>
-
-
-  <li id="tabPhilosophy"><a href="/philosophy/philosophy.html">PHILOSOPHY</a></li>
-
-
-  <li id="tabLicenses" class="active">
-     <span class='no-display'>=</span> 
-    <a href="/licenses/licenses.html">LICENSES</a>
-    <span class="gnun-split"></span>
-     <span class='no-display'>=</span> 
-  </li>
-
-
-  <li id="tabEducation"><a href="/education/education.html">EDUCATION</a></li>
-
-
-  <li id="tabSoftware"><a href="/software/software.html">SOFTWARE</a></li>
-
-
-  <li id="tabDistros"><a href="/distros/distros.html">DISTROS</a></li>
-
-
-  <li id="tabDoc"><a href="/doc/doc.html">DOCS</a></li>
-
-
-  <li id="tabMalware"><a href="/proprietary/proprietary.html">MALWARE</a></li>
-
-
-  <li id="tabHelp"><a href="/help/help.html">HELP&nbsp;GNU</a></li>
-
-
-  <li id="tabAV"><a href="/audio-video/audio-video.html">AUDIO&nbsp;&amp;&nbsp;VIDEO</a></li>
-
-
-  <li id="tabArt"><a href="/graphics/graphics.html">GNU&nbsp;ART</a></li>
-
-
-  <li id="tabFun"><a href="/fun/humor.html">FUN</a></li>
-
-
-  <li id="tabPeople"><a href="/people/people.html">GNU'S&nbsp;WHO?</a></li>
-
-  <li><a href="//directory.fsf.org">SOFTWARE&nbsp;DIRECTORY</a></li>
-  <li><a href="https://h-node.org/">HARDWARE</a></li>
-  <li><a href="/server/sitemap.html">SITEMAP</a></li>
- </ul>
- <div style="clear: both"></div>
-</div><!-- /"navigation -->
-<!-- end of server/body-include-2 -->
-
-<div id="content" role="main">
-<!-- end of server/banner.html -->
-
-<div class="reduced-width">
-<h2>GNU Affero General Public License</h2>
-
-<img class="imgright" src="/graphics/agplv3-155x51.png" alt=" [AGPLv3 Logo] " />
-<p class="button"><b><a href="#license-text">Skip to license text</a></b></p>
-
-<ul>
-  <li><a href="/licenses/why-affero-gpl.html">Why the Affero GPL</a></li>
-  <li><a href="/licenses/gpl-faq.html">Frequently Asked Questions</a></li>
-  <li><a href="/licenses/gpl-howto.html">How to use GNU licenses for your
-       own software</a></li>
-  <li><a href="/licenses/translations.html">Translations
-       of the GNU AGPL</a></li>
-  <li>The GNU AGPL in other formats: 
-       <a href="/licenses/agpl-3.0.txt">plain text</a>,
-       <a href="/licenses/agpl-3.0.dbk">Docbook</a>,
-       <a href="/licenses/agpl-3.0.tex">LaTeX</a>,
-       <a href="/licenses/agpl-3.0-standalone.html">standalone HTML</a>,
-       <a href="/licenses/agpl-3.0.texi">Texinfo</a>, 
-       <a href="/licenses/agpl-3.0.md">Markdown</a>, 
-       <a href="/licenses/agpl-3.0.odt">ODF</a>, 
-       <a href="/licenses/agpl-3.0.rtf">RTF</a></li>
-  <li><a href="/graphics/license-logos.html">GNU AGPL logos</a> to use
-       with your project</li>
-  <li><a href="/licenses/gpl-violation.html">What to do if you see a
-       possible GNU AGPL violation</a></li>
-</ul>
-
-<hr class="thin" />
-
-<!-- The license text is in English and appears broken in RTL as
-     Arabic, Farsi, etc.  Explicitly set the direction to override the
-     one defined in the translation. -->
-<div id="license-text" dir="ltr">
-<h3 style="text-align: center;">GNU AFFERO GENERAL PUBLIC LICENSE</h3>
-<p style="text-align: center;">Version 3, 19 November 2007</p>
-
-<p>Copyright &copy; 2007 Free Software Foundation,
-Inc. &lt;<a href="https://fsf.org/">https://fsf.org/</a>&gt;
- <br />
+ Copyright (C) 2007 Free Software Foundation, Inc. <https://fsf.org/>
  Everyone is permitted to copy and distribute verbatim copies
- of this license document, but changing it is not allowed.</p>
+ of this license document, but changing it is not allowed.
 
-<h4 id="preamble">Preamble</h4>
+                            Preamble
 
-<p>The GNU Affero General Public License is a free, copyleft license
-for software and other kinds of works, specifically designed to ensure
-cooperation with the community in the case of network server software.</p>
+  The GNU Affero General Public License is a free, copyleft license for
+software and other kinds of works, specifically designed to ensure
+cooperation with the community in the case of network server software.
 
-<p>The licenses for most software and other practical works are
-designed to take away your freedom to share and change the works.  By
-contrast, our General Public Licenses are intended to guarantee your
-freedom to share and change all versions of a program--to make sure it
-remains free software for all its users.</p>
+  The licenses for most software and other practical works are designed
+to take away your freedom to share and change the works.  By contrast,
+our General Public Licenses are intended to guarantee your freedom to
+share and change all versions of a program--to make sure it remains free
+software for all its users.
 
-<p>When we speak of free software, we are referring to freedom, not
+  When we speak of free software, we are referring to freedom, not
 price.  Our General Public Licenses are designed to make sure that you
 have the freedom to distribute copies of free software (and charge for
 them if you wish), that you receive source code or can get it if you
 want it, that you can change the software or use pieces of it in new
-free programs, and that you know you can do these things.</p>
+free programs, and that you know you can do these things.
 
-<p>Developers that use our General Public Licenses protect your rights
+  Developers that use our General Public Licenses protect your rights
 with two steps: (1) assert copyright on the software, and (2) offer
 you this License which gives you legal permission to copy, distribute
-and/or modify the software.</p>
+and/or modify the software.
 
-<p>A secondary benefit of defending all users' freedom is that
+  A secondary benefit of defending all users' freedom is that
 improvements made in alternate versions of the program, if they
 receive widespread use, become available for other developers to
 incorporate.  Many developers of free software are heartened and
@@ -242,90 +37,89 @@ encouraged by the resulting cooperation.  However, in the case of
 software used on network servers, this result may fail to come about.
 The GNU General Public License permits making a modified version and
 letting the public access it on a server without ever releasing its
-source code to the public.</p>
+source code to the public.
 
-<p>The GNU Affero General Public License is designed specifically to
+  The GNU Affero General Public License is designed specifically to
 ensure that, in such cases, the modified source code becomes available
 to the community.  It requires the operator of a network server to
 provide the source code of the modified version running there to the
 users of that server.  Therefore, public use of a modified version, on
 a publicly accessible server, gives the public access to the source
-code of the modified version.</p>
+code of the modified version.
 
-<p>An older license, called the Affero General Public License and
+  An older license, called the Affero General Public License and
 published by Affero, was designed to accomplish similar goals.  This is
 a different license, not a version of the Affero GPL, but Affero has
 released a new version of the Affero GPL which permits relicensing under
-this license.</p>
+this license.
 
-<p>The precise terms and conditions for copying, distribution and
-modification follow.</p>
+  The precise terms and conditions for copying, distribution and
+modification follow.
 
-<h4 id="terms">TERMS AND CONDITIONS</h4>
+                       TERMS AND CONDITIONS
 
-<h4 id="section0">0. Definitions.</h4>
+  0. Definitions.
 
-<p>&quot;This License&quot; refers to version 3 of the GNU Affero General Public
-License.</p>
+  "This License" refers to version 3 of the GNU Affero General Public License.
 
-<p>&quot;Copyright&quot; also means copyright-like laws that apply to other kinds
-of works, such as semiconductor masks.</p>
+  "Copyright" also means copyright-like laws that apply to other kinds of
+works, such as semiconductor masks.
 
-<p>&quot;The Program&quot; refers to any copyrightable work licensed under this
-License.  Each licensee is addressed as &quot;you&quot;.  &quot;Licensees&quot; and
-&quot;recipients&quot; may be individuals or organizations.</p>
+  "The Program" refers to any copyrightable work licensed under this
+License.  Each licensee is addressed as "you".  "Licensees" and
+"recipients" may be individuals or organizations.
 
-<p>To &quot;modify&quot; a work means to copy from or adapt all or part of the work
+  To "modify" a work means to copy from or adapt all or part of the work
 in a fashion requiring copyright permission, other than the making of an
-exact copy.  The resulting work is called a &quot;modified version&quot; of the
-earlier work or a work &quot;based on&quot; the earlier work.</p>
+exact copy.  The resulting work is called a "modified version" of the
+earlier work or a work "based on" the earlier work.
 
-<p>A &quot;covered work&quot; means either the unmodified Program or a work based
-on the Program.</p>
+  A "covered work" means either the unmodified Program or a work based
+on the Program.
 
-<p>To &quot;propagate&quot; a work means to do anything with it that, without
+  To "propagate" a work means to do anything with it that, without
 permission, would make you directly or secondarily liable for
 infringement under applicable copyright law, except executing it on a
 computer or modifying a private copy.  Propagation includes copying,
 distribution (with or without modification), making available to the
-public, and in some countries other activities as well.</p>
+public, and in some countries other activities as well.
 
-<p>To &quot;convey&quot; a work means any kind of propagation that enables other
+  To "convey" a work means any kind of propagation that enables other
 parties to make or receive copies.  Mere interaction with a user through
-a computer network, with no transfer of a copy, is not conveying.</p>
+a computer network, with no transfer of a copy, is not conveying.
 
-<p>An interactive user interface displays &quot;Appropriate Legal Notices&quot;
+  An interactive user interface displays "Appropriate Legal Notices"
 to the extent that it includes a convenient and prominently visible
 feature that (1) displays an appropriate copyright notice, and (2)
 tells the user that there is no warranty for the work (except to the
 extent that warranties are provided), that licensees may convey the
 work under this License, and how to view a copy of this License.  If
 the interface presents a list of user commands or options, such as a
-menu, a prominent item in the list meets this criterion.</p>
+menu, a prominent item in the list meets this criterion.
 
-<h4 id="section1">1. Source Code.</h4>
+  1. Source Code.
 
-<p>The &quot;source code&quot; for a work means the preferred form of the work
-for making modifications to it.  &quot;Object code&quot; means any non-source
-form of a work.</p>
+  The "source code" for a work means the preferred form of the work
+for making modifications to it.  "Object code" means any non-source
+form of a work.
 
-<p>A &quot;Standard Interface&quot; means an interface that either is an official
+  A "Standard Interface" means an interface that either is an official
 standard defined by a recognized standards body, or, in the case of
 interfaces specified for a particular programming language, one that
-is widely used among developers working in that language.</p>
+is widely used among developers working in that language.
 
-<p>The &quot;System Libraries&quot; of an executable work include anything, other
+  The "System Libraries" of an executable work include anything, other
 than the work as a whole, that (a) is included in the normal form of
 packaging a Major Component, but which is not part of that Major
 Component, and (b) serves only to enable use of the work with that
 Major Component, or to implement a Standard Interface for which an
 implementation is available to the public in source code form.  A
-&quot;Major Component&quot;, in this context, means a major essential component
+"Major Component", in this context, means a major essential component
 (kernel, window system, and so on) of the specific operating system
 (if any) on which the executable work runs, or a compiler used to
-produce the work, or an object code interpreter used to run it.</p>
+produce the work, or an object code interpreter used to run it.
 
-<p>The &quot;Corresponding Source&quot; for a work in object code form means all
+  The "Corresponding Source" for a work in object code form means all
 the source code needed to generate, install, and (for an executable
 work) run the object code and to modify the work, including scripts to
 control those activities.  However, it does not include the work's
@@ -336,26 +130,26 @@ includes interface definition files associated with source files for
 the work, and the source code for shared libraries and dynamically
 linked subprograms that the work is specifically designed to require,
 such as by intimate data communication or control flow between those
-subprograms and other parts of the work.</p>
+subprograms and other parts of the work.
 
-<p>The Corresponding Source need not include anything that users
+  The Corresponding Source need not include anything that users
 can regenerate automatically from other parts of the Corresponding
-Source.</p>
+Source.
 
-<p>The Corresponding Source for a work in source code form is that
-same work.</p>
+  The Corresponding Source for a work in source code form is that
+same work.
 
-<h4 id="section2">2. Basic Permissions.</h4>
+  2. Basic Permissions.
 
-<p>All rights granted under this License are granted for the term of
+  All rights granted under this License are granted for the term of
 copyright on the Program, and are irrevocable provided the stated
 conditions are met.  This License explicitly affirms your unlimited
 permission to run the unmodified Program.  The output from running a
 covered work is covered by this License only if the output, given its
 content, constitutes a covered work.  This License acknowledges your
-rights of fair use or other equivalent, as provided by copyright law.</p>
+rights of fair use or other equivalent, as provided by copyright law.
 
-<p>You may make, run and propagate covered works that you do not
+  You may make, run and propagate covered works that you do not
 convey, without conditions so long as your license otherwise remains
 in force.  You may convey covered works to others for the sole purpose
 of having them make modifications exclusively for you, or provide you
@@ -364,97 +158,91 @@ the terms of this License in conveying all material for which you do
 not control copyright.  Those thus making or running the covered works
 for you must do so exclusively on your behalf, under your direction
 and control, on terms that prohibit them from making any copies of
-your copyrighted material outside their relationship with you.</p>
+your copyrighted material outside their relationship with you.
 
-<p>Conveying under any other circumstances is permitted solely under
+  Conveying under any other circumstances is permitted solely under
 the conditions stated below.  Sublicensing is not allowed; section 10
-makes it unnecessary.</p>
+makes it unnecessary.
 
-<h4 id="section3">3. Protecting Users' Legal Rights From Anti-Circumvention Law.</h4>
+  3. Protecting Users' Legal Rights From Anti-Circumvention Law.
 
-<p>No covered work shall be deemed part of an effective technological
+  No covered work shall be deemed part of an effective technological
 measure under any applicable law fulfilling obligations under article
 11 of the WIPO copyright treaty adopted on 20 December 1996, or
 similar laws prohibiting or restricting circumvention of such
-measures.</p>
+measures.
 
-<p>When you convey a covered work, you waive any legal power to forbid
+  When you convey a covered work, you waive any legal power to forbid
 circumvention of technological measures to the extent such circumvention
 is effected by exercising rights under this License with respect to
 the covered work, and you disclaim any intention to limit operation or
 modification of the work as a means of enforcing, against the work's
 users, your or third parties' legal rights to forbid circumvention of
-technological measures.</p>
+technological measures.
 
-<h4 id="section4">4. Conveying Verbatim Copies.</h4>
+  4. Conveying Verbatim Copies.
 
-<p>You may convey verbatim copies of the Program's source code as you
+  You may convey verbatim copies of the Program's source code as you
 receive it, in any medium, provided that you conspicuously and
 appropriately publish on each copy an appropriate copyright notice;
 keep intact all notices stating that this License and any
 non-permissive terms added in accord with section 7 apply to the code;
 keep intact all notices of the absence of any warranty; and give all
-recipients a copy of this License along with the Program.</p>
+recipients a copy of this License along with the Program.
 
-<p>You may charge any price or no price for each copy that you convey,
-and you may offer support or warranty protection for a fee.</p>
+  You may charge any price or no price for each copy that you convey,
+and you may offer support or warranty protection for a fee.
 
-<h4 id="section5">5. Conveying Modified Source Versions.</h4>
+  5. Conveying Modified Source Versions.
 
-<p>You may convey a work based on the Program, or the modifications to
+  You may convey a work based on the Program, or the modifications to
 produce it from the Program, in the form of source code under the
-terms of section 4, provided that you also meet all of these conditions:</p>
+terms of section 4, provided that you also meet all of these conditions:
 
-<ul>
+    a) The work must carry prominent notices stating that you modified
+    it, and giving a relevant date.
 
-<li>a) The work must carry prominent notices stating that you modified
-    it, and giving a relevant date.</li>
-
-<li>b) The work must carry prominent notices stating that it is
+    b) The work must carry prominent notices stating that it is
     released under this License and any conditions added under section
     7.  This requirement modifies the requirement in section 4 to
-    &quot;keep intact all notices&quot;.</li>
+    "keep intact all notices".
 
-<li>c) You must license the entire work, as a whole, under this
+    c) You must license the entire work, as a whole, under this
     License to anyone who comes into possession of a copy.  This
     License will therefore apply, along with any applicable section 7
     additional terms, to the whole of the work, and all its parts,
     regardless of how they are packaged.  This License gives no
     permission to license the work in any other way, but it does not
-    invalidate such permission if you have separately received it.</li>
+    invalidate such permission if you have separately received it.
 
-<li>d) If the work has interactive user interfaces, each must display
+    d) If the work has interactive user interfaces, each must display
     Appropriate Legal Notices; however, if the Program has interactive
     interfaces that do not display Appropriate Legal Notices, your
-    work need not make them do so.</li>
+    work need not make them do so.
 
-</ul>
-
-<p>A compilation of a covered work with other separate and independent
+  A compilation of a covered work with other separate and independent
 works, which are not by their nature extensions of the covered work,
 and which are not combined with it such as to form a larger program,
 in or on a volume of a storage or distribution medium, is called an
-&quot;aggregate&quot; if the compilation and its resulting copyright are not
+"aggregate" if the compilation and its resulting copyright are not
 used to limit the access or legal rights of the compilation's users
 beyond what the individual works permit.  Inclusion of a covered work
 in an aggregate does not cause this License to apply to the other
-parts of the aggregate.</p>
+parts of the aggregate.
 
-<h4 id="section6">6. Conveying Non-Source Forms.</h4>
+  6. Conveying Non-Source Forms.
 
-<p>You may convey a covered work in object code form under the terms
+  You may convey a covered work in object code form under the terms
 of sections 4 and 5, provided that you also convey the
 machine-readable Corresponding Source under the terms of this License,
-in one of these ways:</p>
+in one of these ways:
 
-<ul>
-
-<li>a) Convey the object code in, or embodied in, a physical product
+    a) Convey the object code in, or embodied in, a physical product
     (including a physical distribution medium), accompanied by the
     Corresponding Source fixed on a durable physical medium
-    customarily used for software interchange.</li>
+    customarily used for software interchange.
 
-<li>b) Convey the object code in, or embodied in, a physical product
+    b) Convey the object code in, or embodied in, a physical product
     (including a physical distribution medium), accompanied by a
     written offer, valid for at least three years and valid for as
     long as you offer spare parts or customer support for that product
@@ -464,15 +252,15 @@ in one of these ways:</p>
     medium customarily used for software interchange, for a price no
     more than your reasonable cost of physically performing this
     conveying of source, or (2) access to copy the
-    Corresponding Source from a network server at no charge.</li>
+    Corresponding Source from a network server at no charge.
 
-<li>c) Convey individual copies of the object code with a copy of the
+    c) Convey individual copies of the object code with a copy of the
     written offer to provide the Corresponding Source.  This
     alternative is allowed only occasionally and noncommercially, and
     only if you received the object code with such an offer, in accord
-    with subsection 6b.</li>
+    with subsection 6b.
 
-<li>d) Convey the object code by offering access from a designated
+    d) Convey the object code by offering access from a designated
     place (gratis or for a charge), and offer equivalent access to the
     Corresponding Source in the same way through the same place at no
     further charge.  You need not require recipients to copy the
@@ -483,41 +271,39 @@ in one of these ways:</p>
     clear directions next to the object code saying where to find the
     Corresponding Source.  Regardless of what server hosts the
     Corresponding Source, you remain obligated to ensure that it is
-    available for as long as needed to satisfy these requirements.</li>
+    available for as long as needed to satisfy these requirements.
 
-<li>e) Convey the object code using peer-to-peer transmission, provided
+    e) Convey the object code using peer-to-peer transmission, provided
     you inform other peers where the object code and Corresponding
     Source of the work are being offered to the general public at no
-    charge under subsection 6d.</li>
+    charge under subsection 6d.
 
-</ul>
-
-<p>A separable portion of the object code, whose source code is excluded
+  A separable portion of the object code, whose source code is excluded
 from the Corresponding Source as a System Library, need not be
-included in conveying the object code work.</p>
+included in conveying the object code work.
 
-<p>A &quot;User Product&quot; is either (1) a &quot;consumer product&quot;, which means any
+  A "User Product" is either (1) a "consumer product", which means any
 tangible personal property which is normally used for personal, family,
 or household purposes, or (2) anything designed or sold for incorporation
 into a dwelling.  In determining whether a product is a consumer product,
 doubtful cases shall be resolved in favor of coverage.  For a particular
-product received by a particular user, &quot;normally used&quot; refers to a
+product received by a particular user, "normally used" refers to a
 typical or common use of that class of product, regardless of the status
 of the particular user or of the way in which the particular user
 actually uses, or expects or is expected to use, the product.  A product
 is a consumer product regardless of whether the product has substantial
 commercial, industrial or non-consumer uses, unless such uses represent
-the only significant mode of use of the product.</p>
+the only significant mode of use of the product.
 
-<p>&quot;Installation Information&quot; for a User Product means any methods,
+  "Installation Information" for a User Product means any methods,
 procedures, authorization keys, or other information required to install
 and execute modified versions of a covered work in that User Product from
 a modified version of its Corresponding Source.  The information must
 suffice to ensure that the continued functioning of the modified object
 code is in no case prevented or interfered with solely because
-modification has been made.</p>
+modification has been made.
 
-<p>If you convey an object code work under this section in, or with, or
+  If you convey an object code work under this section in, or with, or
 specifically for use in, a User Product, and the conveying occurs as
 part of a transaction in which the right of possession and use of the
 User Product is transferred to the recipient in perpetuity or for a
@@ -526,137 +312,133 @@ Corresponding Source conveyed under this section must be accompanied
 by the Installation Information.  But this requirement does not apply
 if neither you nor any third party retains the ability to install
 modified object code on the User Product (for example, the work has
-been installed in ROM).</p>
+been installed in ROM).
 
-<p>The requirement to provide Installation Information does not include a
+  The requirement to provide Installation Information does not include a
 requirement to continue to provide support service, warranty, or updates
 for a work that has been modified or installed by the recipient, or for
 the User Product in which it has been modified or installed.  Access to a
 network may be denied when the modification itself materially and
 adversely affects the operation of the network or violates the rules and
-protocols for communication across the network.</p>
+protocols for communication across the network.
 
-<p>Corresponding Source conveyed, and Installation Information provided,
+  Corresponding Source conveyed, and Installation Information provided,
 in accord with this section must be in a format that is publicly
 documented (and with an implementation available to the public in
 source code form), and must require no special password or key for
-unpacking, reading or copying.</p>
+unpacking, reading or copying.
 
-<h4 id="section7">7. Additional Terms.</h4>
+  7. Additional Terms.
 
-<p>&quot;Additional permissions&quot; are terms that supplement the terms of this
+  "Additional permissions" are terms that supplement the terms of this
 License by making exceptions from one or more of its conditions.
 Additional permissions that are applicable to the entire Program shall
 be treated as though they were included in this License, to the extent
 that they are valid under applicable law.  If additional permissions
 apply only to part of the Program, that part may be used separately
 under those permissions, but the entire Program remains governed by
-this License without regard to the additional permissions.</p>
+this License without regard to the additional permissions.
 
-<p>When you convey a copy of a covered work, you may at your option
+  When you convey a copy of a covered work, you may at your option
 remove any additional permissions from that copy, or from any part of
 it.  (Additional permissions may be written to require their own
 removal in certain cases when you modify the work.)  You may place
 additional permissions on material, added by you to a covered work,
-for which you have or can give appropriate copyright permission.</p>
+for which you have or can give appropriate copyright permission.
 
-<p>Notwithstanding any other provision of this License, for material you
+  Notwithstanding any other provision of this License, for material you
 add to a covered work, you may (if authorized by the copyright holders of
-that material) supplement the terms of this License with terms:</p>
+that material) supplement the terms of this License with terms:
 
-<ul>
+    a) Disclaiming warranty or limiting liability differently from the
+    terms of sections 15 and 16 of this License; or
 
-<li>a) Disclaiming warranty or limiting liability differently from the
-    terms of sections 15 and 16 of this License; or</li>
-
-<li>b) Requiring preservation of specified reasonable legal notices or
+    b) Requiring preservation of specified reasonable legal notices or
     author attributions in that material or in the Appropriate Legal
-    Notices displayed by works containing it; or</li>
+    Notices displayed by works containing it; or
 
-<li>c) Prohibiting misrepresentation of the origin of that material, or
+    c) Prohibiting misrepresentation of the origin of that material, or
     requiring that modified versions of such material be marked in
-    reasonable ways as different from the original version; or</li>
+    reasonable ways as different from the original version; or
 
-<li>d) Limiting the use for publicity purposes of names of licensors or
-    authors of the material; or</li>
+    d) Limiting the use for publicity purposes of names of licensors or
+    authors of the material; or
 
-<li>e) Declining to grant rights under trademark law for use of some
-    trade names, trademarks, or service marks; or</li>
+    e) Declining to grant rights under trademark law for use of some
+    trade names, trademarks, or service marks; or
 
-<li>f) Requiring indemnification of licensors and authors of that
+    f) Requiring indemnification of licensors and authors of that
     material by anyone who conveys the material (or modified versions of
     it) with contractual assumptions of liability to the recipient, for
     any liability that these contractual assumptions directly impose on
-    those licensors and authors.</li>
+    those licensors and authors.
 
-</ul>
-
-<p>All other non-permissive additional terms are considered &quot;further
-restrictions&quot; within the meaning of section 10.  If the Program as you
+  All other non-permissive additional terms are considered "further
+restrictions" within the meaning of section 10.  If the Program as you
 received it, or any part of it, contains a notice stating that it is
-governed by this License along with a term that is a further restriction,
-you may remove that term.  If a license document contains a further
-restriction but permits relicensing or conveying under this License, you
-may add to a covered work material governed by the terms of that license
-document, provided that the further restriction does not survive such
-relicensing or conveying.</p>
+governed by this License along with a term that is a further
+restriction, you may remove that term.  If a license document contains
+a further restriction but permits relicensing or conveying under this
+License, you may add to a covered work material governed by the terms
+of that license document, provided that the further restriction does
+not survive such relicensing or conveying.
 
-<p>If you add terms to a covered work in accord with this section, you
+  If you add terms to a covered work in accord with this section, you
 must place, in the relevant source files, a statement of the
 additional terms that apply to those files, or a notice indicating
-where to find the applicable terms.</p>
+where to find the applicable terms.
 
-<p>Additional terms, permissive or non-permissive, may be stated in the
+  Additional terms, permissive or non-permissive, may be stated in the
 form of a separately written license, or stated as exceptions;
-the above requirements apply either way.</p>
+the above requirements apply either way.
 
-<h4 id="section8">8. Termination.</h4>
+  8. Termination.
 
-<p>You may not propagate or modify a covered work except as expressly
+  You may not propagate or modify a covered work except as expressly
 provided under this License.  Any attempt otherwise to propagate or
 modify it is void, and will automatically terminate your rights under
 this License (including any patent licenses granted under the third
-paragraph of section 11).</p>
+paragraph of section 11).
 
-<p>However, if you cease all violation of this License, then your
+  However, if you cease all violation of this License, then your
 license from a particular copyright holder is reinstated (a)
 provisionally, unless and until the copyright holder explicitly and
 finally terminates your license, and (b) permanently, if the copyright
 holder fails to notify you of the violation by some reasonable means
-prior to 60 days after the cessation.</p>
+prior to 60 days after the cessation.
 
-<p>Moreover, your license from a particular copyright holder is
+  Moreover, your license from a particular copyright holder is
 reinstated permanently if the copyright holder notifies you of the
 violation by some reasonable means, this is the first time you have
 received notice of violation of this License (for any work) from that
 copyright holder, and you cure the violation prior to 30 days after
-your receipt of the notice.</p>
+your receipt of the notice.
 
-<p>Termination of your rights under this section does not terminate the
+  Termination of your rights under this section does not terminate the
 licenses of parties who have received copies or rights from you under
 this License.  If your rights have been terminated and not permanently
 reinstated, you do not qualify to receive new licenses for the same
-material under section 10.</p>
+material under section 10.
 
-<h4 id="section9">9. Acceptance Not Required for Having Copies.</h4>
+  9. Acceptance Not Required for Having Copies.
 
-<p>You are not required to accept this License in order to receive or
+  You are not required to accept this License in order to receive or
 run a copy of the Program.  Ancillary propagation of a covered work
 occurring solely as a consequence of using peer-to-peer transmission
 to receive a copy likewise does not require acceptance.  However,
 nothing other than this License grants you permission to propagate or
 modify any covered work.  These actions infringe copyright if you do
 not accept this License.  Therefore, by modifying or propagating a
-covered work, you indicate your acceptance of this License to do so.</p>
+covered work, you indicate your acceptance of this License to do so.
 
-<h4 id="section10">10. Automatic Licensing of Downstream Recipients.</h4>
+  10. Automatic Licensing of Downstream Recipients.
 
-<p>Each time you convey a covered work, the recipient automatically
+  Each time you convey a covered work, the recipient automatically
 receives a license from the original licensors, to run, modify and
 propagate that work, subject to this License.  You are not responsible
-for enforcing compliance by third parties with this License.</p>
+for enforcing compliance by third parties with this License.
 
-<p>An &quot;entity transaction&quot; is a transaction transferring control of an
+  An "entity transaction" is a transaction transferring control of an
 organization, or substantially all assets of one, or subdividing an
 organization, or merging organizations.  If propagation of a covered
 work results from an entity transaction, each party to that
@@ -664,45 +446,45 @@ transaction who receives a copy of the work also receives whatever
 licenses to the work the party's predecessor in interest had or could
 give under the previous paragraph, plus a right to possession of the
 Corresponding Source of the work from the predecessor in interest, if
-the predecessor has it or can get it with reasonable efforts.</p>
+the predecessor has it or can get it with reasonable efforts.
 
-<p>You may not impose any further restrictions on the exercise of the
+  You may not impose any further restrictions on the exercise of the
 rights granted or affirmed under this License.  For example, you may
 not impose a license fee, royalty, or other charge for exercise of
 rights granted under this License, and you may not initiate litigation
 (including a cross-claim or counterclaim in a lawsuit) alleging that
 any patent claim is infringed by making, using, selling, offering for
-sale, or importing the Program or any portion of it.</p>
+sale, or importing the Program or any portion of it.
 
-<h4 id="section11">11. Patents.</h4>
+  11. Patents.
 
-<p>A &quot;contributor&quot; is a copyright holder who authorizes use under this
+  A "contributor" is a copyright holder who authorizes use under this
 License of the Program or a work on which the Program is based.  The
-work thus licensed is called the contributor's &quot;contributor version&quot;.</p>
+work thus licensed is called the contributor's "contributor version".
 
-<p>A contributor's &quot;essential patent claims&quot; are all patent claims
+  A contributor's "essential patent claims" are all patent claims
 owned or controlled by the contributor, whether already acquired or
 hereafter acquired, that would be infringed by some manner, permitted
 by this License, of making, using, or selling its contributor version,
 but do not include claims that would be infringed only as a
 consequence of further modification of the contributor version.  For
-purposes of this definition, &quot;control&quot; includes the right to grant
+purposes of this definition, "control" includes the right to grant
 patent sublicenses in a manner consistent with the requirements of
-this License.</p>
+this License.
 
-<p>Each contributor grants you a non-exclusive, worldwide, royalty-free
+  Each contributor grants you a non-exclusive, worldwide, royalty-free
 patent license under the contributor's essential patent claims, to
 make, use, sell, offer for sale, import and otherwise run, modify and
-propagate the contents of its contributor version.</p>
+propagate the contents of its contributor version.
 
-<p>In the following three paragraphs, a &quot;patent license&quot; is any express
+  In the following three paragraphs, a "patent license" is any express
 agreement or commitment, however denominated, not to enforce a patent
 (such as an express permission to practice a patent or covenant not to
-sue for patent infringement).  To &quot;grant&quot; such a patent license to a
+sue for patent infringement).  To "grant" such a patent license to a
 party means to make such an agreement or commitment not to enforce a
-patent against the party.</p>
+patent against the party.
 
-<p>If you convey a covered work, knowingly relying on a patent license,
+  If you convey a covered work, knowingly relying on a patent license,
 and the Corresponding Source of the work is not available for anyone
 to copy, free of charge and under the terms of this License, through a
 publicly available network server or other readily accessible means,
@@ -710,21 +492,21 @@ then you must either (1) cause the Corresponding Source to be so
 available, or (2) arrange to deprive yourself of the benefit of the
 patent license for this particular work, or (3) arrange, in a manner
 consistent with the requirements of this License, to extend the patent
-license to downstream recipients.  &quot;Knowingly relying&quot; means you have
+license to downstream recipients.  "Knowingly relying" means you have
 actual knowledge that, but for the patent license, your conveying the
 covered work in a country, or your recipient's use of the covered work
 in a country, would infringe one or more identifiable patents in that
-country that you have reason to believe are valid.</p>
+country that you have reason to believe are valid.
 
-<p>If, pursuant to or in connection with a single transaction or
+  If, pursuant to or in connection with a single transaction or
 arrangement, you convey, or propagate by procuring conveyance of, a
 covered work, and grant a patent license to some of the parties
 receiving the covered work authorizing them to use, propagate, modify
 or convey a specific copy of the covered work, then the patent license
 you grant is automatically extended to all recipients of the covered
-work and works based on it.</p>
+work and works based on it.
 
-<p>A patent license is &quot;discriminatory&quot; if it does not include within
+  A patent license is "discriminatory" if it does not include within
 the scope of its coverage, prohibits the exercise of, or is
 conditioned on the non-exercise of one or more of the rights that are
 specifically granted under this License.  You may not convey a covered
@@ -737,15 +519,15 @@ patent license (a) in connection with copies of the covered work
 conveyed by you (or copies made from those copies), or (b) primarily
 for and in connection with specific products or compilations that
 contain the covered work, unless you entered into that arrangement,
-or that patent license was granted, prior to 28 March 2007.</p>
+or that patent license was granted, prior to 28 March 2007.
 
-<p>Nothing in this License shall be construed as excluding or limiting
+  Nothing in this License shall be construed as excluding or limiting
 any implied license or other defenses to infringement that may
-otherwise be available to you under applicable patent law.</p>
+otherwise be available to you under applicable patent law.
 
-<h4 id="section12">12. No Surrender of Others' Freedom.</h4>
+  12. No Surrender of Others' Freedom.
 
-<p>If conditions are imposed on you (whether by court order, agreement or
+  If conditions are imposed on you (whether by court order, agreement or
 otherwise) that contradict the conditions of this License, they do not
 excuse you from the conditions of this License.  If you cannot convey a
 covered work so as to satisfy simultaneously your obligations under this
@@ -753,11 +535,11 @@ License and any other pertinent obligations, then as a consequence you may
 not convey it at all.  For example, if you agree to terms that obligate you
 to collect a royalty for further conveying from those to whom you convey
 the Program, the only way you could satisfy both those terms and this
-License would be to refrain entirely from conveying the Program.</p>
+License would be to refrain entirely from conveying the Program.
 
-<h4 id="section13">13. Remote Network Interaction; Use with the GNU General Public License.</h4>
+  13. Remote Network Interaction; Use with the GNU General Public License.
 
-<p>Notwithstanding any other provision of this License, if you modify the
+  Notwithstanding any other provision of this License, if you modify the
 Program, your modified version must prominently offer all users
 interacting with it remotely through a computer network (if your version
 supports such interaction) an opportunity to receive the Corresponding
@@ -766,56 +548,56 @@ from a network server at no charge, through some standard or customary
 means of facilitating copying of software.  This Corresponding Source
 shall include the Corresponding Source for any work covered by version 3
 of the GNU General Public License that is incorporated pursuant to the
-following paragraph.</p>
+following paragraph.
 
-<p>Notwithstanding any other provision of this License, you have permission
-to link or combine any covered work with a work licensed under version 3
-of the GNU General Public License into a single combined work, and to
-convey the resulting work.  The terms of this License will continue to
-apply to the part which is the covered work, but the work with which it is
-combined will remain governed by version 3 of the GNU General Public
-License.</p>
+  Notwithstanding any other provision of this License, you have
+permission to link or combine any covered work with a work licensed
+under version 3 of the GNU General Public License into a single
+combined work, and to convey the resulting work.  The terms of this
+License will continue to apply to the part which is the covered work,
+but the work with which it is combined will remain governed by version
+3 of the GNU General Public License.
 
-<h4 id="section14">14. Revised Versions of this License.</h4>
+  14. Revised Versions of this License.
 
-<p>The Free Software Foundation may publish revised and/or new versions of
-the GNU Affero General Public License from time to time.  Such new
-versions will be similar in spirit to the present version, but may differ
-in detail to address new problems or concerns.</p>
+  The Free Software Foundation may publish revised and/or new versions of
+the GNU Affero General Public License from time to time.  Such new versions
+will be similar in spirit to the present version, but may differ in detail to
+address new problems or concerns.
 
-<p>Each version is given a distinguishing version number.  If the
-Program specifies that a certain numbered version of the GNU Affero
-General Public License &quot;or any later version&quot; applies to it, you have
-the option of following the terms and conditions either of that
-numbered version or of any later version published by the Free
-Software Foundation.  If the Program does not specify a version number
-of the GNU Affero General Public License, you may choose any version
-ever published by the Free Software Foundation.</p>
+  Each version is given a distinguishing version number.  If the
+Program specifies that a certain numbered version of the GNU Affero General
+Public License "or any later version" applies to it, you have the
+option of following the terms and conditions either of that numbered
+version or of any later version published by the Free Software
+Foundation.  If the Program does not specify a version number of the
+GNU Affero General Public License, you may choose any version ever published
+by the Free Software Foundation.
 
-<p>If the Program specifies that a proxy can decide which future
-versions of the GNU Affero General Public License can be used, that
-proxy's public statement of acceptance of a version permanently
-authorizes you to choose that version for the Program.</p>
+  If the Program specifies that a proxy can decide which future
+versions of the GNU Affero General Public License can be used, that proxy's
+public statement of acceptance of a version permanently authorizes you
+to choose that version for the Program.
 
-<p>Later license versions may give you additional or different
+  Later license versions may give you additional or different
 permissions.  However, no additional obligations are imposed on any
 author or copyright holder as a result of your choosing to follow a
-later version.</p>
+later version.
 
-<h4 id="section15">15. Disclaimer of Warranty.</h4>
+  15. Disclaimer of Warranty.
 
-<p>THERE IS NO WARRANTY FOR THE PROGRAM, TO THE EXTENT PERMITTED BY
+  THERE IS NO WARRANTY FOR THE PROGRAM, TO THE EXTENT PERMITTED BY
 APPLICABLE LAW.  EXCEPT WHEN OTHERWISE STATED IN WRITING THE COPYRIGHT
-HOLDERS AND/OR OTHER PARTIES PROVIDE THE PROGRAM &quot;AS IS&quot; WITHOUT WARRANTY
+HOLDERS AND/OR OTHER PARTIES PROVIDE THE PROGRAM "AS IS" WITHOUT WARRANTY
 OF ANY KIND, EITHER EXPRESSED OR IMPLIED, INCLUDING, BUT NOT LIMITED TO,
 THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR
 PURPOSE.  THE ENTIRE RISK AS TO THE QUALITY AND PERFORMANCE OF THE PROGRAM
 IS WITH YOU.  SHOULD THE PROGRAM PROVE DEFECTIVE, YOU ASSUME THE COST OF
-ALL NECESSARY SERVICING, REPAIR OR CORRECTION.</p>
+ALL NECESSARY SERVICING, REPAIR OR CORRECTION.
 
-<h4 id="section16">16. Limitation of Liability.</h4>
+  16. Limitation of Liability.
 
-<p>IN NO EVENT UNLESS REQUIRED BY APPLICABLE LAW OR AGREED TO IN WRITING
+  IN NO EVENT UNLESS REQUIRED BY APPLICABLE LAW OR AGREED TO IN WRITING
 WILL ANY COPYRIGHT HOLDER, OR ANY OTHER PARTY WHO MODIFIES AND/OR CONVEYS
 THE PROGRAM AS PERMITTED ABOVE, BE LIABLE TO YOU FOR DAMAGES, INCLUDING ANY
 GENERAL, SPECIAL, INCIDENTAL OR CONSEQUENTIAL DAMAGES ARISING OUT OF THE
@@ -823,37 +605,37 @@ USE OR INABILITY TO USE THE PROGRAM (INCLUDING BUT NOT LIMITED TO LOSS OF
 DATA OR DATA BEING RENDERED INACCURATE OR LOSSES SUSTAINED BY YOU OR THIRD
 PARTIES OR A FAILURE OF THE PROGRAM TO OPERATE WITH ANY OTHER PROGRAMS),
 EVEN IF SUCH HOLDER OR OTHER PARTY HAS BEEN ADVISED OF THE POSSIBILITY OF
-SUCH DAMAGES.</p>
+SUCH DAMAGES.
 
-<h4 id="section17">17. Interpretation of Sections 15 and 16.</h4>
+  17. Interpretation of Sections 15 and 16.
 
-<p>If the disclaimer of warranty and limitation of liability provided
+  If the disclaimer of warranty and limitation of liability provided
 above cannot be given local legal effect according to their terms,
 reviewing courts shall apply local law that most closely approximates
 an absolute waiver of all civil liability in connection with the
 Program, unless a warranty or assumption of liability accompanies a
-copy of the Program in return for a fee.</p>
+copy of the Program in return for a fee.
 
-<p>END OF TERMS AND CONDITIONS</p>
+                     END OF TERMS AND CONDITIONS
 
-<h4 id="howto">How to Apply These Terms to Your New Programs</h4>
+            How to Apply These Terms to Your New Programs
 
-<p>If you develop a new program, and you want it to be of the greatest
+  If you develop a new program, and you want it to be of the greatest
 possible use to the public, the best way to achieve this is to make it
-free software which everyone can redistribute and change under these terms.</p>
+free software which everyone can redistribute and change under these terms.
 
-<p>To do so, attach the following notices to the program.  It is safest
+  To do so, attach the following notices to the program.  It is safest
 to attach them to the start of each source file to most effectively
 state the exclusion of warranty; and each file should have at least
-the &quot;copyright&quot; line and a pointer to where the full notice is found.</p>
+the "copyright" line and a pointer to where the full notice is found.
 
-<pre>    &lt;one line to give the program's name and a brief idea of what it does.&gt;
-    Copyright (C) &lt;year&gt;  &lt;name of author&gt;
+    <one line to give the program's name and a brief idea of what it does.>
+    Copyright (C) <year>  <name of author>
 
     This program is free software: you can redistribute it and/or modify
-    it under the terms of the GNU Affero General Public License as
-    published by the Free Software Foundation, either version 3 of the
-    License, or (at your option) any later version.
+    it under the terms of the GNU Affero General Public License as published by
+    the Free Software Foundation, either version 3 of the License, or
+    (at your option) any later version.
 
     This program is distributed in the hope that it will be useful,
     but WITHOUT ANY WARRANTY; without even the implied warranty of
@@ -861,149 +643,19 @@ the &quot;copyright&quot; line and a pointer to where the full notice is found.<
     GNU Affero General Public License for more details.
 
     You should have received a copy of the GNU Affero General Public License
-    along with this program.  If not, see &lt;https://www.gnu.org/licenses/&gt;.
-</pre>
+    along with this program.  If not, see <https://www.gnu.org/licenses/>.
 
-<p>Also add information on how to contact you by electronic and paper mail.</p>
+Also add information on how to contact you by electronic and paper mail.
 
-<p>If your software can interact with users remotely through a computer
+  If your software can interact with users remotely through a computer
 network, you should also make sure that it provides a way for users to
 get its source.  For example, if your program is a web application, its
-interface could display a &quot;Source&quot; link that leads users to an archive
+interface could display a "Source" link that leads users to an archive
 of the code.  There are many ways you could offer source, and different
 solutions will be better for different programs; see section 13 for the
-specific requirements.</p>
+specific requirements.
 
-<p>You should also get your employer (if you work as a programmer) or school,
-if any, to sign a &quot;copyright disclaimer&quot; for the program, if necessary.
+  You should also get your employer (if you work as a programmer) or school,
+if any, to sign a "copyright disclaimer" for the program, if necessary.
 For more information on this, and how to apply and follow the GNU AGPL, see
-&lt;<a href="https://www.gnu.org/licenses/">https://www.gnu.org/licenses/</a>&gt;.</p>
-
-</div>
-</div>
-
-</div><!-- for id="content", starts in the include above -->
-
-              <!-- begin server/footer-text.html -->
-
-
-
-
-
-<div style="clear:both"></div>
-
-
-<div id="language-container">
- <div class="backtotop">
-  <hr class="no-display" />
-  <a href="#top"><b>&#9650;</b></a>
- </div>
- <div id="languages" class="rounded-corners">
-  <div class="button">
-   <a href="#top" class="close"><span>BACK TO TOP</span></a>
-  </div>
-  <div id="set-language" class="button">
-   <span class="gnun-split"></span>
-   <a href="/server/select-language.html?callback=/licenses/agpl-3.0" rel="nofollow">
-   Set language
-   <span class="gnun-split"></span>
-   </a>
-  </div>
-  <p>Available for this page:</p>
-  <div id="translations">
-<p>
-<span dir="ltr" class="original">[en]&nbsp;<a lang="en" hreflang="en" href="/licenses/agpl-3.0.en.html">English</a> &nbsp;</span>
-<span dir="ltr">[ca]&nbsp;<a lang="ca" hreflang="ca" href="/licenses/agpl-3.0.ca.html">català</a> &nbsp;</span>
-<span dir="ltr">[de]&nbsp;<a lang="de" hreflang="de" href="/licenses/agpl-3.0.de.html">Deutsch</a> &nbsp;</span>
-<span dir="ltr">[fr]&nbsp;<a lang="fr" hreflang="fr" href="/licenses/agpl-3.0.fr.html">français</a> &nbsp;</span>
-<span dir="ltr">[ja]&nbsp;<a lang="ja" hreflang="ja" href="/licenses/agpl-3.0.ja.html">日本語</a> &nbsp;</span>
-<span dir="ltr">[nl]&nbsp;<a lang="nl" hreflang="nl" href="/licenses/agpl-3.0.nl.html">Nederlands</a> &nbsp;</span>
-<span dir="ltr">[pt-br]&nbsp;<a lang="pt-br" hreflang="pt-br" href="/licenses/agpl-3.0.pt-br.html">português</a> &nbsp;</span>
-<span dir="ltr">[ru]&nbsp;<a lang="ru" hreflang="ru" href="/licenses/agpl-3.0.ru.html">русский</a> &nbsp;</span>
-<span dir="ltr">[tr]&nbsp;<a lang="tr" hreflang="tr" href="/licenses/agpl-3.0.tr.html">Türkçe</a> &nbsp;</span>
-<span dir="ltr">[uk]&nbsp;<a lang="uk" hreflang="uk" href="/licenses/agpl-3.0.uk.html">українська</a> &nbsp;</span>
-<span dir="ltr">[zh-cn]&nbsp;<a lang="zh-cn" hreflang="zh-cn" href="/licenses/agpl-3.0.zh-cn.html">简体中文</a> &nbsp;</span>
-</p>
-</div>
- </div>
-</div>
-
-<div id="mission-statement" role="complementary">
- <div class="backtotop">
-  <hr class="no-display" />
-  <a href="#header"><span>BACK TO TOP </span>&#9650;</a>
- </div>
-<div style="clear: both"></div>
-<blockquote>
-<p style="direction:ltr; text-align:left"><a href="//www.fsf.org"><img id="fsfbanner"
-src="/graphics/fsf-logo-notext-small.png" alt="&nbsp;[FSF logo]&nbsp;"
-width="75" height="25" /></a><strong>
-&ldquo;The Free Software Foundation (FSF) is a nonprofit with a worldwide
-mission to promote computer user freedom. We defend the rights of all
-software users.&rdquo;</strong></p>
-</blockquote>
-
-<div id="support-the-fsf" class="button">
- <a class="join" href="//www.fsf.org/associate/support_freedom?referrer=4052">JOIN</a>
- <a class="donate" href="//donate.fsf.org/">DONATE</a>
- <a class="shop" href="//shop.fsf.org/">SHOP</a>
-</div>
-</div>
-<!-- end server/footer-text.html -->
-
-
-<div id="footer" role="contentinfo">
-<div class="unprintable">
-
-<p>Please send general FSF &amp; GNU inquiries to
-<a href="mailto:gnu@gnu.org">&lt;gnu@gnu.org&gt;</a>.
-There are also <a href="/contact/">other ways to contact</a>
-the FSF.  Broken links and other corrections or suggestions can be sent
-to <a href="mailto:webmasters@gnu.org">&lt;webmasters@gnu.org&gt;</a>.</p>
-
-<p><!-- TRANSLATORS: Ignore the original text in this paragraph,
-        replace it with the translation of these two:
-
-        We work hard and do our best to provide accurate, good quality
-        translations.  However, we are not exempt from imperfection.
-        Please send your comments and general suggestions in this regard
-        to <a href="mailto:web-translators@gnu.org">
-        &lt;web-translators@gnu.org&gt;</a>.</p>
-
-        <p>For information on coordinating and contributing translations of
-        our web pages, see <a
-        href="/server/standards/README.translations.html">Translations
-        README</a>. -->
-Please see the <a
-href="/server/standards/README.translations.html">Translations
-README</a> for information on coordinating and contributing translations
-of this article.</p>
-</div>
-
-<p>Copyright notice above.</p>
-
-<p>
-Everyone is permitted to copy and distribute verbatim copies of this license
-document, but changing it is not allowed.
-</p>
-
-<!-- start of server/bottom-notes.html -->
-<div id="bottom-notes" class="unprintable">
-<p><a href="//www.fsf.org/about/dmca-notice">Copyright Infringement Notification</a></p>
-<div id="generic">
-
-
-</div>
-</div>
-<!-- end of server/bottom-notes.html -->
-
-
-<p class="unprintable">Updated:
-<!-- timestamp start -->
-$Date: 2023/11/30 09:46:01 $
-<!-- timestamp end -->
-</p>
-</div>
-</div><!-- for class="inner", starts in the banner include -->
-</body>
-</html>
+<https://www.gnu.org/licenses/>.

--- a/licenses-generator/src/main/resources/offline-license-mirror/www.gnu.org/licenses/fdl-1.1
+++ b/licenses-generator/src/main/resources/offline-license-mirror/www.gnu.org/licenses/fdl-1.1
@@ -1,660 +1,355 @@
-<!DOCTYPE html>
-<html xmlns="http://www.w3.org/1999/xhtml" xml:lang="en" lang="en">
-<head>
-<meta http-equiv="content-type" content="text/html; charset=utf-8" />
-<link rel="author" href="mailto:webmasters@gnu.org" />
-<link rel="icon" type="image/png" href="/graphics/gnu-head-mini.png" />
-<meta name="ICBM" content="42.355469,-71.058627" />
-<link rel="stylesheet" type="text/css" href="/layout.min.css" media="screen" />
-<link rel="stylesheet" type="text/css" href="/print.min.css" media="print" />
-
-
-
-<!-- Parent-Version: 1.98 -->
-<!-- This page is derived from /server/standards/boilerplate.html -->
-<title>GNU Free Documentation License v1.1 - GNU Project - Free Software Foundation</title>
-<!-- begin translist file -->
-
-<link rel="alternate" type="text/html" href="/licenses/old-licenses/fdl-1.1.html" hreflang="x-default" />
-<link rel="alternate" type="text/html" lang="en" hreflang="en" href="/licenses/old-licenses/fdl-1.1.en.html" title="English" />
-<link rel="alternate" type="text/html" lang="de" hreflang="de" href="/licenses/old-licenses/fdl-1.1.de.html" title="Deutsch" />
-<link rel="alternate" type="text/html" lang="fr" hreflang="fr" href="/licenses/old-licenses/fdl-1.1.fr.html" title="français" />
-<link rel="alternate" type="text/html" lang="ja" hreflang="ja" href="/licenses/old-licenses/fdl-1.1.ja.html" title="日本語" />
-<link rel="alternate" type="text/html" lang="pt-br" hreflang="pt-br" href="/licenses/old-licenses/fdl-1.1.pt-br.html" title="português" />
-<link rel="alternate" type="text/html" lang="ru" hreflang="ru" href="/licenses/old-licenses/fdl-1.1.ru.html" title="русский" />
-<link rel="alternate" type="text/html" lang="uk" hreflang="uk" href="/licenses/old-licenses/fdl-1.1.uk.html" title="українська" />
-<link rel="alternate" type="text/html" lang="zh-cn" hreflang="zh-cn" href="/licenses/old-licenses/fdl-1.1.zh-cn.html" title="简体中文" />
-<!-- end translist file -->
-
-<!-- start of server/banner.html -->
-<!-- start of head-include-2.html -->
-<meta name="viewport" content="width=device-width, initial-scale=1" />
-<!-- end of head-include-2.html -->
-
-</head>
-<body>
-<div class="inner">
-<!-- start of server/body-include-1.html -->
-<div id="top">
-<a class="skip" href="#content"><b>Skip to main text</b></a>
-</div>
-
-<div id="fsf-frame" role="complementary">
-<form id="fssbox" action="https://my.fsf.org/civicrm/profile/create?reset=1&amp;gid=31"
-      method="post">
- <div>
-  <input name="postURL" type="hidden" value="" />
-  <input type="hidden" name="group[25]" value="1" />
-  <input name="cancelURL" type="hidden" value="https://crm.fsf.org/civicrm/profile?reset=1&amp;gid=31" />
-  <input name="_qf_default" type="hidden" value="Edit:cancel" />
-  <label for="frmEmail">
-   <a href="//www.fsf.org/fss">Free Software Supporter</a>:
-  </label>
-  <input type="text" id="frmEmail" name="email-Primary" size="18" maxlength="80"
-         value="email address" onfocus="this.value=''"/>
-  <input type="submit" name="_qf_Edit_next" value="Sign up" />
- </div>
-</form>
-
-<div id="join-fsf" class="button"><a
-href="https://www.fsf.org/associate/support_freedom?referrer=4052">JOIN&nbsp;THE&nbsp;FSF</a>
-</div>
-</div>
-
-<div id="header" role="banner">
-<p id="gnu-banner">
- <a href="/">
- <img src="/graphics/heckert_gnu.transp.small.png" height="48" width="49"
-      alt="&nbsp;[A GNU head]&nbsp;" /><strong>GNU</strong> <span
- class="hide">Operating System</span></a><br />
- <small id="fsf-support">Supported by the
- <a href="#mission-statement">Free Software Foundation</a></small>
-</p>
-
-<div id="switches">
-<!-- begin search button -->
- <div  id="search-button" class="switch">
-  <a href="//www.gnu.org/cgi-bin/estseek.cgi">
-  <img id="search-icon" height="30" width="30"
-       src="/graphics/icons/search.png"
-       alt="&nbsp;[Search www.gnu.org]&nbsp;" /></a>
- </div>
-<!-- end search button -->
-
- <div id="language-button" class="switch">
-  <a href="#language-container">
-  <img id="language-icon" height="30" width="37"
-       src="/graphics/icons/translations.png"
-       alt="&nbsp;[Other languages]&nbsp;" /></a>
- </div>
-
-</div>
-</div>
-<!-- end of server/body-include-1.html -->
-
-<!-- start of server/body-include-2 -->
-
-
-<div style="clear: both"></div>
-
-<div id="navigation" role="navigation">
- <a id="more-links" href="#navigation" title="More...">
-   <span>Site navigation</span></a>
- <a id="less-links" href="#content"><b>Skip</b></a>
- <ul>
-
-   <li id="tabAboutGNU"><a href="/gnu/gnu.html">ABOUT&nbsp;GNU</a></li>
-
-
-  <li id="tabPhilosophy"><a href="/philosophy/philosophy.html">PHILOSOPHY</a></li>
-
-
-  <li id="tabLicenses" class="active">
-     <span class='no-display'>=</span> 
-    <a href="/licenses/licenses.html">LICENSES</a>
-    <span class="gnun-split"></span>
-     <span class='no-display'>=</span> 
-  </li>
-
-
-  <li id="tabEducation"><a href="/education/education.html">EDUCATION</a></li>
-
-
-  <li id="tabSoftware"><a href="/software/software.html">SOFTWARE</a></li>
-
-
-  <li id="tabDistros"><a href="/distros/distros.html">DISTROS</a></li>
-
-
-  <li id="tabDoc"><a href="/doc/doc.html">DOCS</a></li>
-
-
-  <li id="tabMalware"><a href="/proprietary/proprietary.html">MALWARE</a></li>
-
-
-  <li id="tabHelp"><a href="/help/help.html">HELP&nbsp;GNU</a></li>
-
-
-  <li id="tabAV"><a href="/audio-video/audio-video.html">AUDIO&nbsp;&amp;&nbsp;VIDEO</a></li>
-
-
-  <li id="tabArt"><a href="/graphics/graphics.html">GNU&nbsp;ART</a></li>
-
-
-  <li id="tabFun"><a href="/fun/humor.html">FUN</a></li>
-
-
-  <li id="tabPeople"><a href="/people/people.html">GNU'S&nbsp;WHO?</a></li>
-
-  <li><a href="//directory.fsf.org">SOFTWARE&nbsp;DIRECTORY</a></li>
-  <li><a href="https://h-node.org/">HARDWARE</a></li>
-  <li><a href="/server/sitemap.html">SITEMAP</a></li>
- </ul>
- <div style="clear: both"></div>
-</div><!-- /"navigation -->
-<!-- end of server/body-include-2 -->
-
-<div id="content" role="main">
-<!-- end of server/banner.html -->
-
-<div class="reduced-width">
-<h2>GNU Free Documentation License, version&nbsp;1.1</h2>
-
-<p class="button" style="margin: 2em 1.5em">
-  <b><a href="#SEC1">Skip to license text</a></b></p>
-
-<ul>
-  <li><a href="/licenses/fdl.html">The latest version of the FDL,
-      version 1.3</a></li>
-  <li><a href="/philosophy/free-doc.html">Free software and free
-      documentation</a></li>
-  <li><a href="/licenses/gpl-violation.html">What to do if you see a
-      possible GFDL violation</a></li>
-  <li><a href="/licenses/why-gfdl.html">Why publishers should use the
-      GNU Free Documentation License</a></li>
-  <li><a href="/licenses/fdl-howto.html">Tips on how to use the FDL</a></li>
-  <li><a href="/licenses/fdl-howto-opt.html">Using the optional features
-      of the GFDL</a></li>
-  <li><a href="/licenses/old-licenses/fdl-1.1-translations.html">Translations
-      of GFDLv1.1</a></li>
-  <li>The GNU Free Documentation License version 1.1 (GFDLv1.1) in other
-      formats:
-      <a href="/licenses/old-licenses/fdl-1.1.txt">plain text</a>,
-      <a href="/licenses/old-licenses/fdl-1.1.texi">Texinfo</a>,
-      <a href="/licenses/old-licenses/fdl-1.1.tex">LaTeX</a>,
-  <a href="/licenses/old-licenses/fdl-1.1-standalone.html">standalone HTML</a>,
-      <a href="/licenses/old-licenses/fdl-1.1.sgml">Docbook/SGML</a>, 
-      <a href="/licenses/old-licenses/fdl-1.1.md">Markdown</a>, 
-      <a href="/licenses/old-licenses/fdl-1.1.odt">ODF</a>, 
-      <a href="/licenses/old-licenses/fdl-1.1.rtf">RTF</a>
-  </li>
-  <li><a href="/licenses/old-licenses/old-licenses.html#FDL">Old versions
-      of the GFDL</a></li>
-</ul>
-
-<hr class="thin" />
-
-<h3>Table of Contents</h3>
-
-<ul>
-  <li><a id="TOC1" href="#SEC1">GNU Free Documentation License</a></li>
-  <li><a id="TOC4" href="#SEC4">How to use this License for your
-  documents</a></li>
-</ul>
-
-<hr class="thin" />
-
-<!-- The license text is in English and appears broken in RTL as
-     Arabic, Farsi, etc.  Explicitly set the direction to override the
-     one defined in the translation. -->
-<div dir="ltr">
-<h3 id="SEC1">GNU Free Documentation License</h3>
-
-<p>Version 1.1, March 2000</p>
-<pre>Copyright (C) 2000  Free Software Foundation, Inc.
-&lt;<a href="https://www.fsf.org/">https://www.fsf.org/</a>&gt;
-Everyone is permitted to copy and distribute verbatim copies
-of this license document, but changing it is not allowed.</pre>
-
-<h4 id="section0">0. PREAMBLE</h4>
-
-<p>The purpose of this License is to make a manual, textbook, or other written
-document "free" in the sense of freedom: to assure everyone the effective
-freedom to copy and redistribute it, with or without modifying it, either
-commercially or noncommercially. Secondarily, this License preserves for the
-author and publisher a way to get credit for their work, while not being
-considered responsible for modifications made by others.</p>
-
-<p>This License is a kind of "copyleft", which means that derivative works of
-the document must themselves be free in the same sense. It complements the GNU
-General Public License, which is a copyleft license designed for free
-software.</p>
-
-<p>We have designed this License in order to use it for manuals for free
-software, because free software needs free documentation: a free program should
-come with manuals providing the same freedoms that the software does. But this
-License is not limited to software manuals; it can be used for any textual
-work, regardless of subject matter or whether it is published as a printed
-book. We recommend this License principally for works whose purpose is
-instruction or reference.</p>
-
-<h4 id="section1">1. APPLICABILITY AND DEFINITIONS</h4>
-
-<p>This License applies to any manual or other work that contains a notice
-placed by the copyright holder saying it can be distributed under the terms of
-this License. The "Document", below, refers to any such manual or work. Any
-member of the public is a licensee, and is addressed as "you".</p>
-
-<p>A "Modified Version" of the Document means any work containing the Document
-or a portion of it, either copied verbatim, or with modifications and/or
-translated into another language.</p>
-
-<p>A "Secondary Section" is a named appendix or a front-matter section of the
-Document that deals exclusively with the relationship of the publishers or
-authors of the Document to the Document's overall subject (or to related
-matters) and contains nothing that could fall directly within that overall
-subject. (For example, if the Document is in part a textbook of mathematics, a
-Secondary Section may not explain any mathematics.) The relationship could be a
-matter of historical connection with the subject or with related matters, or of
-legal, commercial, philosophical, ethical or political position regarding
-them.</p>
-
-<p>The "Invariant Sections" are certain Secondary Sections whose titles are
-designated, as being those of Invariant Sections, in the notice that says that
-the Document is released under this License.</p>
-
-<p>The "Cover Texts" are certain short passages of text that are listed, as
-Front-Cover Texts or Back-Cover Texts, in the notice that says that the
-Document is released under this License.</p>
-
-<p>A "Transparent" copy of the Document means a machine-readable copy,
-represented in a format whose specification is available to the general public,
-whose contents can be viewed and edited directly and straightforwardly with
-generic text editors or (for images composed of pixels) generic paint programs
-or (for drawings) some widely available drawing editor, and that is suitable
-for input to text formatters or for automatic translation to a variety of
-formats suitable for input to text formatters. A copy made in an otherwise
-Transparent file format whose markup has been designed to thwart or discourage
-subsequent modification by readers is not Transparent. A copy that is not
-"Transparent" is called "Opaque".</p>
-
-<p>Examples of suitable formats for Transparent copies include plain ASCII
-without markup, Texinfo input format, LaTeX input format, SGML or XML using a
-publicly available DTD, and standard-conforming simple HTML designed for human
-modification. Opaque formats include PostScript, PDF, proprietary formats that
-can be read and edited only by proprietary word processors, SGML or XML for
-which the DTD and/or processing tools are not generally available, and the
-machine-generated HTML produced by some word processors for output purposes
-only.</p>
-
-<p>The "Title Page" means, for a printed book, the title page itself, plus such
-following pages as are needed to hold, legibly, the material this License
-requires to appear in the title page. For works in formats which do not have
-any title page as such, "Title Page" means the text near the most prominent
-appearance of the work's title, preceding the beginning of the body of the
-text.</p>
-
-<h4 id="section2">2. VERBATIM COPYING</h4>
-
-<p>You may copy and distribute the Document in any medium, either commercially
-or noncommercially, provided that this License, the copyright notices, and the
-license notice saying this License applies to the Document are reproduced in
-all copies, and that you add no other conditions whatsoever to those of this
-License. You may not use technical measures to obstruct or control the reading
-or further copying of the copies you make or distribute. However, you may
-accept compensation in exchange for copies. If you distribute a large enough
-number of copies you must also follow the conditions in section 3.</p>
-
-<p>You may also lend copies, under the same conditions stated above, and you
-may publicly display copies.</p>
-
-<h4 id="section3">3. COPYING IN QUANTITY</h4>
-
-<p>If you publish printed copies of the Document numbering more than 100, and
-the Document's license notice requires Cover Texts, you must enclose the copies
-in covers that carry, clearly and legibly, all these Cover Texts: Front-Cover
-Texts on the front cover, and Back-Cover Texts on the back cover. Both covers
-must also clearly and legibly identify you as the publisher of these copies.
-The front cover must present the full title with all words of the title equally
-prominent and visible. You may add other material on the covers in addition.
-Copying with changes limited to the covers, as long as they preserve the title
-of the Document and satisfy these conditions, can be treated as verbatim
-copying in other respects.</p>
-
-<p>If the required texts for either cover are too voluminous to fit legibly,
-you should put the first ones listed (as many as fit reasonably) on the actual
-cover, and continue the rest onto adjacent pages.</p>
-
-<p>If you publish or distribute Opaque copies of the Document numbering more
-than 100, you must either include a machine-readable Transparent copy along
-with each Opaque copy, or state in or with each Opaque copy a
-publicly-accessible computer-network location containing a complete Transparent
-copy of the Document, free of added material, which the general network-using
-public has access to download anonymously at no charge using public-standard
-network protocols. If you use the latter option, you must take reasonably
-prudent steps, when you begin distribution of Opaque copies in quantity, to
-ensure that this Transparent copy will remain thus accessible at the stated
-location until at least one year after the last time you distribute an Opaque
-copy (directly or through your agents or retailers) of that edition to the
-public.</p>
-
-<p>It is requested, but not required, that you contact the authors of the
-Document well before redistributing any large number of copies, to give them a
-chance to provide you with an updated version of the Document.</p>
-
-<h4 id="section4">4. MODIFICATIONS</h4>
-
-<p>You may copy and distribute a Modified Version of the Document under the
-conditions of sections 2 and 3 above, provided that you release the Modified
-Version under precisely this License, with the Modified Version filling the
-role of the Document, thus licensing distribution and modification of the
-Modified Version to whoever possesses a copy of it. In addition, you must do
-these things in the Modified Version:</p>
-<ul>
-  <li><strong>A.</strong> Use in the Title Page (and on the covers, if any) a
-    title distinct from that of the Document, and from those of previous
-    versions (which should, if there were any, be listed in the History section
-    of the Document). You may use the same title as a previous version if the
-    original publisher of that version gives permission.</li>
-  <li><strong>B.</strong> List on the Title Page, as authors, one or more
-    persons or entities responsible for authorship of the modifications in the
-    Modified Version, together with at least five of the principal authors of
-    the Document (all of its principal authors, if it has less than five).</li>
-  <li><strong>C.</strong> State on the Title page the name of the publisher of
-    the Modified Version, as the publisher.</li>
-  <li><strong>D.</strong> Preserve all the copyright notices of the
-  Document.</li>
-  <li><strong>E.</strong> Add an appropriate copyright notice for your
-    modifications adjacent to the other copyright notices.</li>
-  <li><strong>F.</strong> Include, immediately after the copyright notices, a
-    license notice giving the public permission to use the Modified Version
-    under the terms of this License, in the form shown in the Addendum
-  below.</li>
-  <li><strong>G.</strong> Preserve in that license notice the full lists of
-    Invariant Sections and required Cover Texts given in the Document's license
-    notice.</li>
-  <li><strong>H.</strong> Include an unaltered copy of this License.</li>
-  <li><strong>I.</strong> Preserve the section entitled "History", and its
-    title, and add to it an item stating at least the title, year, new authors,
-    and publisher of the Modified Version as given on the Title Page. If there
-    is no section entitled "History" in the Document, create one stating the
-    title, year, authors, and publisher of the Document as given on its Title
-    Page, then add an item describing the Modified Version as stated in the
-    previous sentence.</li>
-  <li><strong>J.</strong> Preserve the network location, if any, given in the
-    Document for public access to a Transparent copy of the Document, and
-    likewise the network locations given in the Document for previous versions
-    it was based on. These may be placed in the "History" section. You may omit
-    a network location for a work that was published at least four years before
-    the Document itself, or if the original publisher of the version it refers
-    to gives permission.</li>
-  <li><strong>K.</strong> In any section entitled "Acknowledgements" or
-    "Dedications", preserve the section's title, and preserve in the section
-    all the substance and tone of each of the contributor acknowledgements
-    and/or dedications given therein.</li>
-  <li><strong>L.</strong> Preserve all the Invariant Sections of the Document,
-    unaltered in their text and in their titles. Section numbers or the
-    equivalent are not considered part of the section titles.</li>
-  <li><strong>M.</strong> Delete any section entitled "Endorsements". Such a
-    section may not be included in the Modified Version.</li>
-  <li><strong>N.</strong> Do not retitle any existing section as "Endorsements"
-    or to conflict in title with any Invariant Section.</li>
-</ul>
-
-<p>If the Modified Version includes new front-matter sections or appendices
-that qualify as Secondary Sections and contain no material copied from the
-Document, you may at your option designate some or all of these sections as
-invariant. To do this, add their titles to the list of Invariant Sections in
-the Modified Version's license notice. These titles must be distinct from any
-other section titles.</p>
-
-<p>You may add a section entitled "Endorsements", provided it contains nothing
-but endorsements of your Modified Version by various parties--for example,
-statements of peer review or that the text has been approved by an organization
-as the authoritative definition of a standard.</p>
-
-<p>You may add a passage of up to five words as a Front-Cover Text, and a
-passage of up to 25 words as a Back-Cover Text, to the end of the list of Cover
-Texts in the Modified Version. Only one passage of Front-Cover Text and one of
-Back-Cover Text may be added by (or through arrangements made by) any one
-entity. If the Document already includes a cover text for the same cover,
-previously added by you or by arrangement made by the same entity you are
-acting on behalf of, you may not add another; but you may replace the old one,
-on explicit permission from the previous publisher that added the old one.</p>
-
-<p>The author(s) and publisher(s) of the Document do not by this License give
-permission to use their names for publicity for or to assert or imply
-endorsement of any Modified Version.</p>
-
-<h4 id="section5">5. COMBINING DOCUMENTS</h4>
-
-<p>You may combine the Document with other documents released under this
-License, under the terms defined in section 4 above for modified versions,
-provided that you include in the combination all of the Invariant Sections of
-all of the original documents, unmodified, and list them all as Invariant
-Sections of your combined work in its license notice.</p>
-
-<p>The combined work need only contain one copy of this License, and multiple
-identical Invariant Sections may be replaced with a single copy. If there are
-multiple Invariant Sections with the same name but different contents, make the
-title of each such section unique by adding at the end of it, in parentheses,
-the name of the original author or publisher of that section if known, or else
-a unique number. Make the same adjustment to the section titles in the list of
-Invariant Sections in the license notice of the combined work.</p>
-
-<p>In the combination, you must combine any sections entitled "History" in the
-various original documents, forming one section entitled "History"; likewise
-combine any sections entitled "Acknowledgements", and any sections entitled
-"Dedications". You must delete all sections entitled "Endorsements."</p>
-
-<h4 id="section6">6. COLLECTIONS OF DOCUMENTS</h4>
-
-<p>You may make a collection consisting of the Document and other documents
-released under this License, and replace the individual copies of this License
-in the various documents with a single copy that is included in the collection,
-provided that you follow the rules of this License for verbatim copying of each
-of the documents in all other respects.</p>
-
-<p>You may extract a single document from such a collection, and distribute it
-individually under this License, provided you insert a copy of this License
-into the extracted document, and follow this License in all other respects
-regarding verbatim copying of that document.</p>
-
-<h4 id="section7">7. AGGREGATION WITH INDEPENDENT WORKS</h4>
-
-<p>A compilation of the Document or its derivatives with other separate and
-independent documents or works, in or on a volume of a storage or distribution
-medium, does not as a whole count as a Modified Version of the Document,
-provided no compilation copyright is claimed for the compilation. Such a
-compilation is called an "aggregate", and this License does not apply to the
-other self-contained works thus compiled with the Document, on account of their
-being thus compiled, if they are not themselves derivative works of the
-Document.</p>
-
-<p>If the Cover Text requirement of section 3 is applicable to these copies of
-the Document, then if the Document is less than one quarter of the entire
-aggregate, the Document's Cover Texts may be placed on covers that surround
-only the Document within the aggregate. Otherwise they must appear on covers
-around the whole aggregate.</p>
-
-<h4 id="section8">8. TRANSLATION</h4>
-
-<p>Translation is considered a kind of modification, so you may distribute
-translations of the Document under the terms of section 4. Replacing Invariant
-Sections with translations requires special permission from their copyright
-holders, but you may include translations of some or all Invariant Sections in
-addition to the original versions of these Invariant Sections. You may include
-a translation of this License provided that you also include the original
-English version of this License. In case of a disagreement between the
-translation and the original English version of this License, the original
-English version will prevail.</p>
-
-<h4 id="section9">9. TERMINATION</h4>
-
-<p>You may not copy, modify, sublicense, or distribute the Document except as
-expressly provided for under this License. Any other attempt to copy, modify,
-sublicense or distribute the Document is void, and will automatically terminate
-your rights under this License. However, parties who have received copies, or
-rights, from you under this License will not have their licenses terminated so
-long as such parties remain in full compliance.</p>
-
-<h4 id="section10">10. FUTURE REVISIONS OF THIS LICENSE</h4>
-
-<p>The Free Software Foundation may publish new, revised versions of the GNU
-Free Documentation License from time to time. Such new versions will be similar
-in spirit to the present version, but may differ in detail to address new
-problems or concerns. See https://www.gnu.org/licenses/.</p>
-
-<p>Each version of the License is given a distinguishing version number. If the
-Document specifies that a particular numbered version of this License "or any
-later version" applies to it, you have the option of following the terms and
-conditions either of that specified version or of any later version that has
-been published (not as a draft) by the Free Software Foundation. If the
-Document does not specify a version number of this License, you may choose any
-version ever published (not as a draft) by the Free Software Foundation.</p>
-
-<h4 id="SEC4">How to use this License for your documents</h4>
-
-<p>To use this License in a document you have written, include a copy of the
-License in the document and put the following copyright and license notices
-just after the title page:</p>
-<pre>      Copyright (c)  YEAR  YOUR NAME.
+                GNU Free Documentation License
+                   Version 1.1, March 2000
+
+ Copyright (C) 2000  Free Software Foundation, Inc.
+     <https://fsf.org/>
+ Everyone is permitted to copy and distribute verbatim copies
+ of this license document, but changing it is not allowed.
+
+
+0. PREAMBLE
+
+The purpose of this License is to make a manual, textbook, or other
+written document "free" in the sense of freedom: to assure everyone
+the effective freedom to copy and redistribute it, with or without
+modifying it, either commercially or noncommercially.  Secondarily,
+this License preserves for the author and publisher a way to get
+credit for their work, while not being considered responsible for
+modifications made by others.
+
+This License is a kind of "copyleft", which means that derivative
+works of the document must themselves be free in the same sense.  It
+complements the GNU General Public License, which is a copyleft
+license designed for free software.
+
+We have designed this License in order to use it for manuals for free
+software, because free software needs free documentation: a free
+program should come with manuals providing the same freedoms that the
+software does.  But this License is not limited to software manuals;
+it can be used for any textual work, regardless of subject matter or
+whether it is published as a printed book.  We recommend this License
+principally for works whose purpose is instruction or reference.
+
+
+1. APPLICABILITY AND DEFINITIONS
+
+This License applies to any manual or other work that contains a
+notice placed by the copyright holder saying it can be distributed
+under the terms of this License.  The "Document", below, refers to any
+such manual or work.  Any member of the public is a licensee, and is
+addressed as "you".
+
+A "Modified Version" of the Document means any work containing the
+Document or a portion of it, either copied verbatim, or with
+modifications and/or translated into another language.
+
+A "Secondary Section" is a named appendix or a front-matter section of
+the Document that deals exclusively with the relationship of the
+publishers or authors of the Document to the Document's overall subject
+(or to related matters) and contains nothing that could fall directly
+within that overall subject.  (For example, if the Document is in part a
+textbook of mathematics, a Secondary Section may not explain any
+mathematics.)  The relationship could be a matter of historical
+connection with the subject or with related matters, or of legal,
+commercial, philosophical, ethical or political position regarding
+them.
+
+The "Invariant Sections" are certain Secondary Sections whose titles
+are designated, as being those of Invariant Sections, in the notice
+that says that the Document is released under this License.
+
+The "Cover Texts" are certain short passages of text that are listed,
+as Front-Cover Texts or Back-Cover Texts, in the notice that says that
+the Document is released under this License.
+
+A "Transparent" copy of the Document means a machine-readable copy,
+represented in a format whose specification is available to the
+general public, whose contents can be viewed and edited directly and
+straightforwardly with generic text editors or (for images composed of
+pixels) generic paint programs or (for drawings) some widely available
+drawing editor, and that is suitable for input to text formatters or
+for automatic translation to a variety of formats suitable for input
+to text formatters.  A copy made in an otherwise Transparent file
+format whose markup has been designed to thwart or discourage
+subsequent modification by readers is not Transparent.  A copy that is
+not "Transparent" is called "Opaque".
+
+Examples of suitable formats for Transparent copies include plain
+ASCII without markup, Texinfo input format, LaTeX input format, SGML
+or XML using a publicly available DTD, and standard-conforming simple
+HTML designed for human modification.  Opaque formats include
+PostScript, PDF, proprietary formats that can be read and edited only
+by proprietary word processors, SGML or XML for which the DTD and/or
+processing tools are not generally available, and the
+machine-generated HTML produced by some word processors for output
+purposes only.
+
+The "Title Page" means, for a printed book, the title page itself,
+plus such following pages as are needed to hold, legibly, the material
+this License requires to appear in the title page.  For works in
+formats which do not have any title page as such, "Title Page" means
+the text near the most prominent appearance of the work's title,
+preceding the beginning of the body of the text.
+
+
+2. VERBATIM COPYING
+
+You may copy and distribute the Document in any medium, either
+commercially or noncommercially, provided that this License, the
+copyright notices, and the license notice saying this License applies
+to the Document are reproduced in all copies, and that you add no other
+conditions whatsoever to those of this License.  You may not use
+technical measures to obstruct or control the reading or further
+copying of the copies you make or distribute.  However, you may accept
+compensation in exchange for copies.  If you distribute a large enough
+number of copies you must also follow the conditions in section 3.
+
+You may also lend copies, under the same conditions stated above, and
+you may publicly display copies.
+
+
+3. COPYING IN QUANTITY
+
+If you publish printed copies of the Document numbering more than 100,
+and the Document's license notice requires Cover Texts, you must enclose
+the copies in covers that carry, clearly and legibly, all these Cover
+Texts: Front-Cover Texts on the front cover, and Back-Cover Texts on
+the back cover.  Both covers must also clearly and legibly identify
+you as the publisher of these copies.  The front cover must present
+the full title with all words of the title equally prominent and
+visible.  You may add other material on the covers in addition.
+Copying with changes limited to the covers, as long as they preserve
+the title of the Document and satisfy these conditions, can be treated
+as verbatim copying in other respects.
+
+If the required texts for either cover are too voluminous to fit
+legibly, you should put the first ones listed (as many as fit
+reasonably) on the actual cover, and continue the rest onto adjacent
+pages.
+
+If you publish or distribute Opaque copies of the Document numbering
+more than 100, you must either include a machine-readable Transparent
+copy along with each Opaque copy, or state in or with each Opaque copy
+a publicly-accessible computer-network location containing a complete
+Transparent copy of the Document, free of added material, which the
+general network-using public has access to download anonymously at no
+charge using public-standard network protocols.  If you use the latter
+option, you must take reasonably prudent steps, when you begin
+distribution of Opaque copies in quantity, to ensure that this
+Transparent copy will remain thus accessible at the stated location
+until at least one year after the last time you distribute an Opaque
+copy (directly or through your agents or retailers) of that edition to
+the public.
+
+It is requested, but not required, that you contact the authors of the
+Document well before redistributing any large number of copies, to give
+them a chance to provide you with an updated version of the Document.
+
+
+4. MODIFICATIONS
+
+You may copy and distribute a Modified Version of the Document under
+the conditions of sections 2 and 3 above, provided that you release
+the Modified Version under precisely this License, with the Modified
+Version filling the role of the Document, thus licensing distribution
+and modification of the Modified Version to whoever possesses a copy
+of it.  In addition, you must do these things in the Modified Version:
+
+A. Use in the Title Page (and on the covers, if any) a title distinct
+   from that of the Document, and from those of previous versions
+   (which should, if there were any, be listed in the History section
+   of the Document).  You may use the same title as a previous version
+   if the original publisher of that version gives permission.
+B. List on the Title Page, as authors, one or more persons or entities
+   responsible for authorship of the modifications in the Modified
+   Version, together with at least five of the principal authors of the
+   Document (all of its principal authors, if it has less than five).
+C. State on the Title page the name of the publisher of the
+   Modified Version, as the publisher.
+D. Preserve all the copyright notices of the Document.
+E. Add an appropriate copyright notice for your modifications
+   adjacent to the other copyright notices.
+F. Include, immediately after the copyright notices, a license notice
+   giving the public permission to use the Modified Version under the
+   terms of this License, in the form shown in the Addendum below.
+G. Preserve in that license notice the full lists of Invariant Sections
+   and required Cover Texts given in the Document's license notice.
+H. Include an unaltered copy of this License.
+I. Preserve the section entitled "History", and its title, and add to
+   it an item stating at least the title, year, new authors, and
+   publisher of the Modified Version as given on the Title Page.  If
+   there is no section entitled "History" in the Document, create one
+   stating the title, year, authors, and publisher of the Document as
+   given on its Title Page, then add an item describing the Modified
+   Version as stated in the previous sentence.
+J. Preserve the network location, if any, given in the Document for
+   public access to a Transparent copy of the Document, and likewise
+   the network locations given in the Document for previous versions
+   it was based on.  These may be placed in the "History" section.
+   You may omit a network location for a work that was published at
+   least four years before the Document itself, or if the original
+   publisher of the version it refers to gives permission.
+K. In any section entitled "Acknowledgements" or "Dedications",
+   preserve the section's title, and preserve in the section all the
+   substance and tone of each of the contributor acknowledgements
+   and/or dedications given therein.
+L. Preserve all the Invariant Sections of the Document,
+   unaltered in their text and in their titles.  Section numbers
+   or the equivalent are not considered part of the section titles.
+M. Delete any section entitled "Endorsements".  Such a section
+   may not be included in the Modified Version.
+N. Do not retitle any existing section as "Endorsements"
+   or to conflict in title with any Invariant Section.
+
+If the Modified Version includes new front-matter sections or
+appendices that qualify as Secondary Sections and contain no material
+copied from the Document, you may at your option designate some or all
+of these sections as invariant.  To do this, add their titles to the
+list of Invariant Sections in the Modified Version's license notice.
+These titles must be distinct from any other section titles.
+
+You may add a section entitled "Endorsements", provided it contains
+nothing but endorsements of your Modified Version by various
+parties--for example, statements of peer review or that the text has
+been approved by an organization as the authoritative definition of a
+standard.
+
+You may add a passage of up to five words as a Front-Cover Text, and a
+passage of up to 25 words as a Back-Cover Text, to the end of the list
+of Cover Texts in the Modified Version.  Only one passage of
+Front-Cover Text and one of Back-Cover Text may be added by (or
+through arrangements made by) any one entity.  If the Document already
+includes a cover text for the same cover, previously added by you or
+by arrangement made by the same entity you are acting on behalf of,
+you may not add another; but you may replace the old one, on explicit
+permission from the previous publisher that added the old one.
+
+The author(s) and publisher(s) of the Document do not by this License
+give permission to use their names for publicity for or to assert or
+imply endorsement of any Modified Version.
+
+
+5. COMBINING DOCUMENTS
+
+You may combine the Document with other documents released under this
+License, under the terms defined in section 4 above for modified
+versions, provided that you include in the combination all of the
+Invariant Sections of all of the original documents, unmodified, and
+list them all as Invariant Sections of your combined work in its
+license notice.
+
+The combined work need only contain one copy of this License, and
+multiple identical Invariant Sections may be replaced with a single
+copy.  If there are multiple Invariant Sections with the same name but
+different contents, make the title of each such section unique by
+adding at the end of it, in parentheses, the name of the original
+author or publisher of that section if known, or else a unique number.
+Make the same adjustment to the section titles in the list of
+Invariant Sections in the license notice of the combined work.
+
+In the combination, you must combine any sections entitled "History"
+in the various original documents, forming one section entitled
+"History"; likewise combine any sections entitled "Acknowledgements",
+and any sections entitled "Dedications".  You must delete all sections
+entitled "Endorsements."
+
+
+6. COLLECTIONS OF DOCUMENTS
+
+You may make a collection consisting of the Document and other documents
+released under this License, and replace the individual copies of this
+License in the various documents with a single copy that is included in
+the collection, provided that you follow the rules of this License for
+verbatim copying of each of the documents in all other respects.
+
+You may extract a single document from such a collection, and distribute
+it individually under this License, provided you insert a copy of this
+License into the extracted document, and follow this License in all
+other respects regarding verbatim copying of that document.
+
+
+7. AGGREGATION WITH INDEPENDENT WORKS
+
+A compilation of the Document or its derivatives with other separate
+and independent documents or works, in or on a volume of a storage or
+distribution medium, does not as a whole count as a Modified Version
+of the Document, provided no compilation copyright is claimed for the
+compilation.  Such a compilation is called an "aggregate", and this
+License does not apply to the other self-contained works thus compiled
+with the Document, on account of their being thus compiled, if they
+are not themselves derivative works of the Document.
+
+If the Cover Text requirement of section 3 is applicable to these
+copies of the Document, then if the Document is less than one quarter
+of the entire aggregate, the Document's Cover Texts may be placed on
+covers that surround only the Document within the aggregate.
+Otherwise they must appear on covers around the whole aggregate.
+
+
+8. TRANSLATION
+
+Translation is considered a kind of modification, so you may
+distribute translations of the Document under the terms of section 4.
+Replacing Invariant Sections with translations requires special
+permission from their copyright holders, but you may include
+translations of some or all Invariant Sections in addition to the
+original versions of these Invariant Sections.  You may include a
+translation of this License provided that you also include the
+original English version of this License.  In case of a disagreement
+between the translation and the original English version of this
+License, the original English version will prevail.
+
+
+9. TERMINATION
+
+You may not copy, modify, sublicense, or distribute the Document except
+as expressly provided for under this License.  Any other attempt to
+copy, modify, sublicense or distribute the Document is void, and will
+automatically terminate your rights under this License.  However,
+parties who have received copies, or rights, from you under this
+License will not have their licenses terminated so long as such
+parties remain in full compliance.
+
+
+10. FUTURE REVISIONS OF THIS LICENSE
+
+The Free Software Foundation may publish new, revised versions
+of the GNU Free Documentation License from time to time.  Such new
+versions will be similar in spirit to the present version, but may
+differ in detail to address new problems or concerns.  See
+https://www.gnu.org/licenses/.
+
+Each version of the License is given a distinguishing version number.
+If the Document specifies that a particular numbered version of this
+License "or any later version" applies to it, you have the option of
+following the terms and conditions either of that specified version or
+of any later version that has been published (not as a draft) by the
+Free Software Foundation.  If the Document does not specify a version
+number of this License, you may choose any version ever published (not
+as a draft) by the Free Software Foundation.
+
+
+ADDENDUM: How to use this License for your documents
+
+To use this License in a document you have written, include a copy of
+the License in the document and put the following copyright and
+license notices just after the title page:
+
+      Copyright (c)  YEAR  YOUR NAME.
       Permission is granted to copy, distribute and/or modify this document
       under the terms of the GNU Free Documentation License, Version 1.1
       or any later version published by the Free Software Foundation;
       with the Invariant Sections being LIST THEIR TITLES, with the
       Front-Cover Texts being LIST, and with the Back-Cover Texts being LIST.
       A copy of the license is included in the section entitled "GNU
-      Free Documentation License".</pre>
+      Free Documentation License".
 
-<p>If you have no Invariant Sections, write "with no Invariant Sections"
-instead of saying which ones are invariant. If you have no Front-Cover Texts,
-write "no Front-Cover Texts" instead of "Front-Cover Texts being LIST";
-likewise for Back-Cover Texts.</p>
+If you have no Invariant Sections, write "with no Invariant Sections"
+instead of saying which ones are invariant.  If you have no
+Front-Cover Texts, write "no Front-Cover Texts" instead of
+"Front-Cover Texts being LIST"; likewise for Back-Cover Texts.
 
-<p>If your document contains nontrivial examples of program code, we recommend
-releasing these examples in parallel under your choice of free software
-license, such as the GNU General Public License, to permit their use in free
-software.</p>
-
-<!-- END OF TERMS AND CONDITIONS -->
-
-</div>
-</div>
-
-</div><!-- for id="content", starts in the include above -->
-
-              <!-- begin server/footer-text.html -->
-
-
-
-
-
-<div style="clear:both"></div>
-
-
-<div id="language-container">
- <div class="backtotop">
-  <hr class="no-display" />
-  <a href="#top"><b>&#9650;</b></a>
- </div>
- <div id="languages" class="rounded-corners">
-  <div class="button">
-   <a href="#top" class="close"><span>BACK TO TOP</span></a>
-  </div>
-  <div id="set-language" class="button">
-   <span class="gnun-split"></span>
-   <a href="/server/select-language.html?callback=/licenses/old-licenses/fdl-1.1" rel="nofollow">
-   Set language
-   <span class="gnun-split"></span>
-   </a>
-  </div>
-  <p>Available for this page:</p>
-  <div id="translations">
-<p>
-<span dir="ltr" class="original">[en]&nbsp;<a lang="en" hreflang="en" href="/licenses/old-licenses/fdl-1.1.en.html">English</a> &nbsp;</span>
-<span dir="ltr">[de]&nbsp;<a lang="de" hreflang="de" href="/licenses/old-licenses/fdl-1.1.de.html">Deutsch</a> &nbsp;</span>
-<span dir="ltr">[fr]&nbsp;<a lang="fr" hreflang="fr" href="/licenses/old-licenses/fdl-1.1.fr.html">français</a> &nbsp;</span>
-<span dir="ltr">[ja]&nbsp;<a lang="ja" hreflang="ja" href="/licenses/old-licenses/fdl-1.1.ja.html">日本語</a> &nbsp;</span>
-<span dir="ltr">[pt-br]&nbsp;<a lang="pt-br" hreflang="pt-br" href="/licenses/old-licenses/fdl-1.1.pt-br.html">português</a> &nbsp;</span>
-<span dir="ltr">[ru]&nbsp;<a lang="ru" hreflang="ru" href="/licenses/old-licenses/fdl-1.1.ru.html">русский</a> &nbsp;</span>
-<span dir="ltr">[uk]&nbsp;<a lang="uk" hreflang="uk" href="/licenses/old-licenses/fdl-1.1.uk.html">українська</a> &nbsp;</span>
-<span dir="ltr">[zh-cn]&nbsp;<a lang="zh-cn" hreflang="zh-cn" href="/licenses/old-licenses/fdl-1.1.zh-cn.html">简体中文</a> &nbsp;</span>
-</p>
-</div>
- </div>
-</div>
-
-<div id="mission-statement" role="complementary">
- <div class="backtotop">
-  <hr class="no-display" />
-  <a href="#header"><span>BACK TO TOP </span>&#9650;</a>
- </div>
-<div style="clear: both"></div>
-<blockquote>
-<p style="direction:ltr; text-align:left"><a href="//www.fsf.org"><img id="fsfbanner"
-src="/graphics/fsf-logo-notext-small.png" alt="&nbsp;[FSF logo]&nbsp;"
-width="75" height="25" /></a><strong>
-&ldquo;The Free Software Foundation (FSF) is a nonprofit with a worldwide
-mission to promote computer user freedom. We defend the rights of all
-software users.&rdquo;</strong></p>
-</blockquote>
-
-<div id="support-the-fsf" class="button">
- <a class="join" href="//www.fsf.org/associate/support_freedom?referrer=4052">JOIN</a>
- <a class="donate" href="//donate.fsf.org/">DONATE</a>
- <a class="shop" href="//shop.fsf.org/">SHOP</a>
-</div>
-</div>
-<!-- end server/footer-text.html -->
-
-
-<div id="footer" role="contentinfo">
-<div class="unprintable">
-
-<p>Please send general FSF &amp; GNU inquiries to
-<a href="mailto:gnu@gnu.org">&lt;gnu@gnu.org&gt;</a>.
-There are also <a href="/contact/">other ways to contact</a>
-the FSF.  Broken links and other corrections or suggestions can be sent
-to <a href="mailto:webmasters@gnu.org">&lt;webmasters@gnu.org&gt;</a>.</p>
-
-<p><!-- TRANSLATORS: Ignore the original text in this paragraph,
-        replace it with the translation of these two:
-
-        We work hard and do our best to provide accurate, good quality
-        translations.  However, we are not exempt from imperfection.
-        Please send your comments and general suggestions in this regard
-        to <a href="mailto:web-translators@gnu.org">
-        &lt;web-translators@gnu.org&gt;</a>.</p>
-
-        <p>For information on coordinating and contributing translations of
-        our web pages, see <a
-        href="/server/standards/README.translations.html">Translations
-        README</a>. -->
-Please see the <a
-href="/server/standards/README.translations.html">Translations
-README</a> for information on coordinating and contributing translations
-of this article.</p>
-</div>
-
-<p>Copyright notice above.</p>
-
-<!-- start of server/bottom-notes.html -->
-<div id="bottom-notes" class="unprintable">
-<p><a href="//www.fsf.org/about/dmca-notice">Copyright Infringement Notification</a></p>
-<div id="generic">
-
-
-</div>
-</div>
-<!-- end of server/bottom-notes.html -->
-
-
-<p class="unprintable">Updated:
-<!-- timestamp start -->
-$Date: 2023/11/30 09:46:01 $
-<!-- timestamp end --></p>
-</div>
-</div><!-- for class="inner", starts in the banner include -->
-</body>
-</html>
+If your document contains nontrivial examples of program code, we
+recommend releasing these examples in parallel under your choice of
+free software license, such as the GNU General Public License,
+to permit their use in free software.

--- a/licenses-generator/src/main/resources/offline-license-mirror/www.gnu.org/licenses/fdl-1.2
+++ b/licenses-generator/src/main/resources/offline-license-mirror/www.gnu.org/licenses/fdl-1.2
@@ -1,821 +1,397 @@
-<!DOCTYPE html>
-<html xmlns="http://www.w3.org/1999/xhtml" xml:lang="en" lang="en">
-<head>
-<meta http-equiv="content-type" content="text/html; charset=utf-8" />
-<link rel="author" href="mailto:webmasters@gnu.org" />
-<link rel="icon" type="image/png" href="/graphics/gnu-head-mini.png" />
-<meta name="ICBM" content="42.355469,-71.058627" />
-<link rel="stylesheet" type="text/css" href="/layout.min.css" media="screen" />
-<link rel="stylesheet" type="text/css" href="/print.min.css" media="print" />
-
-
-
-<!-- Parent-Version: 1.98 -->
-<!-- This page is derived from /server/standards/boilerplate.html -->
-<title>GNU Free Documentation License 1.2
-- GNU Project - Free Software Foundation</title>
-<!-- begin translist file -->
-
-<link rel="alternate" type="text/html" href="/licenses/old-licenses/fdl-1.2.html" hreflang="x-default" />
-<link rel="alternate" type="text/html" lang="en" hreflang="en" href="/licenses/old-licenses/fdl-1.2.en.html" title="English" />
-<link rel="alternate" type="text/html" lang="de" hreflang="de" href="/licenses/old-licenses/fdl-1.2.de.html" title="Deutsch" />
-<link rel="alternate" type="text/html" lang="fr" hreflang="fr" href="/licenses/old-licenses/fdl-1.2.fr.html" title="français" />
-<link rel="alternate" type="text/html" lang="ja" hreflang="ja" href="/licenses/old-licenses/fdl-1.2.ja.html" title="日本語" />
-<link rel="alternate" type="text/html" lang="pt-br" hreflang="pt-br" href="/licenses/old-licenses/fdl-1.2.pt-br.html" title="português" />
-<link rel="alternate" type="text/html" lang="ru" hreflang="ru" href="/licenses/old-licenses/fdl-1.2.ru.html" title="русский" />
-<link rel="alternate" type="text/html" lang="uk" hreflang="uk" href="/licenses/old-licenses/fdl-1.2.uk.html" title="українська" />
-<link rel="alternate" type="text/html" lang="zh-cn" hreflang="zh-cn" href="/licenses/old-licenses/fdl-1.2.zh-cn.html" title="简体中文" />
-<!-- end translist file -->
-
-<!-- start of server/banner.html -->
-<!-- start of head-include-2.html -->
-<meta name="viewport" content="width=device-width, initial-scale=1" />
-<!-- end of head-include-2.html -->
-
-</head>
-<body>
-<div class="inner">
-<!-- start of server/body-include-1.html -->
-<div id="top">
-<a class="skip" href="#content"><b>Skip to main text</b></a>
-</div>
-
-<div id="fsf-frame" role="complementary">
-<form id="fssbox" action="https://my.fsf.org/civicrm/profile/create?reset=1&amp;gid=31"
-      method="post">
- <div>
-  <input name="postURL" type="hidden" value="" />
-  <input type="hidden" name="group[25]" value="1" />
-  <input name="cancelURL" type="hidden" value="https://crm.fsf.org/civicrm/profile?reset=1&amp;gid=31" />
-  <input name="_qf_default" type="hidden" value="Edit:cancel" />
-  <label for="frmEmail">
-   <a href="//www.fsf.org/fss">Free Software Supporter</a>:
-  </label>
-  <input type="text" id="frmEmail" name="email-Primary" size="18" maxlength="80"
-         value="email address" onfocus="this.value=''"/>
-  <input type="submit" name="_qf_Edit_next" value="Sign up" />
- </div>
-</form>
-
-<div id="join-fsf" class="button"><a
-href="https://www.fsf.org/associate/support_freedom?referrer=4052">JOIN&nbsp;THE&nbsp;FSF</a>
-</div>
-</div>
-
-<div id="header" role="banner">
-<p id="gnu-banner">
- <a href="/">
- <img src="/graphics/heckert_gnu.transp.small.png" height="48" width="49"
-      alt="&nbsp;[A GNU head]&nbsp;" /><strong>GNU</strong> <span
- class="hide">Operating System</span></a><br />
- <small id="fsf-support">Supported by the
- <a href="#mission-statement">Free Software Foundation</a></small>
-</p>
-
-<div id="switches">
-<!-- begin search button -->
- <div  id="search-button" class="switch">
-  <a href="//www.gnu.org/cgi-bin/estseek.cgi">
-  <img id="search-icon" height="30" width="30"
-       src="/graphics/icons/search.png"
-       alt="&nbsp;[Search www.gnu.org]&nbsp;" /></a>
- </div>
-<!-- end search button -->
-
- <div id="language-button" class="switch">
-  <a href="#language-container">
-  <img id="language-icon" height="30" width="37"
-       src="/graphics/icons/translations.png"
-       alt="&nbsp;[Other languages]&nbsp;" /></a>
- </div>
-
-</div>
-</div>
-<!-- end of server/body-include-1.html -->
-
-<!-- start of server/body-include-2 -->
-
-
-<div style="clear: both"></div>
-
-<div id="navigation" role="navigation">
- <a id="more-links" href="#navigation" title="More...">
-   <span>Site navigation</span></a>
- <a id="less-links" href="#content"><b>Skip</b></a>
- <ul>
-
-   <li id="tabAboutGNU"><a href="/gnu/gnu.html">ABOUT&nbsp;GNU</a></li>
-
-
-  <li id="tabPhilosophy"><a href="/philosophy/philosophy.html">PHILOSOPHY</a></li>
-
-
-  <li id="tabLicenses" class="active">
-     <span class='no-display'>=</span> 
-    <a href="/licenses/licenses.html">LICENSES</a>
-    <span class="gnun-split"></span>
-     <span class='no-display'>=</span> 
-  </li>
-
-
-  <li id="tabEducation"><a href="/education/education.html">EDUCATION</a></li>
-
-
-  <li id="tabSoftware"><a href="/software/software.html">SOFTWARE</a></li>
-
-
-  <li id="tabDistros"><a href="/distros/distros.html">DISTROS</a></li>
-
-
-  <li id="tabDoc"><a href="/doc/doc.html">DOCS</a></li>
-
-
-  <li id="tabMalware"><a href="/proprietary/proprietary.html">MALWARE</a></li>
-
-
-  <li id="tabHelp"><a href="/help/help.html">HELP&nbsp;GNU</a></li>
-
-
-  <li id="tabAV"><a href="/audio-video/audio-video.html">AUDIO&nbsp;&amp;&nbsp;VIDEO</a></li>
-
-
-  <li id="tabArt"><a href="/graphics/graphics.html">GNU&nbsp;ART</a></li>
-
-
-  <li id="tabFun"><a href="/fun/humor.html">FUN</a></li>
-
-
-  <li id="tabPeople"><a href="/people/people.html">GNU'S&nbsp;WHO?</a></li>
-
-  <li><a href="//directory.fsf.org">SOFTWARE&nbsp;DIRECTORY</a></li>
-  <li><a href="https://h-node.org/">HARDWARE</a></li>
-  <li><a href="/server/sitemap.html">SITEMAP</a></li>
- </ul>
- <div style="clear: both"></div>
-</div><!-- /"navigation -->
-<!-- end of server/body-include-2 -->
-
-<div id="content" role="main">
-<!-- end of server/banner.html -->
-
-<div class="reduced-width">
-<h2>GNU Free Documentation License&nbsp;1.2</h2>
-
-<p class="button" style="margin: 2em 1.5em">
-  <b><a href="#SEC1">Skip to license text</a></b></p>
-
-<h3>Related Pages</h3>
-<ul>
-  <li><a href="/licenses/fdl.html">The latest version of the FDL,
-      version 1.3</a></li>
-  <li><a href="/philosophy/free-doc.html">Free software and free
-      documentation</a></li>
-  <li><a href="/licenses/gpl-violation.html">What to do if you see a
-      possible GFDL violation</a></li>
-  <li><a href="/licenses/why-gfdl.html">Why publishers should use the
-      GNU Free Documentation License</a></li>
-  <li><a href="/licenses/fdl-howto.html">Tips on how to use the FDL</a></li>
-  <li><a href="/licenses/fdl-howto-opt.html">Using the optional features
-      of the GFDL</a></li>
-  <li><a href="/licenses/old-licenses/fdl-1.2-translations.html">Translations
-      of GFDLv1.2</a></li>
-  <li>The GNU Free Documentation License version 1.2 (GFDLv1.2) in other
-      formats:
-      <a href="/licenses/old-licenses/fdl-1.2.txt">plain text</a>,
-      <a href="/licenses/old-licenses/fdl-1.2.texi">Texinfo</a>,
-      <a href="/licenses/old-licenses/fdl-1.2.tex">LaTeX</a>,
-  <a href="/licenses/old-licenses/fdl-1.2-standalone.html">standalone HTML</a>,
-      <a href="/licenses/old-licenses/fdl-1.2.xml">Docbook</a>, 
-      <a href="/licenses/old-licenses/fdl-1.2.md">Markdown</a>, 
-      <a href="/licenses/old-licenses/fdl-1.2.odt">ODF</a>, 
-      <a href="/licenses/old-licenses/fdl-1.2.rtf">RTF</a>
-  </li>
-  <li><a href="/licenses/old-licenses/old-licenses.html#FDL">Old versions
-      of the GFDL</a></li>
-</ul>
-
-<p><i>Differences between versions 1.1 and 1.2 of the
-  GNU Free Documentation License:</i>
-</p>
-<ul>
-  <li><a href="/licenses/fdl-1.2-diff.txt">Plain context diff</a></li>
-  <li><a href="/licenses/fdl-1.2-wdiff.txt">Word diff</a></li>
-  <li><a href="/licenses/fdl-1.2-pdiff.ps">Word diff in
-      PostScript format</a></li>
-</ul>
-
-<hr class="thin" />
-
-<h3>Table of Contents</h3>
-
-<ul>
-  <li><a id="TOC1" href="#SEC1">Current version of the GNU Free Documentation License</a></li>
-  <li><a id="TOC4" href="#SEC4">How to use this License for your documents</a></li>
-</ul>
-
-<hr class="thin" />
-
-<!-- The license text is in English and appears broken in RTL as
-     Arabic, Farsi, etc.  Explicitly set the direction to override the
-     one defined in the translation. -->
-<div dir="ltr">
-<h3 id="SEC1">GNU Free Documentation License</h3>
-<p>
-  Version 1.2, November 2002
-</p>
-
-<pre>
-  Copyright (C) 2000,2001,2002  Free Software Foundation, Inc.
-  &lt;<a href="https://www.fsf.org">https://www.fsf.org/</a>&gt;
-  Everyone is permitted to copy and distribute verbatim copies
-  of this license document, but changing it is not allowed.
-</pre>
-
-<h4 id="section0">0. PREAMBLE</h4>
-
-<p>
-  The purpose of this License is to make a manual, textbook, or other
-  functional and useful document "free" in the sense of freedom: to
-  assure everyone the effective freedom to copy and redistribute it,
-  with or without modifying it, either commercially or noncommercially.
-  Secondarily, this License preserves for the author and publisher a way
-  to get credit for their work, while not being considered responsible
-  for modifications made by others.
-</p>
-
-<p>
-  This License is a kind of "copyleft", which means that derivative
-  works of the document must themselves be free in the same sense.  It
-  complements the GNU General Public License, which is a copyleft
-  license designed for free software.
-</p>
-
-<p>
-  We have designed this License in order to use it for manuals for free
-  software, because free software needs free documentation: a free
-  program should come with manuals providing the same freedoms that the
-  software does.  But this License is not limited to software manuals;
-  it can be used for any textual work, regardless of subject matter or
-  whether it is published as a printed book.  We recommend this License
-  principally for works whose purpose is instruction or reference.
-</p>
-
-<h4 id="section1">1. APPLICABILITY AND DEFINITIONS</h4>
-
-<p>
-  This License applies to any manual or other work, in any medium, that
-  contains a notice placed by the copyright holder saying it can be
-  distributed under the terms of this License.  Such a notice grants a
-  world-wide, royalty-free license, unlimited in duration, to use that
-  work under the conditions stated herein.  The "Document", below,
-  refers to any such manual or work.  Any member of the public is a
-  licensee, and is addressed as "you".  You accept the license if you
-  copy, modify or distribute the work in a way requiring permission
-  under copyright law.
-</p>
-
-<p>
-  A "Modified Version" of the Document means any work containing the
-  Document or a portion of it, either copied verbatim, or with
-  modifications and/or translated into another language.
-</p>
-
-<p>
-  A "Secondary Section" is a named appendix or a front-matter section of
-  the Document that deals exclusively with the relationship of the
-  publishers or authors of the Document to the Document's overall subject
-  (or to related matters) and contains nothing that could fall directly
-  within that overall subject.  (Thus, if the Document is in part a
-  textbook of mathematics, a Secondary Section may not explain any
-  mathematics.)  The relationship could be a matter of historical
-  connection with the subject or with related matters, or of legal,
-  commercial, philosophical, ethical or political position regarding
-  them.
-</p>
-
-<p>
-  The "Invariant Sections" are certain Secondary Sections whose titles
-  are designated, as being those of Invariant Sections, in the notice
-  that says that the Document is released under this License.  If a
-  section does not fit the above definition of Secondary then it is not
-  allowed to be designated as Invariant.  The Document may contain zero
-  Invariant Sections.  If the Document does not identify any Invariant
-  Sections then there are none.
-</p>
-
-<p>
-  The "Cover Texts" are certain short passages of text that are listed,
-  as Front-Cover Texts or Back-Cover Texts, in the notice that says that
-  the Document is released under this License.  A Front-Cover Text may
-  be at most 5 words, and a Back-Cover Text may be at most 25 words.
-</p>
-
-<p>
-  A "Transparent" copy of the Document means a machine-readable copy,
-  represented in a format whose specification is available to the
-  general public, that is suitable for revising the document
-  straightforwardly with generic text editors or (for images composed of
-  pixels) generic paint programs or (for drawings) some widely available
-  drawing editor, and that is suitable for input to text formatters or
-  for automatic translation to a variety of formats suitable for input
-  to text formatters.  A copy made in an otherwise Transparent file
-  format whose markup, or absence of markup, has been arranged to thwart
-  or discourage subsequent modification by readers is not Transparent.
-  An image format is not Transparent if used for any substantial amount
-  of text.  A copy that is not "Transparent" is called "Opaque".
-</p>
-
-<p>
-  Examples of suitable formats for Transparent copies include plain
-  ASCII without markup, Texinfo input format, LaTeX input format, SGML
-  or XML using a publicly available DTD, and standard-conforming simple
-  HTML, PostScript or PDF designed for human modification.  Examples of
-  transparent image formats include PNG, XCF and JPG.  Opaque formats
-  include proprietary formats that can be read and edited only by
-  proprietary word processors, SGML or XML for which the DTD and/or
-  processing tools are not generally available, and the
-  machine-generated HTML, PostScript or PDF produced by some word
-  processors for output purposes only.
-</p>
-
-<p>
-  The "Title Page" means, for a printed book, the title page itself,
-  plus such following pages as are needed to hold, legibly, the material
-  this License requires to appear in the title page.  For works in
-  formats which do not have any title page as such, "Title Page" means
-  the text near the most prominent appearance of the work's title,
-  preceding the beginning of the body of the text.
-</p>
-
-<p>
-  A section "Entitled XYZ" means a named subunit of the Document whose
-  title either is precisely XYZ or contains XYZ in parentheses following
-  text that translates XYZ in another language.  (Here XYZ stands for a
-  specific section name mentioned below, such as "Acknowledgements",
-  "Dedications", "Endorsements", or "History".)  To "Preserve the Title"
-  of such a section when you modify the Document means that it remains a
-  section "Entitled XYZ" according to this definition.
-</p>
-
-<p>
-  The Document may include Warranty Disclaimers next to the notice which
-  states that this License applies to the Document.  These Warranty
-  Disclaimers are considered to be included by reference in this
-  License, but only as regards disclaiming warranties: any other
-  implication that these Warranty Disclaimers may have is void and has
-  no effect on the meaning of this License.
-</p>
-
-<h4 id="section2">2. VERBATIM COPYING</h4>
-
-<p>
-  You may copy and distribute the Document in any medium, either
-  commercially or noncommercially, provided that this License, the
-  copyright notices, and the license notice saying this License applies
-  to the Document are reproduced in all copies, and that you add no other
-  conditions whatsoever to those of this License.  You may not use
-  technical measures to obstruct or control the reading or further
-  copying of the copies you make or distribute.  However, you may accept
-  compensation in exchange for copies.  If you distribute a large enough
-  number of copies you must also follow the conditions in section 3.
-</p>
-
-<p>
-  You may also lend copies, under the same conditions stated above, and
-  you may publicly display copies.
-</p>
-
-<h4 id="section3">3. COPYING IN QUANTITY</h4>
-
-<p>
-  If you publish printed copies (or copies in media that commonly have
-  printed covers) of the Document, numbering more than 100, and the
-  Document's license notice requires Cover Texts, you must enclose the
-  copies in covers that carry, clearly and legibly, all these Cover
-  Texts: Front-Cover Texts on the front cover, and Back-Cover Texts on
-  the back cover.  Both covers must also clearly and legibly identify
-  you as the publisher of these copies.  The front cover must present
-  the full title with all words of the title equally prominent and
-  visible.  You may add other material on the covers in addition.
-  Copying with changes limited to the covers, as long as they preserve
-  the title of the Document and satisfy these conditions, can be treated
-  as verbatim copying in other respects.
-</p>
-
-<p>
-  If the required texts for either cover are too voluminous to fit
-  legibly, you should put the first ones listed (as many as fit
-  reasonably) on the actual cover, and continue the rest onto adjacent
-  pages.
-</p>
-
-<p>
-  If you publish or distribute Opaque copies of the Document numbering
-  more than 100, you must either include a machine-readable Transparent
-  copy along with each Opaque copy, or state in or with each Opaque copy
-  a computer-network location from which the general network-using
-  public has access to download using public-standard network protocols
-  a complete Transparent copy of the Document, free of added material.
-  If you use the latter option, you must take reasonably prudent steps,
-  when you begin distribution of Opaque copies in quantity, to ensure
-  that this Transparent copy will remain thus accessible at the stated
-  location until at least one year after the last time you distribute an
-  Opaque copy (directly or through your agents or retailers) of that
-  edition to the public.
-</p>
-
-<p>
-  It is requested, but not required, that you contact the authors of the
-  Document well before redistributing any large number of copies, to give
-  them a chance to provide you with an updated version of the Document.
-</p>
-
-<h4 id="section4">4. MODIFICATIONS</h4>
-
-<p>
-  You may copy and distribute a Modified Version of the Document under
-  the conditions of sections 2 and 3 above, provided that you release
-  the Modified Version under precisely this License, with the Modified
-  Version filling the role of the Document, thus licensing distribution
-  and modification of the Modified Version to whoever possesses a copy
-  of it.  In addition, you must do these things in the Modified Version:
-</p>
-
-<ul>
-  <li><strong>A.</strong> Use in the Title Page (and on the covers, if any) a title distinct
-  from that of the Document, and from those of previous versions
-  (which should, if there were any, be listed in the History section
-  of the Document).  You may use the same title as a previous version
-  if the original publisher of that version gives permission.</li>
-  <li><strong>B.</strong> List on the Title Page, as authors, one or more persons or entities
-  responsible for authorship of the modifications in the Modified
-  Version, together with at least five of the principal authors of the
-  Document (all of its principal authors, if it has fewer than five),
-  unless they release you from this requirement.</li>
-  <li><strong>C.</strong> State on the Title page the name of the publisher of the
-  Modified Version, as the publisher.</li>
-  <li><strong>D.</strong> Preserve all the copyright notices of the Document.</li>
-  <li><strong>E.</strong> Add an appropriate copyright notice for your modifications
-  adjacent to the other copyright notices.</li>
-  <li><strong>F.</strong> Include, immediately after the copyright notices, a license notice
-  giving the public permission to use the Modified Version under the
-  terms of this License, in the form shown in the Addendum below.</li>
-  <li><strong>G.</strong> Preserve in that license notice the full lists of Invariant Sections
-  and required Cover Texts given in the Document's license notice.</li>
-  <li><strong>H.</strong> Include an unaltered copy of this License.</li>
-  <li><strong>I.</strong> Preserve the section Entitled "History", Preserve its Title, and add
-  to it an item stating at least the title, year, new authors, and
-  publisher of the Modified Version as given on the Title Page.  If
-  there is no section Entitled "History" in the Document, create one
-  stating the title, year, authors, and publisher of the Document as
-  given on its Title Page, then add an item describing the Modified
-  Version as stated in the previous sentence.</li>
-  <li><strong>J.</strong> Preserve the network location, if any, given in the Document for
-  public access to a Transparent copy of the Document, and likewise
-  the network locations given in the Document for previous versions
-  it was based on.  These may be placed in the "History" section.
-  You may omit a network location for a work that was published at
-  least four years before the Document itself, or if the original
-  publisher of the version it refers to gives permission.</li>
-  <li><strong>K.</strong> For any section Entitled "Acknowledgements" or "Dedications",
-  Preserve the Title of the section, and preserve in the section all
-  the substance and tone of each of the contributor acknowledgements
-  and/or dedications given therein.</li>
-  <li><strong>L.</strong> Preserve all the Invariant Sections of the Document,
-  unaltered in their text and in their titles.  Section numbers
-  or the equivalent are not considered part of the section titles.</li>
-  <li><strong>M.</strong> Delete any section Entitled "Endorsements".  Such a section
-  may not be included in the Modified Version.</li>
-  <li><strong>N.</strong> Do not retitle any existing section to be Entitled "Endorsements"
-  or to conflict in title with any Invariant Section.</li>
-  <li><strong>O.</strong> Preserve any Warranty Disclaimers.</li>
-</ul>
-
-<p>
-  If the Modified Version includes new front-matter sections or
-  appendices that qualify as Secondary Sections and contain no material
-  copied from the Document, you may at your option designate some or all
-  of these sections as invariant.  To do this, add their titles to the
-  list of Invariant Sections in the Modified Version's license notice.
-  These titles must be distinct from any other section titles.
-</p>
-
-<p>
-  You may add a section Entitled "Endorsements", provided it contains
-  nothing but endorsements of your Modified Version by various
-  parties--for example, statements of peer review or that the text has
-  been approved by an organization as the authoritative definition of a
-  standard.
-</p>
-
-<p>
-  You may add a passage of up to five words as a Front-Cover Text, and a
-  passage of up to 25 words as a Back-Cover Text, to the end of the list
-  of Cover Texts in the Modified Version.  Only one passage of
-  Front-Cover Text and one of Back-Cover Text may be added by (or
-  through arrangements made by) any one entity.  If the Document already
-  includes a cover text for the same cover, previously added by you or
-  by arrangement made by the same entity you are acting on behalf of,
-  you may not add another; but you may replace the old one, on explicit
-  permission from the previous publisher that added the old one.
-</p>
-
-<p>
-  The author(s) and publisher(s) of the Document do not by this License
-  give permission to use their names for publicity for or to assert or
-  imply endorsement of any Modified Version.
-</p>
-
-<h4 id="section5">5. COMBINING DOCUMENTS</h4>
-
-<p>
-  You may combine the Document with other documents released under this
-  License, under the terms defined in section 4 above for modified
-  versions, provided that you include in the combination all of the
-  Invariant Sections of all of the original documents, unmodified, and
-  list them all as Invariant Sections of your combined work in its
-  license notice, and that you preserve all their Warranty Disclaimers.
-</p>
-
-<p>
-  The combined work need only contain one copy of this License, and
-  multiple identical Invariant Sections may be replaced with a single
-  copy.  If there are multiple Invariant Sections with the same name but
-  different contents, make the title of each such section unique by
-  adding at the end of it, in parentheses, the name of the original
-  author or publisher of that section if known, or else a unique number.
-  Make the same adjustment to the section titles in the list of
-  Invariant Sections in the license notice of the combined work.
-</p>
-
-<p>
-  In the combination, you must combine any sections Entitled "History"
-  in the various original documents, forming one section Entitled
-  "History"; likewise combine any sections Entitled "Acknowledgements",
-  and any sections Entitled "Dedications".  You must delete all sections
-  Entitled "Endorsements."
-</p>
-
-<h4 id="section6">6. COLLECTIONS OF DOCUMENTS</h4>
-
-<p>
-  You may make a collection consisting of the Document and other documents
-  released under this License, and replace the individual copies of this
-  License in the various documents with a single copy that is included in
-  the collection, provided that you follow the rules of this License for
-  verbatim copying of each of the documents in all other respects.
-</p>
-
-<p>
-  You may extract a single document from such a collection, and distribute
-  it individually under this License, provided you insert a copy of this
-  License into the extracted document, and follow this License in all
-  other respects regarding verbatim copying of that document.
-</p>
-
-<h4 id="section7">7. AGGREGATION WITH INDEPENDENT WORKS</h4>
-
-<p>
-  A compilation of the Document or its derivatives with other separate
-  and independent documents or works, in or on a volume of a storage or
-  distribution medium, is called an "aggregate" if the copyright
-  resulting from the compilation is not used to limit the legal rights
-  of the compilation's users beyond what the individual works permit.
-  When the Document is included in an aggregate, this License does not
-  apply to the other works in the aggregate which are not themselves
-  derivative works of the Document.
-</p>
-
-<p>
-  If the Cover Text requirement of section 3 is applicable to these
-  copies of the Document, then if the Document is less than one half of
-  the entire aggregate, the Document's Cover Texts may be placed on
-  covers that bracket the Document within the aggregate, or the
-  electronic equivalent of covers if the Document is in electronic form.
-  Otherwise they must appear on printed covers that bracket the whole
-  aggregate.
-</p>
-
-<h4 id="section8">8. TRANSLATION</h4>
-
-<p>
-  Translation is considered a kind of modification, so you may
-  distribute translations of the Document under the terms of section 4.
-  Replacing Invariant Sections with translations requires special
-  permission from their copyright holders, but you may include
-  translations of some or all Invariant Sections in addition to the
-  original versions of these Invariant Sections.  You may include a
-  translation of this License, and all the license notices in the
-  Document, and any Warranty Disclaimers, provided that you also include
-  the original English version of this License and the original versions
-  of those notices and disclaimers.  In case of a disagreement between
-  the translation and the original version of this License or a notice
-  or disclaimer, the original version will prevail.
-</p>
-
-<p>
-  If a section in the Document is Entitled "Acknowledgements",
-  "Dedications", or "History", the requirement (section 4) to Preserve
-  its Title (section 1) will typically require changing the actual
-  title.
-</p>
-
-<h4 id="section9">9. TERMINATION</h4>
-
-<p>
-  You may not copy, modify, sublicense, or distribute the Document except
-  as expressly provided for under this License.  Any other attempt to
-  copy, modify, sublicense or distribute the Document is void, and will
-  automatically terminate your rights under this License.  However,
-  parties who have received copies, or rights, from you under this
-  License will not have their licenses terminated so long as such
-  parties remain in full compliance.
-</p>
-
-<h4 id="section10">10. FUTURE REVISIONS OF THIS LICENSE</h4>
-
-<p>
-  The Free Software Foundation may publish new, revised versions
-  of the GNU Free Documentation License from time to time.  Such new
-  versions will be similar in spirit to the present version, but may
-  differ in detail to address new problems or concerns.  See
-  https://www.gnu.org/licenses/.
-</p>
-
-<p>
-  Each version of the License is given a distinguishing version number.
-  If the Document specifies that a particular numbered version of this
-  License "or any later version" applies to it, you have the option of
-  following the terms and conditions either of that specified version or
-  of any later version that has been published (not as a draft) by the
-  Free Software Foundation.  If the Document does not specify a version
-  number of this License, you may choose any version ever published (not
-  as a draft) by the Free Software Foundation.
-</p>
-
-<h4 id="SEC4">How to use this License for your documents</h4>
-
-<p>
-  To use this License in a document you have written, include a copy of
-  the License in the document and put the following copyright and
-  license notices just after the title page:
-</p>
-
-<pre>
-  Copyright (c)  YEAR  YOUR NAME.
-  Permission is granted to copy, distribute and/or modify this document
-  under the terms of the GNU Free Documentation License, Version 1.2
-  or any later version published by the Free Software Foundation;
-  with no Invariant Sections, no Front-Cover Texts, and no Back-Cover
-  Texts.  A copy of the license is included in the section entitled "GNU
-  Free Documentation License".
-</pre>
-
-<p>
-  If you have Invariant Sections, Front-Cover Texts and Back-Cover Texts,
-  replace the "with...Texts." line with this:
-</p>
-
-<pre>
-  with the Invariant Sections being LIST THEIR TITLES, with the
-  Front-Cover Texts being LIST, and with the Back-Cover Texts being LIST.
-</pre>
-
-<p>
-  If you have Invariant Sections without Cover Texts, or some other
-  combination of the three, merge those two alternatives to suit the
-  situation.
-</p>
-
-<p>
-  If your document contains nontrivial examples of program code, we
-  recommend releasing these examples in parallel under your choice of
-  free software license, such as the GNU General Public License,
-  to permit their use in free software.
-</p>
-
-</div>
-</div>
-
-</div><!-- for id="content", starts in the include above -->
-
-              <!-- begin server/footer-text.html -->
-
-
-
-
-
-<div style="clear:both"></div>
-
-
-<div id="language-container">
- <div class="backtotop">
-  <hr class="no-display" />
-  <a href="#top"><b>&#9650;</b></a>
- </div>
- <div id="languages" class="rounded-corners">
-  <div class="button">
-   <a href="#top" class="close"><span>BACK TO TOP</span></a>
-  </div>
-  <div id="set-language" class="button">
-   <span class="gnun-split"></span>
-   <a href="/server/select-language.html?callback=/licenses/old-licenses/fdl-1.2" rel="nofollow">
-   Set language
-   <span class="gnun-split"></span>
-   </a>
-  </div>
-  <p>Available for this page:</p>
-  <div id="translations">
-<p>
-<span dir="ltr" class="original">[en]&nbsp;<a lang="en" hreflang="en" href="/licenses/old-licenses/fdl-1.2.en.html">English</a> &nbsp;</span>
-<span dir="ltr">[de]&nbsp;<a lang="de" hreflang="de" href="/licenses/old-licenses/fdl-1.2.de.html">Deutsch</a> &nbsp;</span>
-<span dir="ltr">[fr]&nbsp;<a lang="fr" hreflang="fr" href="/licenses/old-licenses/fdl-1.2.fr.html">français</a> &nbsp;</span>
-<span dir="ltr">[ja]&nbsp;<a lang="ja" hreflang="ja" href="/licenses/old-licenses/fdl-1.2.ja.html">日本語</a> &nbsp;</span>
-<span dir="ltr">[pt-br]&nbsp;<a lang="pt-br" hreflang="pt-br" href="/licenses/old-licenses/fdl-1.2.pt-br.html">português</a> &nbsp;</span>
-<span dir="ltr">[ru]&nbsp;<a lang="ru" hreflang="ru" href="/licenses/old-licenses/fdl-1.2.ru.html">русский</a> &nbsp;</span>
-<span dir="ltr">[uk]&nbsp;<a lang="uk" hreflang="uk" href="/licenses/old-licenses/fdl-1.2.uk.html">українська</a> &nbsp;</span>
-<span dir="ltr">[zh-cn]&nbsp;<a lang="zh-cn" hreflang="zh-cn" href="/licenses/old-licenses/fdl-1.2.zh-cn.html">简体中文</a> &nbsp;</span>
-</p>
-</div>
- </div>
-</div>
-
-<div id="mission-statement" role="complementary">
- <div class="backtotop">
-  <hr class="no-display" />
-  <a href="#header"><span>BACK TO TOP </span>&#9650;</a>
- </div>
-<div style="clear: both"></div>
-<blockquote>
-<p style="direction:ltr; text-align:left"><a href="//www.fsf.org"><img id="fsfbanner"
-src="/graphics/fsf-logo-notext-small.png" alt="&nbsp;[FSF logo]&nbsp;"
-width="75" height="25" /></a><strong>
-&ldquo;The Free Software Foundation (FSF) is a nonprofit with a worldwide
-mission to promote computer user freedom. We defend the rights of all
-software users.&rdquo;</strong></p>
-</blockquote>
-
-<div id="support-the-fsf" class="button">
- <a class="join" href="//www.fsf.org/associate/support_freedom?referrer=4052">JOIN</a>
- <a class="donate" href="//donate.fsf.org/">DONATE</a>
- <a class="shop" href="//shop.fsf.org/">SHOP</a>
-</div>
-</div>
-<!-- end server/footer-text.html -->
-
-
-<div id="footer" role="contentinfo">
-<div class="unprintable">
-
-<p>Please send general FSF &amp; GNU inquiries to
-<a href="mailto:gnu@gnu.org">&lt;gnu@gnu.org&gt;</a>.
-There are also <a href="/contact/">other ways to contact</a>
-the FSF.  Broken links and other corrections or suggestions can be sent
-to <a href="mailto:webmasters@gnu.org">&lt;webmasters@gnu.org&gt;</a>.</p>
-
-<p><!-- TRANSLATORS: Ignore the original text in this paragraph,
-        replace it with the translation of these two:
-
-        We work hard and do our best to provide accurate, good quality
-        translations.  However, we are not exempt from imperfection.
-        Please send your comments and general suggestions in this regard
-        to <a href="mailto:web-translators@gnu.org">
-        &lt;web-translators@gnu.org&gt;</a>.</p>
-
-        <p>For information on coordinating and contributing translations of
-        our web pages, see <a
-        href="/server/standards/README.translations.html">Translations
-        README</a>. -->
-Please see the <a
-href="/server/standards/README.translations.html">Translations README</a> for
-information on coordinating and contributing translations of this article.</p>
-</div>
-
-<p>Copyright notice above.</p>
-
-<p>
-Verbatim copying and distribution of this entire article is
-permitted in any medium without royalty provided this notice is 
-preserved.
-</p>
-
-<!-- start of server/bottom-notes.html -->
-<div id="bottom-notes" class="unprintable">
-<p><a href="//www.fsf.org/about/dmca-notice">Copyright Infringement Notification</a></p>
-<div id="generic">
-
-
-</div>
-</div>
-<!-- end of server/bottom-notes.html -->
-
-
-<p class="unprintable">Updated:
-<!-- timestamp start -->
-$Date: 2023/11/30 09:46:01 $
-<!-- timestamp end -->
-</p>
-</div>
-</div><!-- for class="inner", starts in the banner include -->
-</body>
-</html>
+                GNU Free Documentation License
+                  Version 1.2, November 2002
+
+
+ Copyright (C) 2000,2001,2002  Free Software Foundation, Inc.
+     <https://fsf.org/>
+ Everyone is permitted to copy and distribute verbatim copies
+ of this license document, but changing it is not allowed.
+
+
+0. PREAMBLE
+
+The purpose of this License is to make a manual, textbook, or other
+functional and useful document "free" in the sense of freedom: to
+assure everyone the effective freedom to copy and redistribute it,
+with or without modifying it, either commercially or noncommercially.
+Secondarily, this License preserves for the author and publisher a way
+to get credit for their work, while not being considered responsible
+for modifications made by others.
+
+This License is a kind of "copyleft", which means that derivative
+works of the document must themselves be free in the same sense.  It
+complements the GNU General Public License, which is a copyleft
+license designed for free software.
+
+We have designed this License in order to use it for manuals for free
+software, because free software needs free documentation: a free
+program should come with manuals providing the same freedoms that the
+software does.  But this License is not limited to software manuals;
+it can be used for any textual work, regardless of subject matter or
+whether it is published as a printed book.  We recommend this License
+principally for works whose purpose is instruction or reference.
+
+
+1. APPLICABILITY AND DEFINITIONS
+
+This License applies to any manual or other work, in any medium, that
+contains a notice placed by the copyright holder saying it can be
+distributed under the terms of this License.  Such a notice grants a
+world-wide, royalty-free license, unlimited in duration, to use that
+work under the conditions stated herein.  The "Document", below,
+refers to any such manual or work.  Any member of the public is a
+licensee, and is addressed as "you".  You accept the license if you
+copy, modify or distribute the work in a way requiring permission
+under copyright law.
+
+A "Modified Version" of the Document means any work containing the
+Document or a portion of it, either copied verbatim, or with
+modifications and/or translated into another language.
+
+A "Secondary Section" is a named appendix or a front-matter section of
+the Document that deals exclusively with the relationship of the
+publishers or authors of the Document to the Document's overall subject
+(or to related matters) and contains nothing that could fall directly
+within that overall subject.  (Thus, if the Document is in part a
+textbook of mathematics, a Secondary Section may not explain any
+mathematics.)  The relationship could be a matter of historical
+connection with the subject or with related matters, or of legal,
+commercial, philosophical, ethical or political position regarding
+them.
+
+The "Invariant Sections" are certain Secondary Sections whose titles
+are designated, as being those of Invariant Sections, in the notice
+that says that the Document is released under this License.  If a
+section does not fit the above definition of Secondary then it is not
+allowed to be designated as Invariant.  The Document may contain zero
+Invariant Sections.  If the Document does not identify any Invariant
+Sections then there are none.
+
+The "Cover Texts" are certain short passages of text that are listed,
+as Front-Cover Texts or Back-Cover Texts, in the notice that says that
+the Document is released under this License.  A Front-Cover Text may
+be at most 5 words, and a Back-Cover Text may be at most 25 words.
+
+A "Transparent" copy of the Document means a machine-readable copy,
+represented in a format whose specification is available to the
+general public, that is suitable for revising the document
+straightforwardly with generic text editors or (for images composed of
+pixels) generic paint programs or (for drawings) some widely available
+drawing editor, and that is suitable for input to text formatters or
+for automatic translation to a variety of formats suitable for input
+to text formatters.  A copy made in an otherwise Transparent file
+format whose markup, or absence of markup, has been arranged to thwart
+or discourage subsequent modification by readers is not Transparent.
+An image format is not Transparent if used for any substantial amount
+of text.  A copy that is not "Transparent" is called "Opaque".
+
+Examples of suitable formats for Transparent copies include plain
+ASCII without markup, Texinfo input format, LaTeX input format, SGML
+or XML using a publicly available DTD, and standard-conforming simple
+HTML, PostScript or PDF designed for human modification.  Examples of
+transparent image formats include PNG, XCF and JPG.  Opaque formats
+include proprietary formats that can be read and edited only by
+proprietary word processors, SGML or XML for which the DTD and/or
+processing tools are not generally available, and the
+machine-generated HTML, PostScript or PDF produced by some word
+processors for output purposes only.
+
+The "Title Page" means, for a printed book, the title page itself,
+plus such following pages as are needed to hold, legibly, the material
+this License requires to appear in the title page.  For works in
+formats which do not have any title page as such, "Title Page" means
+the text near the most prominent appearance of the work's title,
+preceding the beginning of the body of the text.
+
+A section "Entitled XYZ" means a named subunit of the Document whose
+title either is precisely XYZ or contains XYZ in parentheses following
+text that translates XYZ in another language.  (Here XYZ stands for a
+specific section name mentioned below, such as "Acknowledgements",
+"Dedications", "Endorsements", or "History".)  To "Preserve the Title"
+of such a section when you modify the Document means that it remains a
+section "Entitled XYZ" according to this definition.
+
+The Document may include Warranty Disclaimers next to the notice which
+states that this License applies to the Document.  These Warranty
+Disclaimers are considered to be included by reference in this
+License, but only as regards disclaiming warranties: any other
+implication that these Warranty Disclaimers may have is void and has
+no effect on the meaning of this License.
+
+
+2. VERBATIM COPYING
+
+You may copy and distribute the Document in any medium, either
+commercially or noncommercially, provided that this License, the
+copyright notices, and the license notice saying this License applies
+to the Document are reproduced in all copies, and that you add no other
+conditions whatsoever to those of this License.  You may not use
+technical measures to obstruct or control the reading or further
+copying of the copies you make or distribute.  However, you may accept
+compensation in exchange for copies.  If you distribute a large enough
+number of copies you must also follow the conditions in section 3.
+
+You may also lend copies, under the same conditions stated above, and
+you may publicly display copies.
+
+
+3. COPYING IN QUANTITY
+
+If you publish printed copies (or copies in media that commonly have
+printed covers) of the Document, numbering more than 100, and the
+Document's license notice requires Cover Texts, you must enclose the
+copies in covers that carry, clearly and legibly, all these Cover
+Texts: Front-Cover Texts on the front cover, and Back-Cover Texts on
+the back cover.  Both covers must also clearly and legibly identify
+you as the publisher of these copies.  The front cover must present
+the full title with all words of the title equally prominent and
+visible.  You may add other material on the covers in addition.
+Copying with changes limited to the covers, as long as they preserve
+the title of the Document and satisfy these conditions, can be treated
+as verbatim copying in other respects.
+
+If the required texts for either cover are too voluminous to fit
+legibly, you should put the first ones listed (as many as fit
+reasonably) on the actual cover, and continue the rest onto adjacent
+pages.
+
+If you publish or distribute Opaque copies of the Document numbering
+more than 100, you must either include a machine-readable Transparent
+copy along with each Opaque copy, or state in or with each Opaque copy
+a computer-network location from which the general network-using
+public has access to download using public-standard network protocols
+a complete Transparent copy of the Document, free of added material.
+If you use the latter option, you must take reasonably prudent steps,
+when you begin distribution of Opaque copies in quantity, to ensure
+that this Transparent copy will remain thus accessible at the stated
+location until at least one year after the last time you distribute an
+Opaque copy (directly or through your agents or retailers) of that
+edition to the public.
+
+It is requested, but not required, that you contact the authors of the
+Document well before redistributing any large number of copies, to give
+them a chance to provide you with an updated version of the Document.
+
+
+4. MODIFICATIONS
+
+You may copy and distribute a Modified Version of the Document under
+the conditions of sections 2 and 3 above, provided that you release
+the Modified Version under precisely this License, with the Modified
+Version filling the role of the Document, thus licensing distribution
+and modification of the Modified Version to whoever possesses a copy
+of it.  In addition, you must do these things in the Modified Version:
+
+A. Use in the Title Page (and on the covers, if any) a title distinct
+   from that of the Document, and from those of previous versions
+   (which should, if there were any, be listed in the History section
+   of the Document).  You may use the same title as a previous version
+   if the original publisher of that version gives permission.
+B. List on the Title Page, as authors, one or more persons or entities
+   responsible for authorship of the modifications in the Modified
+   Version, together with at least five of the principal authors of the
+   Document (all of its principal authors, if it has fewer than five),
+   unless they release you from this requirement.
+C. State on the Title page the name of the publisher of the
+   Modified Version, as the publisher.
+D. Preserve all the copyright notices of the Document.
+E. Add an appropriate copyright notice for your modifications
+   adjacent to the other copyright notices.
+F. Include, immediately after the copyright notices, a license notice
+   giving the public permission to use the Modified Version under the
+   terms of this License, in the form shown in the Addendum below.
+G. Preserve in that license notice the full lists of Invariant Sections
+   and required Cover Texts given in the Document's license notice.
+H. Include an unaltered copy of this License.
+I. Preserve the section Entitled "History", Preserve its Title, and add
+   to it an item stating at least the title, year, new authors, and
+   publisher of the Modified Version as given on the Title Page.  If
+   there is no section Entitled "History" in the Document, create one
+   stating the title, year, authors, and publisher of the Document as
+   given on its Title Page, then add an item describing the Modified
+   Version as stated in the previous sentence.
+J. Preserve the network location, if any, given in the Document for
+   public access to a Transparent copy of the Document, and likewise
+   the network locations given in the Document for previous versions
+   it was based on.  These may be placed in the "History" section.
+   You may omit a network location for a work that was published at
+   least four years before the Document itself, or if the original
+   publisher of the version it refers to gives permission.
+K. For any section Entitled "Acknowledgements" or "Dedications",
+   Preserve the Title of the section, and preserve in the section all
+   the substance and tone of each of the contributor acknowledgements
+   and/or dedications given therein.
+L. Preserve all the Invariant Sections of the Document,
+   unaltered in their text and in their titles.  Section numbers
+   or the equivalent are not considered part of the section titles.
+M. Delete any section Entitled "Endorsements".  Such a section
+   may not be included in the Modified Version.
+N. Do not retitle any existing section to be Entitled "Endorsements"
+   or to conflict in title with any Invariant Section.
+O. Preserve any Warranty Disclaimers.
+
+If the Modified Version includes new front-matter sections or
+appendices that qualify as Secondary Sections and contain no material
+copied from the Document, you may at your option designate some or all
+of these sections as invariant.  To do this, add their titles to the
+list of Invariant Sections in the Modified Version's license notice.
+These titles must be distinct from any other section titles.
+
+You may add a section Entitled "Endorsements", provided it contains
+nothing but endorsements of your Modified Version by various
+parties--for example, statements of peer review or that the text has
+been approved by an organization as the authoritative definition of a
+standard.
+
+You may add a passage of up to five words as a Front-Cover Text, and a
+passage of up to 25 words as a Back-Cover Text, to the end of the list
+of Cover Texts in the Modified Version.  Only one passage of
+Front-Cover Text and one of Back-Cover Text may be added by (or
+through arrangements made by) any one entity.  If the Document already
+includes a cover text for the same cover, previously added by you or
+by arrangement made by the same entity you are acting on behalf of,
+you may not add another; but you may replace the old one, on explicit
+permission from the previous publisher that added the old one.
+
+The author(s) and publisher(s) of the Document do not by this License
+give permission to use their names for publicity for or to assert or
+imply endorsement of any Modified Version.
+
+
+5. COMBINING DOCUMENTS
+
+You may combine the Document with other documents released under this
+License, under the terms defined in section 4 above for modified
+versions, provided that you include in the combination all of the
+Invariant Sections of all of the original documents, unmodified, and
+list them all as Invariant Sections of your combined work in its
+license notice, and that you preserve all their Warranty Disclaimers.
+
+The combined work need only contain one copy of this License, and
+multiple identical Invariant Sections may be replaced with a single
+copy.  If there are multiple Invariant Sections with the same name but
+different contents, make the title of each such section unique by
+adding at the end of it, in parentheses, the name of the original
+author or publisher of that section if known, or else a unique number.
+Make the same adjustment to the section titles in the list of
+Invariant Sections in the license notice of the combined work.
+
+In the combination, you must combine any sections Entitled "History"
+in the various original documents, forming one section Entitled
+"History"; likewise combine any sections Entitled "Acknowledgements",
+and any sections Entitled "Dedications".  You must delete all sections
+Entitled "Endorsements".
+
+
+6. COLLECTIONS OF DOCUMENTS
+
+You may make a collection consisting of the Document and other documents
+released under this License, and replace the individual copies of this
+License in the various documents with a single copy that is included in
+the collection, provided that you follow the rules of this License for
+verbatim copying of each of the documents in all other respects.
+
+You may extract a single document from such a collection, and distribute
+it individually under this License, provided you insert a copy of this
+License into the extracted document, and follow this License in all
+other respects regarding verbatim copying of that document.
+
+
+7. AGGREGATION WITH INDEPENDENT WORKS
+
+A compilation of the Document or its derivatives with other separate
+and independent documents or works, in or on a volume of a storage or
+distribution medium, is called an "aggregate" if the copyright
+resulting from the compilation is not used to limit the legal rights
+of the compilation's users beyond what the individual works permit.
+When the Document is included in an aggregate, this License does not
+apply to the other works in the aggregate which are not themselves
+derivative works of the Document.
+
+If the Cover Text requirement of section 3 is applicable to these
+copies of the Document, then if the Document is less than one half of
+the entire aggregate, the Document's Cover Texts may be placed on
+covers that bracket the Document within the aggregate, or the
+electronic equivalent of covers if the Document is in electronic form.
+Otherwise they must appear on printed covers that bracket the whole
+aggregate.
+
+
+8. TRANSLATION
+
+Translation is considered a kind of modification, so you may
+distribute translations of the Document under the terms of section 4.
+Replacing Invariant Sections with translations requires special
+permission from their copyright holders, but you may include
+translations of some or all Invariant Sections in addition to the
+original versions of these Invariant Sections.  You may include a
+translation of this License, and all the license notices in the
+Document, and any Warranty Disclaimers, provided that you also include
+the original English version of this License and the original versions
+of those notices and disclaimers.  In case of a disagreement between
+the translation and the original version of this License or a notice
+or disclaimer, the original version will prevail.
+
+If a section in the Document is Entitled "Acknowledgements",
+"Dedications", or "History", the requirement (section 4) to Preserve
+its Title (section 1) will typically require changing the actual
+title.
+
+
+9. TERMINATION
+
+You may not copy, modify, sublicense, or distribute the Document except
+as expressly provided for under this License.  Any other attempt to
+copy, modify, sublicense or distribute the Document is void, and will
+automatically terminate your rights under this License.  However,
+parties who have received copies, or rights, from you under this
+License will not have their licenses terminated so long as such
+parties remain in full compliance.
+
+
+10. FUTURE REVISIONS OF THIS LICENSE
+
+The Free Software Foundation may publish new, revised versions
+of the GNU Free Documentation License from time to time.  Such new
+versions will be similar in spirit to the present version, but may
+differ in detail to address new problems or concerns.  See
+https://www.gnu.org/licenses/.
+
+Each version of the License is given a distinguishing version number.
+If the Document specifies that a particular numbered version of this
+License "or any later version" applies to it, you have the option of
+following the terms and conditions either of that specified version or
+of any later version that has been published (not as a draft) by the
+Free Software Foundation.  If the Document does not specify a version
+number of this License, you may choose any version ever published (not
+as a draft) by the Free Software Foundation.
+
+
+ADDENDUM: How to use this License for your documents
+
+To use this License in a document you have written, include a copy of
+the License in the document and put the following copyright and
+license notices just after the title page:
+
+    Copyright (c)  YEAR  YOUR NAME.
+    Permission is granted to copy, distribute and/or modify this document
+    under the terms of the GNU Free Documentation License, Version 1.2
+    or any later version published by the Free Software Foundation;
+    with no Invariant Sections, no Front-Cover Texts, and no Back-Cover Texts.
+    A copy of the license is included in the section entitled "GNU
+    Free Documentation License".
+
+If you have Invariant Sections, Front-Cover Texts and Back-Cover Texts,
+replace the "with...Texts." line with this:
+
+    with the Invariant Sections being LIST THEIR TITLES, with the
+    Front-Cover Texts being LIST, and with the Back-Cover Texts being LIST.
+
+If you have Invariant Sections without Cover Texts, or some other
+combination of the three, merge those two alternatives to suit the
+situation.
+
+If your document contains nontrivial examples of program code, we
+recommend releasing these examples in parallel under your choice of
+free software license, such as the GNU General Public License,
+to permit their use in free software.

--- a/licenses-generator/src/main/resources/offline-license-mirror/www.gnu.org/licenses/fdl-1.3
+++ b/licenses-generator/src/main/resources/offline-license-mirror/www.gnu.org/licenses/fdl-1.3
@@ -1,267 +1,54 @@
-<!DOCTYPE html>
-<html xmlns="http://www.w3.org/1999/xhtml" xml:lang="en" lang="en">
-<head>
-<meta http-equiv="content-type" content="text/html; charset=utf-8" />
-<link rel="author" href="mailto:webmasters@gnu.org" />
-<link rel="icon" type="image/png" href="/graphics/gnu-head-mini.png" />
-<meta name="ICBM" content="42.355469,-71.058627" />
-<link rel="stylesheet" type="text/css" href="/layout.min.css" media="screen" />
-<link rel="stylesheet" type="text/css" href="/print.min.css" media="print" />
+
+                GNU Free Documentation License
+                 Version 1.3, 3 November 2008
 
 
+ Copyright (C) 2000, 2001, 2002, 2007, 2008 Free Software Foundation, Inc.
+     <https://fsf.org/>
+ Everyone is permitted to copy and distribute verbatim copies
+ of this license document, but changing it is not allowed.
 
-<!-- Parent-Version: 1.98 -->
-<!-- This page is derived from /server/standards/boilerplate.html -->
-<title>GNU Free Documentation License v1.3
-- GNU Project - Free Software Foundation</title>
-<style type="text/css" media="screen"><!--
-#content .button { margin: 2em 1.5em; }
-@media (max-width:30em) { #content img.imgright { display: none; }}
---></style>
-<link rel="alternate" type="application/rdf+xml"
-      href="/licenses/fdl-1.3.rdf" /> 
-<!-- begin translist file -->
+0. PREAMBLE
 
-<link rel="alternate" type="text/html" href="/licenses/fdl-1.3.html" hreflang="x-default" />
-<link rel="alternate" type="text/html" lang="en" hreflang="en" href="/licenses/fdl-1.3.en.html" title="English" />
-<link rel="alternate" type="text/html" lang="ca" hreflang="ca" href="/licenses/fdl-1.3.ca.html" title="català" />
-<link rel="alternate" type="text/html" lang="de" hreflang="de" href="/licenses/fdl-1.3.de.html" title="Deutsch" />
-<link rel="alternate" type="text/html" lang="fr" hreflang="fr" href="/licenses/fdl-1.3.fr.html" title="français" />
-<link rel="alternate" type="text/html" lang="ja" hreflang="ja" href="/licenses/fdl-1.3.ja.html" title="日本語" />
-<link rel="alternate" type="text/html" lang="pt-br" hreflang="pt-br" href="/licenses/fdl-1.3.pt-br.html" title="português" />
-<link rel="alternate" type="text/html" lang="ru" hreflang="ru" href="/licenses/fdl-1.3.ru.html" title="русский" />
-<link rel="alternate" type="text/html" lang="tr" hreflang="tr" href="/licenses/fdl-1.3.tr.html" title="Türkçe" />
-<link rel="alternate" type="text/html" lang="uk" hreflang="uk" href="/licenses/fdl-1.3.uk.html" title="українська" />
-<link rel="alternate" type="text/html" lang="zh-cn" hreflang="zh-cn" href="/licenses/fdl-1.3.zh-cn.html" title="简体中文" />
-<link rel="alternate" type="text/html" lang="zh-tw" hreflang="zh-tw" href="/licenses/fdl-1.3.zh-tw.html" title="繁體中文" />
-<!-- end translist file -->
-
-<!-- start of server/banner.html -->
-<!-- start of head-include-2.html -->
-<meta name="viewport" content="width=device-width, initial-scale=1" />
-<!-- end of head-include-2.html -->
-
-</head>
-<body>
-<div class="inner">
-<!-- start of server/body-include-1.html -->
-<div id="top">
-<a class="skip" href="#content"><b>Skip to main text</b></a>
-</div>
-
-<div id="fsf-frame" role="complementary">
-<form id="fssbox" action="https://my.fsf.org/civicrm/profile/create?reset=1&amp;gid=31"
-      method="post">
- <div>
-  <input name="postURL" type="hidden" value="" />
-  <input type="hidden" name="group[25]" value="1" />
-  <input name="cancelURL" type="hidden" value="https://crm.fsf.org/civicrm/profile?reset=1&amp;gid=31" />
-  <input name="_qf_default" type="hidden" value="Edit:cancel" />
-  <label for="frmEmail">
-   <a href="//www.fsf.org/fss">Free Software Supporter</a>:
-  </label>
-  <input type="text" id="frmEmail" name="email-Primary" size="18" maxlength="80"
-         value="email address" onfocus="this.value=''"/>
-  <input type="submit" name="_qf_Edit_next" value="Sign up" />
- </div>
-</form>
-
-<div id="join-fsf" class="button"><a
-href="https://www.fsf.org/associate/support_freedom?referrer=4052">JOIN&nbsp;THE&nbsp;FSF</a>
-</div>
-</div>
-
-<div id="header" role="banner">
-<p id="gnu-banner">
- <a href="/">
- <img src="/graphics/heckert_gnu.transp.small.png" height="48" width="49"
-      alt="&nbsp;[A GNU head]&nbsp;" /><strong>GNU</strong> <span
- class="hide">Operating System</span></a><br />
- <small id="fsf-support">Supported by the
- <a href="#mission-statement">Free Software Foundation</a></small>
-</p>
-
-<div id="switches">
-<!-- begin search button -->
- <div  id="search-button" class="switch">
-  <a href="//www.gnu.org/cgi-bin/estseek.cgi">
-  <img id="search-icon" height="30" width="30"
-       src="/graphics/icons/search.png"
-       alt="&nbsp;[Search www.gnu.org]&nbsp;" /></a>
- </div>
-<!-- end search button -->
-
- <div id="language-button" class="switch">
-  <a href="#language-container">
-  <img id="language-icon" height="30" width="37"
-       src="/graphics/icons/translations.png"
-       alt="&nbsp;[Other languages]&nbsp;" /></a>
- </div>
-
-</div>
-</div>
-<!-- end of server/body-include-1.html -->
-
-<!-- start of server/body-include-2 -->
-
-
-<div style="clear: both"></div>
-
-<div id="navigation" role="navigation">
- <a id="more-links" href="#navigation" title="More...">
-   <span>Site navigation</span></a>
- <a id="less-links" href="#content"><b>Skip</b></a>
- <ul>
-
-   <li id="tabAboutGNU"><a href="/gnu/gnu.html">ABOUT&nbsp;GNU</a></li>
-
-
-  <li id="tabPhilosophy"><a href="/philosophy/philosophy.html">PHILOSOPHY</a></li>
-
-
-  <li id="tabLicenses" class="active">
-     <span class='no-display'>=</span> 
-    <a href="/licenses/licenses.html">LICENSES</a>
-    <span class="gnun-split"></span>
-     <span class='no-display'>=</span> 
-  </li>
-
-
-  <li id="tabEducation"><a href="/education/education.html">EDUCATION</a></li>
-
-
-  <li id="tabSoftware"><a href="/software/software.html">SOFTWARE</a></li>
-
-
-  <li id="tabDistros"><a href="/distros/distros.html">DISTROS</a></li>
-
-
-  <li id="tabDoc"><a href="/doc/doc.html">DOCS</a></li>
-
-
-  <li id="tabMalware"><a href="/proprietary/proprietary.html">MALWARE</a></li>
-
-
-  <li id="tabHelp"><a href="/help/help.html">HELP&nbsp;GNU</a></li>
-
-
-  <li id="tabAV"><a href="/audio-video/audio-video.html">AUDIO&nbsp;&amp;&nbsp;VIDEO</a></li>
-
-
-  <li id="tabArt"><a href="/graphics/graphics.html">GNU&nbsp;ART</a></li>
-
-
-  <li id="tabFun"><a href="/fun/humor.html">FUN</a></li>
-
-
-  <li id="tabPeople"><a href="/people/people.html">GNU'S&nbsp;WHO?</a></li>
-
-  <li><a href="//directory.fsf.org">SOFTWARE&nbsp;DIRECTORY</a></li>
-  <li><a href="https://h-node.org/">HARDWARE</a></li>
-  <li><a href="/server/sitemap.html">SITEMAP</a></li>
- </ul>
- <div style="clear: both"></div>
-</div><!-- /"navigation -->
-<!-- end of server/body-include-2 -->
-
-<div id="content" role="main">
-<!-- end of server/banner.html -->
-
-<div class="reduced-width">
-<h2>GNU Free Documentation License</h2>
-
-<img class="imgright" src="/graphics/gfdl-logo-small.png" alt=" [GFDL Logo] " />
-<p class="button"><b><a href="#license-text">Skip to license text</a></b></p>
-
-<ul>
-  <li><a href="/licenses/fdl-1.3-faq.html">FDL 1.3 Frequently Asked
-  Questions</a></li>
-  <li><a href="/licenses/fdl-1.3-pdiff.ps">Marked-up changes between
-  FDL 1.2 and FDL 1.3 (PostScript)</a></li>
-  <li><a href="/licenses/fdl-howto.html">Tips on how to use the FDL</a></li>
-  <li><a href="/licenses/fdl-howto-opt.html">How to Use the Optional
-  Features of the GFDL</a></li>
-  <li><a href="/licenses/translations.html">Translations
-  of the GFDL</a></li>
-
-  <li>The FDL in other formats:
-     <a href="/licenses/fdl-1.3.txt">plain text</a>,
-     <a href="/licenses/fdl-1.3.texi">Texinfo</a>,
-     <a href="/licenses/fdl-1.3-standalone.html">standalone HTML</a>,
-     DocBook/XML <a href="/licenses/fdl-1.3.xml">v4</a> or 
-     <a href="/licenses/fdl-1.3-db5.xml">v5</a>, 
-     <a href="/licenses/fdl-1.3.tex">LaTeX</a>, 
-     <a href="/licenses/fdl-1.3.md">Markdown</a>, 
-     <a href="/licenses/fdl-1.3.odt">ODF</a>, 
-     <a href="/licenses/fdl-1.3.rtf">RTF</a>
-  </li>
-
-  <li><a href="/licenses/why-gfdl.html">Why publishers should use the
-  GNU Free Documentation License</a></li>
-  <li><a href="/philosophy/free-doc.html">Free Software and Free
-  Manuals</a></li>
-  <li><a href="/licenses/old-licenses/old-licenses.html#FDL">Old versions
-  of the GNU Free Documentation License</a></li>
-  <li><a href="/licenses/gpl-violation.html">What to do if you see a
-  possible GFDL violation</a></li>
-</ul>
-
-<hr class="thin" />
-
-<!-- The license text is in English and appears broken in RTL as
-     Arabic, Farsi, etc.  Explicitly set the direction to override the
-     one defined in the translation. -->
-<div id="license-text" dir="ltr">
-
-<h3 style="text-align: center;">GNU Free Documentation License</h3>
-
-<p style="text-align: center;">Version 1.3, 3 November 2008</p>
-
-<p> Copyright &copy; 2000, 2001, 2002, 2007, 2008 Free Software Foundation, Inc.
-     &lt;<a href="https://fsf.org/">https://fsf.org/</a>&gt;
- </p><p>Everyone is permitted to copy and distribute verbatim copies
- of this license document, but changing it is not allowed.</p>
-
-<h4 id="section0">0. PREAMBLE</h4>
-
-<p>The purpose of this License is to make a manual, textbook, or other
-functional and useful document &quot;free&quot; in the sense of freedom: to
+The purpose of this License is to make a manual, textbook, or other
+functional and useful document "free" in the sense of freedom: to
 assure everyone the effective freedom to copy and redistribute it,
 with or without modifying it, either commercially or noncommercially.
 Secondarily, this License preserves for the author and publisher a way
 to get credit for their work, while not being considered responsible
-for modifications made by others.</p>
+for modifications made by others.
 
-<p>This License is a kind of &quot;copyleft&quot;, which means that derivative
+This License is a kind of "copyleft", which means that derivative
 works of the document must themselves be free in the same sense.  It
 complements the GNU General Public License, which is a copyleft
-license designed for free software.</p>
+license designed for free software.
 
-<p>We have designed this License in order to use it for manuals for free
+We have designed this License in order to use it for manuals for free
 software, because free software needs free documentation: a free
 program should come with manuals providing the same freedoms that the
 software does.  But this License is not limited to software manuals;
 it can be used for any textual work, regardless of subject matter or
 whether it is published as a printed book.  We recommend this License
-principally for works whose purpose is instruction or reference.</p>
+principally for works whose purpose is instruction or reference.
 
-<h4 id="section1">1. APPLICABILITY AND DEFINITIONS</h4>
 
-<p>This License applies to any manual or other work, in any medium, that
+1. APPLICABILITY AND DEFINITIONS
+
+This License applies to any manual or other work, in any medium, that
 contains a notice placed by the copyright holder saying it can be
 distributed under the terms of this License.  Such a notice grants a
 world-wide, royalty-free license, unlimited in duration, to use that
-work under the conditions stated herein.  The &quot;Document&quot;, below,
+work under the conditions stated herein.  The "Document", below,
 refers to any such manual or work.  Any member of the public is a
-licensee, and is addressed as &quot;you&quot;.  You accept the license if you
+licensee, and is addressed as "you".  You accept the license if you
 copy, modify or distribute the work in a way requiring permission
-under copyright law.</p>
+under copyright law.
 
-<p>A &quot;Modified Version&quot; of the Document means any work containing the
+A "Modified Version" of the Document means any work containing the
 Document or a portion of it, either copied verbatim, or with
-modifications and/or translated into another language.</p>
+modifications and/or translated into another language.
 
-<p>A &quot;Secondary Section&quot; is a named appendix or a front-matter section of
+A "Secondary Section" is a named appendix or a front-matter section of
 the Document that deals exclusively with the relationship of the
 publishers or authors of the Document to the Document's overall
 subject (or to related matters) and contains nothing that could fall
@@ -270,22 +57,22 @@ part a textbook of mathematics, a Secondary Section may not explain
 any mathematics.)  The relationship could be a matter of historical
 connection with the subject or with related matters, or of legal,
 commercial, philosophical, ethical or political position regarding
-them.</p>
+them.
 
-<p>The &quot;Invariant Sections&quot; are certain Secondary Sections whose titles
+The "Invariant Sections" are certain Secondary Sections whose titles
 are designated, as being those of Invariant Sections, in the notice
 that says that the Document is released under this License.  If a
 section does not fit the above definition of Secondary then it is not
 allowed to be designated as Invariant.  The Document may contain zero
 Invariant Sections.  If the Document does not identify any Invariant
-Sections then there are none.</p>
+Sections then there are none.
 
-<p>The &quot;Cover Texts&quot; are certain short passages of text that are listed,
+The "Cover Texts" are certain short passages of text that are listed,
 as Front-Cover Texts or Back-Cover Texts, in the notice that says that
 the Document is released under this License.  A Front-Cover Text may
-be at most 5 words, and a Back-Cover Text may be at most 25 words.</p>
+be at most 5 words, and a Back-Cover Text may be at most 25 words.
 
-<p>A &quot;Transparent&quot; copy of the Document means a machine-readable copy,
+A "Transparent" copy of the Document means a machine-readable copy,
 represented in a format whose specification is available to the
 general public, that is suitable for revising the document
 straightforwardly with generic text editors or (for images composed of
@@ -296,9 +83,9 @@ to text formatters.  A copy made in an otherwise Transparent file
 format whose markup, or absence of markup, has been arranged to thwart
 or discourage subsequent modification by readers is not Transparent.
 An image format is not Transparent if used for any substantial amount
-of text.  A copy that is not &quot;Transparent&quot; is called &quot;Opaque&quot;.</p>
+of text.  A copy that is not "Transparent" is called "Opaque".
 
-<p>Examples of suitable formats for Transparent copies include plain
+Examples of suitable formats for Transparent copies include plain
 ASCII without markup, Texinfo input format, LaTeX input format, SGML
 or XML using a publicly available DTD, and standard-conforming simple
 HTML, PostScript or PDF designed for human modification.  Examples of
@@ -307,36 +94,36 @@ include proprietary formats that can be read and edited only by
 proprietary word processors, SGML or XML for which the DTD and/or
 processing tools are not generally available, and the
 machine-generated HTML, PostScript or PDF produced by some word
-processors for output purposes only.</p>
+processors for output purposes only.
 
-<p>The &quot;Title Page&quot; means, for a printed book, the title page itself,
+The "Title Page" means, for a printed book, the title page itself,
 plus such following pages as are needed to hold, legibly, the material
 this License requires to appear in the title page.  For works in
-formats which do not have any title page as such, &quot;Title Page&quot; means
+formats which do not have any title page as such, "Title Page" means
 the text near the most prominent appearance of the work's title,
-preceding the beginning of the body of the text.</p>
+preceding the beginning of the body of the text.
 
-<p>The &quot;publisher&quot; means any person or entity that distributes copies of
-the Document to the public.</p>
+The "publisher" means any person or entity that distributes copies of
+the Document to the public.
 
-<p>A section &quot;Entitled XYZ&quot; means a named subunit of the Document whose
+A section "Entitled XYZ" means a named subunit of the Document whose
 title either is precisely XYZ or contains XYZ in parentheses following
 text that translates XYZ in another language.  (Here XYZ stands for a
-specific section name mentioned below, such as &quot;Acknowledgements&quot;,
-&quot;Dedications&quot;, &quot;Endorsements&quot;, or &quot;History&quot;.)  To &quot;Preserve the Title&quot;
+specific section name mentioned below, such as "Acknowledgements",
+"Dedications", "Endorsements", or "History".)  To "Preserve the Title"
 of such a section when you modify the Document means that it remains a
-section &quot;Entitled XYZ&quot; according to this definition.</p>
+section "Entitled XYZ" according to this definition.
 
-<p>The Document may include Warranty Disclaimers next to the notice which
+The Document may include Warranty Disclaimers next to the notice which
 states that this License applies to the Document.  These Warranty
 Disclaimers are considered to be included by reference in this
 License, but only as regards disclaiming warranties: any other
 implication that these Warranty Disclaimers may have is void and has
-no effect on the meaning of this License.</p>
+no effect on the meaning of this License.
 
-<h4 id="section2">2. VERBATIM COPYING</h4>
+2. VERBATIM COPYING
 
-<p>You may copy and distribute the Document in any medium, either
+You may copy and distribute the Document in any medium, either
 commercially or noncommercially, provided that this License, the
 copyright notices, and the license notice saying this License applies
 to the Document are reproduced in all copies, and that you add no
@@ -344,14 +131,15 @@ other conditions whatsoever to those of this License.  You may not use
 technical measures to obstruct or control the reading or further
 copying of the copies you make or distribute.  However, you may accept
 compensation in exchange for copies.  If you distribute a large enough
-number of copies you must also follow the conditions in section 3.</p>
+number of copies you must also follow the conditions in section 3.
 
-<p>You may also lend copies, under the same conditions stated above, and
-you may publicly display copies.</p>
+You may also lend copies, under the same conditions stated above, and
+you may publicly display copies.
 
-<h4 id="section3">3. COPYING IN QUANTITY</h4>
 
-<p>If you publish printed copies (or copies in media that commonly have
+3. COPYING IN QUANTITY
+
+If you publish printed copies (or copies in media that commonly have
 printed covers) of the Document, numbering more than 100, and the
 Document's license notice requires Cover Texts, you must enclose the
 copies in covers that carry, clearly and legibly, all these Cover
@@ -362,14 +150,14 @@ the full title with all words of the title equally prominent and
 visible.  You may add other material on the covers in addition.
 Copying with changes limited to the covers, as long as they preserve
 the title of the Document and satisfy these conditions, can be treated
-as verbatim copying in other respects.</p>
+as verbatim copying in other respects.
 
-<p>If the required texts for either cover are too voluminous to fit
+If the required texts for either cover are too voluminous to fit
 legibly, you should put the first ones listed (as many as fit
 reasonably) on the actual cover, and continue the rest onto adjacent
-pages.</p>
+pages.
 
-<p>If you publish or distribute Opaque copies of the Document numbering
+If you publish or distribute Opaque copies of the Document numbering
 more than 100, you must either include a machine-readable Transparent
 copy along with each Opaque copy, or state in or with each Opaque copy
 a computer-network location from which the general network-using
@@ -380,117 +168,85 @@ when you begin distribution of Opaque copies in quantity, to ensure
 that this Transparent copy will remain thus accessible at the stated
 location until at least one year after the last time you distribute an
 Opaque copy (directly or through your agents or retailers) of that
-edition to the public.</p>
+edition to the public.
 
-<p>It is requested, but not required, that you contact the authors of the
+It is requested, but not required, that you contact the authors of the
 Document well before redistributing any large number of copies, to
 give them a chance to provide you with an updated version of the
-Document.</p>
+Document.
 
-<h4 id="section4">4. MODIFICATIONS</h4>
 
-<p>You may copy and distribute a Modified Version of the Document under
+4. MODIFICATIONS
+
+You may copy and distribute a Modified Version of the Document under
 the conditions of sections 2 and 3 above, provided that you release
 the Modified Version under precisely this License, with the Modified
 Version filling the role of the Document, thus licensing distribution
 and modification of the Modified Version to whoever possesses a copy
-of it.  In addition, you must do these things in the Modified Version:</p>
+of it.  In addition, you must do these things in the Modified Version:
 
-<ul>
-
-
-<li>A. Use in the Title Page (and on the covers, if any) a title distinct
+A. Use in the Title Page (and on the covers, if any) a title distinct
    from that of the Document, and from those of previous versions
    (which should, if there were any, be listed in the History section
    of the Document).  You may use the same title as a previous version
    if the original publisher of that version gives permission.
-</li>
-
-<li>B. List on the Title Page, as authors, one or more persons or entities
+B. List on the Title Page, as authors, one or more persons or entities
    responsible for authorship of the modifications in the Modified
    Version, together with at least five of the principal authors of the
    Document (all of its principal authors, if it has fewer than five),
    unless they release you from this requirement.
-</li>
-
-<li>C. State on the Title page the name of the publisher of the
+C. State on the Title page the name of the publisher of the
    Modified Version, as the publisher.
-</li>
-
-<li>D. Preserve all the copyright notices of the Document.
-</li>
-
-<li>E. Add an appropriate copyright notice for your modifications
+D. Preserve all the copyright notices of the Document.
+E. Add an appropriate copyright notice for your modifications
    adjacent to the other copyright notices.
-</li>
-
-<li>F. Include, immediately after the copyright notices, a license notice
+F. Include, immediately after the copyright notices, a license notice
    giving the public permission to use the Modified Version under the
    terms of this License, in the form shown in the Addendum below.
-</li>
-
-<li>G. Preserve in that license notice the full lists of Invariant Sections
+G. Preserve in that license notice the full lists of Invariant Sections
    and required Cover Texts given in the Document's license notice.
-</li>
-
-<li>H. Include an unaltered copy of this License.
-</li>
-
-<li>I. Preserve the section Entitled &quot;History&quot;, Preserve its Title, and add
+H. Include an unaltered copy of this License.
+I. Preserve the section Entitled "History", Preserve its Title, and add
    to it an item stating at least the title, year, new authors, and
    publisher of the Modified Version as given on the Title Page.  If
-   there is no section Entitled &quot;History&quot; in the Document, create one
+   there is no section Entitled "History" in the Document, create one
    stating the title, year, authors, and publisher of the Document as
    given on its Title Page, then add an item describing the Modified
    Version as stated in the previous sentence.
-</li>
-
-<li>J. Preserve the network location, if any, given in the Document for
+J. Preserve the network location, if any, given in the Document for
    public access to a Transparent copy of the Document, and likewise
    the network locations given in the Document for previous versions
-   it was based on.  These may be placed in the &quot;History&quot; section.
+   it was based on.  These may be placed in the "History" section.
    You may omit a network location for a work that was published at
    least four years before the Document itself, or if the original
    publisher of the version it refers to gives permission.
-</li>
-
-<li>K. For any section Entitled &quot;Acknowledgements&quot; or &quot;Dedications&quot;,
+K. For any section Entitled "Acknowledgements" or "Dedications",
    Preserve the Title of the section, and preserve in the section all
    the substance and tone of each of the contributor acknowledgements
    and/or dedications given therein.
-</li>
-
-<li>L. Preserve all the Invariant Sections of the Document,
+L. Preserve all the Invariant Sections of the Document,
    unaltered in their text and in their titles.  Section numbers
    or the equivalent are not considered part of the section titles.
-</li>
-
-<li>M. Delete any section Entitled &quot;Endorsements&quot;.  Such a section
+M. Delete any section Entitled "Endorsements".  Such a section
    may not be included in the Modified Version.
-</li>
-
-<li>N. Do not retitle any existing section to be Entitled &quot;Endorsements&quot;
+N. Do not retitle any existing section to be Entitled "Endorsements"
    or to conflict in title with any Invariant Section.
-</li>
+O. Preserve any Warranty Disclaimers.
 
-<li>O. Preserve any Warranty Disclaimers.</li>
-
-</ul>
-
-<p>If the Modified Version includes new front-matter sections or
+If the Modified Version includes new front-matter sections or
 appendices that qualify as Secondary Sections and contain no material
 copied from the Document, you may at your option designate some or all
 of these sections as invariant.  To do this, add their titles to the
 list of Invariant Sections in the Modified Version's license notice.
-These titles must be distinct from any other section titles.</p>
+These titles must be distinct from any other section titles.
 
-<p>You may add a section Entitled &quot;Endorsements&quot;, provided it contains
+You may add a section Entitled "Endorsements", provided it contains
 nothing but endorsements of your Modified Version by various
-parties&mdash;for example, statements of peer review or that the text has
+parties--for example, statements of peer review or that the text has
 been approved by an organization as the authoritative definition of a
-standard.</p>
+standard.
 
-<p>You may add a passage of up to five words as a Front-Cover Text, and a
+You may add a passage of up to five words as a Front-Cover Text, and a
 passage of up to 25 words as a Back-Cover Text, to the end of the list
 of Cover Texts in the Modified Version.  Only one passage of
 Front-Cover Text and one of Back-Cover Text may be added by (or
@@ -498,73 +254,77 @@ through arrangements made by) any one entity.  If the Document already
 includes a cover text for the same cover, previously added by you or
 by arrangement made by the same entity you are acting on behalf of,
 you may not add another; but you may replace the old one, on explicit
-permission from the previous publisher that added the old one.</p>
+permission from the previous publisher that added the old one.
 
-<p>The author(s) and publisher(s) of the Document do not by this License
+The author(s) and publisher(s) of the Document do not by this License
 give permission to use their names for publicity for or to assert or
-imply endorsement of any Modified Version.</p>
+imply endorsement of any Modified Version.
 
-<h4 id="section5">5. COMBINING DOCUMENTS</h4>
 
-<p>You may combine the Document with other documents released under this
+5. COMBINING DOCUMENTS
+
+You may combine the Document with other documents released under this
 License, under the terms defined in section 4 above for modified
 versions, provided that you include in the combination all of the
 Invariant Sections of all of the original documents, unmodified, and
 list them all as Invariant Sections of your combined work in its
-license notice, and that you preserve all their Warranty Disclaimers.</p>
+license notice, and that you preserve all their Warranty Disclaimers.
 
-<p>The combined work need only contain one copy of this License, and
+The combined work need only contain one copy of this License, and
 multiple identical Invariant Sections may be replaced with a single
 copy.  If there are multiple Invariant Sections with the same name but
 different contents, make the title of each such section unique by
 adding at the end of it, in parentheses, the name of the original
 author or publisher of that section if known, or else a unique number.
 Make the same adjustment to the section titles in the list of
-Invariant Sections in the license notice of the combined work.</p>
+Invariant Sections in the license notice of the combined work.
 
-<p>In the combination, you must combine any sections Entitled &quot;History&quot;
+In the combination, you must combine any sections Entitled "History"
 in the various original documents, forming one section Entitled
-&quot;History&quot;; likewise combine any sections Entitled &quot;Acknowledgements&quot;,
-and any sections Entitled &quot;Dedications&quot;.  You must delete all sections
-Entitled &quot;Endorsements&quot;.</p>
+"History"; likewise combine any sections Entitled "Acknowledgements",
+and any sections Entitled "Dedications".  You must delete all sections
+Entitled "Endorsements".
 
-<h4 id="section6">6. COLLECTIONS OF DOCUMENTS</h4>
 
-<p>You may make a collection consisting of the Document and other
+6. COLLECTIONS OF DOCUMENTS
+
+You may make a collection consisting of the Document and other
 documents released under this License, and replace the individual
 copies of this License in the various documents with a single copy
 that is included in the collection, provided that you follow the rules
 of this License for verbatim copying of each of the documents in all
-other respects.</p>
+other respects.
 
-<p>You may extract a single document from such a collection, and
+You may extract a single document from such a collection, and
 distribute it individually under this License, provided you insert a
 copy of this License into the extracted document, and follow this
 License in all other respects regarding verbatim copying of that
-document.</p>
+document.
 
-<h4 id="section7">7. AGGREGATION WITH INDEPENDENT WORKS</h4>
 
-<p>A compilation of the Document or its derivatives with other separate
+7. AGGREGATION WITH INDEPENDENT WORKS
+
+A compilation of the Document or its derivatives with other separate
 and independent documents or works, in or on a volume of a storage or
-distribution medium, is called an &quot;aggregate&quot; if the copyright
+distribution medium, is called an "aggregate" if the copyright
 resulting from the compilation is not used to limit the legal rights
 of the compilation's users beyond what the individual works permit.
 When the Document is included in an aggregate, this License does not
 apply to the other works in the aggregate which are not themselves
-derivative works of the Document.</p>
+derivative works of the Document.
 
-<p>If the Cover Text requirement of section 3 is applicable to these
+If the Cover Text requirement of section 3 is applicable to these
 copies of the Document, then if the Document is less than one half of
 the entire aggregate, the Document's Cover Texts may be placed on
 covers that bracket the Document within the aggregate, or the
 electronic equivalent of covers if the Document is in electronic form.
 Otherwise they must appear on printed covers that bracket the whole
-aggregate.</p>
+aggregate.
 
-<h4 id="section8">8. TRANSLATION</h4>
 
-<p>Translation is considered a kind of modification, so you may
+8. TRANSLATION
+
+Translation is considered a kind of modification, so you may
 distribute translations of the Document under the terms of section 4.
 Replacing Invariant Sections with translations requires special
 permission from their copyright holders, but you may include
@@ -575,51 +335,53 @@ Document, and any Warranty Disclaimers, provided that you also include
 the original English version of this License and the original versions
 of those notices and disclaimers.  In case of a disagreement between
 the translation and the original version of this License or a notice
-or disclaimer, the original version will prevail.</p>
+or disclaimer, the original version will prevail.
 
-<p>If a section in the Document is Entitled &quot;Acknowledgements&quot;,
-&quot;Dedications&quot;, or &quot;History&quot;, the requirement (section 4) to Preserve
+If a section in the Document is Entitled "Acknowledgements",
+"Dedications", or "History", the requirement (section 4) to Preserve
 its Title (section 1) will typically require changing the actual
-title.</p>
+title.
 
-<h4 id="section9">9. TERMINATION</h4>
 
-<p>You may not copy, modify, sublicense, or distribute the Document
+9. TERMINATION
+
+You may not copy, modify, sublicense, or distribute the Document
 except as expressly provided under this License.  Any attempt
 otherwise to copy, modify, sublicense, or distribute it is void, and
-will automatically terminate your rights under this License.</p>
+will automatically terminate your rights under this License.
 
-<p>However, if you cease all violation of this License, then your license
+However, if you cease all violation of this License, then your license
 from a particular copyright holder is reinstated (a) provisionally,
 unless and until the copyright holder explicitly and finally
 terminates your license, and (b) permanently, if the copyright holder
 fails to notify you of the violation by some reasonable means prior to
-60 days after the cessation.</p>
+60 days after the cessation.
 
-<p>Moreover, your license from a particular copyright holder is
+Moreover, your license from a particular copyright holder is
 reinstated permanently if the copyright holder notifies you of the
 violation by some reasonable means, this is the first time you have
 received notice of violation of this License (for any work) from that
 copyright holder, and you cure the violation prior to 30 days after
-your receipt of the notice.</p>
+your receipt of the notice.
 
-<p>Termination of your rights under this section does not terminate the
+Termination of your rights under this section does not terminate the
 licenses of parties who have received copies or rights from you under
 this License.  If your rights have been terminated and not permanently
 reinstated, receipt of a copy of some or all of the same material does
-not give you any rights to use it.</p>
+not give you any rights to use it.
 
-<h4 id="section10">10. FUTURE REVISIONS OF THIS LICENSE</h4>
 
-<p>The Free Software Foundation may publish new, revised versions of the
+10. FUTURE REVISIONS OF THIS LICENSE
+
+The Free Software Foundation may publish new, revised versions of the
 GNU Free Documentation License from time to time.  Such new versions
 will be similar in spirit to the present version, but may differ in
 detail to address new problems or concerns.  See
-<a href="https://www.gnu.org/licenses/">https://www.gnu.org/licenses/</a>.</p>
+https://www.gnu.org/licenses/.
 
-<p>Each version of the License is given a distinguishing version number.
+Each version of the License is given a distinguishing version number.
 If the Document specifies that a particular numbered version of this
-License &quot;or any later version&quot; applies to it, you have the option of
+License "or any later version" applies to it, you have the option of
 following the terms and conditions either of that specified version or
 of any later version that has been published (not as a draft) by the
 Free Software Foundation.  If the Document does not specify a version
@@ -628,193 +390,62 @@ as a draft) by the Free Software Foundation.  If the Document
 specifies that a proxy can decide which future versions of this
 License can be used, that proxy's public statement of acceptance of a
 version permanently authorizes you to choose that version for the
-Document.</p>
+Document.
 
-<h4 id="section11">11. RELICENSING</h4>
+11. RELICENSING
 
-<p>&quot;Massive Multiauthor Collaboration Site&quot; (or &quot;MMC Site&quot;) means any
+"Massive Multiauthor Collaboration Site" (or "MMC Site") means any
 World Wide Web server that publishes copyrightable works and also
 provides prominent facilities for anybody to edit those works.  A
 public wiki that anybody can edit is an example of such a server.  A
-&quot;Massive Multiauthor Collaboration&quot; (or &quot;MMC&quot;) contained in the site
-means any set of copyrightable works thus published on the MMC site.</p>
+"Massive Multiauthor Collaboration" (or "MMC") contained in the site
+means any set of copyrightable works thus published on the MMC site.
 
-<p>&quot;CC-BY-SA&quot; means the Creative Commons Attribution-Share Alike 3.0 
-license published by Creative Commons Corporation, a not-for-profit 
-corporation with a principal place of business in San Francisco, 
-California, as well as future copyleft versions of that license 
-published by that same organization.</p>
+"CC-BY-SA" means the Creative Commons Attribution-Share Alike 3.0
+license published by Creative Commons Corporation, a not-for-profit
+corporation with a principal place of business in San Francisco,
+California, as well as future copyleft versions of that license
+published by that same organization.
 
-<p>&quot;Incorporate&quot; means to publish or republish a Document, in whole or in 
-part, as part of another Document.</p>
+"Incorporate" means to publish or republish a Document, in whole or in
+part, as part of another Document.
 
-<p>An MMC is &quot;eligible for relicensing&quot; if it is licensed under this 
-License, and if all works that were first published under this License 
-somewhere other than this MMC, and subsequently incorporated in whole or 
-in part into the MMC, (1) had no cover texts or invariant sections, and 
-(2) were thus incorporated prior to November 1, 2008.</p>
+An MMC is "eligible for relicensing" if it is licensed under this
+License, and if all works that were first published under this License
+somewhere other than this MMC, and subsequently incorporated in whole or
+in part into the MMC, (1) had no cover texts or invariant sections, and
+(2) were thus incorporated prior to November 1, 2008.
 
-<p>The operator of an MMC Site may republish an MMC contained in the site
+The operator of an MMC Site may republish an MMC contained in the site
 under CC-BY-SA on the same site at any time before August 1, 2009,
-provided the MMC is eligible for relicensing.</p>
+provided the MMC is eligible for relicensing.
 
-<h3 id="addendum">ADDENDUM: How to use this License for your documents</h3>
 
-<p>To use this License in a document you have written, include a copy of
+ADDENDUM: How to use this License for your documents
+
+To use this License in a document you have written, include a copy of
 the License in the document and put the following copyright and
-license notices just after the title page:</p>
+license notices just after the title page:
 
-<pre>    Copyright (C)  YEAR  YOUR NAME.
+    Copyright (c)  YEAR  YOUR NAME.
     Permission is granted to copy, distribute and/or modify this document
     under the terms of the GNU Free Documentation License, Version 1.3
     or any later version published by the Free Software Foundation;
     with no Invariant Sections, no Front-Cover Texts, and no Back-Cover Texts.
-    A copy of the license is included in the section entitled &quot;GNU
-    Free Documentation License&quot;.
-</pre>
+    A copy of the license is included in the section entitled "GNU
+    Free Documentation License".
 
-<p>If you have Invariant Sections, Front-Cover Texts and Back-Cover Texts,
-replace the &quot;with &hellip; Texts.&quot; line with this:</p>
+If you have Invariant Sections, Front-Cover Texts and Back-Cover Texts,
+replace the "with...Texts." line with this:
 
-<pre>    with the Invariant Sections being LIST THEIR TITLES, with the
+    with the Invariant Sections being LIST THEIR TITLES, with the
     Front-Cover Texts being LIST, and with the Back-Cover Texts being LIST.
-</pre>
 
-<p>If you have Invariant Sections without Cover Texts, or some other
+If you have Invariant Sections without Cover Texts, or some other
 combination of the three, merge those two alternatives to suit the
-situation.</p>
+situation.
 
-<p>If your document contains nontrivial examples of program code, we
+If your document contains nontrivial examples of program code, we
 recommend releasing these examples in parallel under your choice of
 free software license, such as the GNU General Public License,
 to permit their use in free software.
-</p>
-
-</div>
-</div>
-
-</div><!-- for id="content", starts in the include above -->
-
-              <!-- begin server/footer-text.html -->
-
-
-
-
-
-<div style="clear:both"></div>
-
-
-<div id="language-container">
- <div class="backtotop">
-  <hr class="no-display" />
-  <a href="#top"><b>&#9650;</b></a>
- </div>
- <div id="languages" class="rounded-corners">
-  <div class="button">
-   <a href="#top" class="close"><span>BACK TO TOP</span></a>
-  </div>
-  <div id="set-language" class="button">
-   <span class="gnun-split"></span>
-   <a href="/server/select-language.html?callback=/licenses/fdl-1.3" rel="nofollow">
-   Set language
-   <span class="gnun-split"></span>
-   </a>
-  </div>
-  <p>Available for this page:</p>
-  <div id="translations">
-<p>
-<span dir="ltr" class="original">[en]&nbsp;<a lang="en" hreflang="en" href="/licenses/fdl-1.3.en.html">English</a> &nbsp;</span>
-<span dir="ltr">[ca]&nbsp;<a lang="ca" hreflang="ca" href="/licenses/fdl-1.3.ca.html">català</a> &nbsp;</span>
-<span dir="ltr">[de]&nbsp;<a lang="de" hreflang="de" href="/licenses/fdl-1.3.de.html">Deutsch</a> &nbsp;</span>
-<span dir="ltr">[fr]&nbsp;<a lang="fr" hreflang="fr" href="/licenses/fdl-1.3.fr.html">français</a> &nbsp;</span>
-<span dir="ltr">[ja]&nbsp;<a lang="ja" hreflang="ja" href="/licenses/fdl-1.3.ja.html">日本語</a> &nbsp;</span>
-<span dir="ltr">[pt-br]&nbsp;<a lang="pt-br" hreflang="pt-br" href="/licenses/fdl-1.3.pt-br.html">português</a> &nbsp;</span>
-<span dir="ltr">[ru]&nbsp;<a lang="ru" hreflang="ru" href="/licenses/fdl-1.3.ru.html">русский</a> &nbsp;</span>
-<span dir="ltr">[tr]&nbsp;<a lang="tr" hreflang="tr" href="/licenses/fdl-1.3.tr.html">Türkçe</a> &nbsp;</span>
-<span dir="ltr">[uk]&nbsp;<a lang="uk" hreflang="uk" href="/licenses/fdl-1.3.uk.html">українська</a> &nbsp;</span>
-<span dir="ltr">[zh-cn]&nbsp;<a lang="zh-cn" hreflang="zh-cn" href="/licenses/fdl-1.3.zh-cn.html">简体中文</a> &nbsp;</span>
-<span dir="ltr">[zh-tw]&nbsp;<a lang="zh-tw" hreflang="zh-tw" href="/licenses/fdl-1.3.zh-tw.html">繁體中文</a> &nbsp;</span>
-</p>
-</div>
- </div>
-</div>
-
-<div id="mission-statement" role="complementary">
- <div class="backtotop">
-  <hr class="no-display" />
-  <a href="#header"><span>BACK TO TOP </span>&#9650;</a>
- </div>
-<div style="clear: both"></div>
-<blockquote>
-<p style="direction:ltr; text-align:left"><a href="//www.fsf.org"><img id="fsfbanner"
-src="/graphics/fsf-logo-notext-small.png" alt="&nbsp;[FSF logo]&nbsp;"
-width="75" height="25" /></a><strong>
-&ldquo;The Free Software Foundation (FSF) is a nonprofit with a worldwide
-mission to promote computer user freedom. We defend the rights of all
-software users.&rdquo;</strong></p>
-</blockquote>
-
-<div id="support-the-fsf" class="button">
- <a class="join" href="//www.fsf.org/associate/support_freedom?referrer=4052">JOIN</a>
- <a class="donate" href="//donate.fsf.org/">DONATE</a>
- <a class="shop" href="//shop.fsf.org/">SHOP</a>
-</div>
-</div>
-<!-- end server/footer-text.html -->
-
-
-<div id="footer" role="contentinfo">
-<div class="unprintable">
-
-<p>Please send general FSF &amp; GNU inquiries to
-<a href="mailto:gnu@gnu.org">&lt;gnu@gnu.org&gt;</a>.
-There are also <a href="/contact/">other ways to contact</a>
-the FSF.  Broken links and other corrections or suggestions can be sent
-to <a href="mailto:webmasters@gnu.org">&lt;webmasters@gnu.org&gt;</a>.</p>
-
-<p><!-- TRANSLATORS: Ignore the original text in this paragraph,
-        replace it with the translation of these two:
-
-        We work hard and do our best to provide accurate, good quality
-        translations.  However, we are not exempt from imperfection.
-        Please send your comments and general suggestions in this regard
-        to <a href="mailto:web-translators@gnu.org">
-        &lt;web-translators@gnu.org&gt;</a>.</p>
-
-        <p>For information on coordinating and contributing translations of
-        our web pages, see <a
-        href="/server/standards/README.translations.html">Translations
-        README</a>. -->
-Please see the <a
-href="/server/standards/README.translations.html">Translations
-README</a> for information on coordinating and contributing translations
-of this article.</p>
-</div>
-
-<p>Copyright notice above.</p>
-
-<p>
-Everyone is permitted to copy and distribute verbatim copies of this license
-document, but changing it is not allowed.
-</p>
-
-<!-- start of server/bottom-notes.html -->
-<div id="bottom-notes" class="unprintable">
-<p><a href="//www.fsf.org/about/dmca-notice">Copyright Infringement Notification</a></p>
-<div id="generic">
-
-
-</div>
-</div>
-<!-- end of server/bottom-notes.html -->
-
-
-<p class="unprintable">Updated:
-<!-- timestamp start -->
-$Date: 2023/11/30 09:46:01 $
-<!-- timestamp end -->
-</p>
-</div>
-</div><!-- for class="inner", starts in the banner include -->
-</body>
-</html>

--- a/licenses-generator/src/main/resources/offline-license-mirror/www.gnu.org/licenses/gpl-1.0
+++ b/licenses-generator/src/main/resources/offline-license-mirror/www.gnu.org/licenses/gpl-1.0
@@ -1,199 +1,10 @@
-<!DOCTYPE html>
-<html xmlns="http://www.w3.org/1999/xhtml" xml:lang="en" lang="en">
-<head>
-<meta http-equiv="content-type" content="text/html; charset=utf-8" />
-<link rel="author" href="mailto:webmasters@gnu.org" />
-<link rel="icon" type="image/png" href="/graphics/gnu-head-mini.png" />
-<meta name="ICBM" content="42.355469,-71.058627" />
-<link rel="stylesheet" type="text/css" href="/layout.min.css" media="screen" />
-<link rel="stylesheet" type="text/css" href="/print.min.css" media="print" />
 
-
-
-<!-- Parent-Version: 1.98 -->
-<!-- This page is derived from /server/standards/boilerplate.html -->
-<title>GNU General Public License v1.0 - GNU Project - Free Software Foundation</title>
-<!-- begin translist file -->
-
-<link rel="alternate" type="text/html" href="/licenses/old-licenses/gpl-1.0.html" hreflang="x-default" />
-<link rel="alternate" type="text/html" lang="en" hreflang="en" href="/licenses/old-licenses/gpl-1.0.en.html" title="English" />
-<link rel="alternate" type="text/html" lang="de" hreflang="de" href="/licenses/old-licenses/gpl-1.0.de.html" title="Deutsch" />
-<link rel="alternate" type="text/html" lang="fr" hreflang="fr" href="/licenses/old-licenses/gpl-1.0.fr.html" title="français" />
-<link rel="alternate" type="text/html" lang="ja" hreflang="ja" href="/licenses/old-licenses/gpl-1.0.ja.html" title="日本語" />
-<link rel="alternate" type="text/html" lang="pt-br" hreflang="pt-br" href="/licenses/old-licenses/gpl-1.0.pt-br.html" title="português" />
-<link rel="alternate" type="text/html" lang="ru" hreflang="ru" href="/licenses/old-licenses/gpl-1.0.ru.html" title="русский" />
-<link rel="alternate" type="text/html" lang="uk" hreflang="uk" href="/licenses/old-licenses/gpl-1.0.uk.html" title="українська" />
-<link rel="alternate" type="text/html" lang="zh-cn" hreflang="zh-cn" href="/licenses/old-licenses/gpl-1.0.zh-cn.html" title="简体中文" />
-<!-- end translist file -->
-
-<!-- start of server/banner.html -->
-<!-- start of head-include-2.html -->
-<meta name="viewport" content="width=device-width, initial-scale=1" />
-<!-- end of head-include-2.html -->
-
-</head>
-<body>
-<div class="inner">
-<!-- start of server/body-include-1.html -->
-<div id="top">
-<a class="skip" href="#content"><b>Skip to main text</b></a>
-</div>
-
-<div id="fsf-frame" role="complementary">
-<form id="fssbox" action="https://my.fsf.org/civicrm/profile/create?reset=1&amp;gid=31"
-      method="post">
- <div>
-  <input name="postURL" type="hidden" value="" />
-  <input type="hidden" name="group[25]" value="1" />
-  <input name="cancelURL" type="hidden" value="https://crm.fsf.org/civicrm/profile?reset=1&amp;gid=31" />
-  <input name="_qf_default" type="hidden" value="Edit:cancel" />
-  <label for="frmEmail">
-   <a href="//www.fsf.org/fss">Free Software Supporter</a>:
-  </label>
-  <input type="text" id="frmEmail" name="email-Primary" size="18" maxlength="80"
-         value="email address" onfocus="this.value=''"/>
-  <input type="submit" name="_qf_Edit_next" value="Sign up" />
- </div>
-</form>
-
-<div id="join-fsf" class="button"><a
-href="https://www.fsf.org/associate/support_freedom?referrer=4052">JOIN&nbsp;THE&nbsp;FSF</a>
-</div>
-</div>
-
-<div id="header" role="banner">
-<p id="gnu-banner">
- <a href="/">
- <img src="/graphics/heckert_gnu.transp.small.png" height="48" width="49"
-      alt="&nbsp;[A GNU head]&nbsp;" /><strong>GNU</strong> <span
- class="hide">Operating System</span></a><br />
- <small id="fsf-support">Supported by the
- <a href="#mission-statement">Free Software Foundation</a></small>
-</p>
-
-<div id="switches">
-<!-- begin search button -->
- <div  id="search-button" class="switch">
-  <a href="//www.gnu.org/cgi-bin/estseek.cgi">
-  <img id="search-icon" height="30" width="30"
-       src="/graphics/icons/search.png"
-       alt="&nbsp;[Search www.gnu.org]&nbsp;" /></a>
- </div>
-<!-- end search button -->
-
- <div id="language-button" class="switch">
-  <a href="#language-container">
-  <img id="language-icon" height="30" width="37"
-       src="/graphics/icons/translations.png"
-       alt="&nbsp;[Other languages]&nbsp;" /></a>
- </div>
-
-</div>
-</div>
-<!-- end of server/body-include-1.html -->
-
-<!-- start of server/body-include-2 -->
-
-
-<div style="clear: both"></div>
-
-<div id="navigation" role="navigation">
- <a id="more-links" href="#navigation" title="More...">
-   <span>Site navigation</span></a>
- <a id="less-links" href="#content"><b>Skip</b></a>
- <ul>
-
-   <li id="tabAboutGNU"><a href="/gnu/gnu.html">ABOUT&nbsp;GNU</a></li>
-
-
-  <li id="tabPhilosophy"><a href="/philosophy/philosophy.html">PHILOSOPHY</a></li>
-
-
-  <li id="tabLicenses" class="active">
-     <span class='no-display'>=</span> 
-    <a href="/licenses/licenses.html">LICENSES</a>
-    <span class="gnun-split"></span>
-     <span class='no-display'>=</span> 
-  </li>
-
-
-  <li id="tabEducation"><a href="/education/education.html">EDUCATION</a></li>
-
-
-  <li id="tabSoftware"><a href="/software/software.html">SOFTWARE</a></li>
-
-
-  <li id="tabDistros"><a href="/distros/distros.html">DISTROS</a></li>
-
-
-  <li id="tabDoc"><a href="/doc/doc.html">DOCS</a></li>
-
-
-  <li id="tabMalware"><a href="/proprietary/proprietary.html">MALWARE</a></li>
-
-
-  <li id="tabHelp"><a href="/help/help.html">HELP&nbsp;GNU</a></li>
-
-
-  <li id="tabAV"><a href="/audio-video/audio-video.html">AUDIO&nbsp;&amp;&nbsp;VIDEO</a></li>
-
-
-  <li id="tabArt"><a href="/graphics/graphics.html">GNU&nbsp;ART</a></li>
-
-
-  <li id="tabFun"><a href="/fun/humor.html">FUN</a></li>
-
-
-  <li id="tabPeople"><a href="/people/people.html">GNU'S&nbsp;WHO?</a></li>
-
-  <li><a href="//directory.fsf.org">SOFTWARE&nbsp;DIRECTORY</a></li>
-  <li><a href="https://h-node.org/">HARDWARE</a></li>
-  <li><a href="/server/sitemap.html">SITEMAP</a></li>
- </ul>
- <div style="clear: both"></div>
-</div><!-- /"navigation -->
-<!-- end of server/body-include-2 -->
-
-<div id="content" role="main">
-<!-- end of server/banner.html -->
-
-<div class="reduced-width">
-<h2>GNU General Public License, version&nbsp;1</h2>
-
-<p class="button" style="margin: 2em 1.5em">
-  <b><a href="#license-text">Skip to license text</a></b></p>
-
-<ul>
-  <li><a href="/licenses/gpl.html">The latest version of the GPL,
-      version 3</a></li>
-  <li><a href="/licenses/gpl-violation.html">What to do if you see a
-       possible GPL violation</a></li>
-  <li>The GNU General Public License version 1 (GPLv1) in other formats:
-       <a href="/licenses/old-licenses/gpl-1.0.txt">plain text format</a>,
-       <a href="/licenses/old-licenses/gpl-1.0-standalone.html">standalone HTML</a>,
-       <a href="/licenses/old-licenses/gpl-1.0.md">Markdown</a>, 
-       <a href="/licenses/old-licenses/gpl-1.0.odt">ODF</a>, 
-       <a href="/licenses/old-licenses/gpl-1.0.rtf">RTF</a>, 
-       <a href="/licenses/old-licenses/gpl-1.0.dbk">Docbook</a>, 
-       <a href="/licenses/old-licenses/gpl-1.0.tex">LaTeX</a>, 
-       <a href="/licenses/old-licenses/gpl-1.0.texi">Texinfo</a>
-  </li>
-  <li><a href="/licenses/old-licenses/old-licenses.html#GPL">Old versions
-      of the GPL</a></li>
-</ul>
-
-<hr class="thin" />
-
-<!-- The license text is in English and appears broken in RTL as
-     Arabic, Farsi, etc.  Explicitly set the direction to override the
-     one defined in the translation. -->
-<div id="license-text" dir="ltr">
-<pre>
                     GNU GENERAL PUBLIC LICENSE
                      Version 1, February 1989
 
  Copyright (C) 1989 Free Software Foundation, Inc.
- &lt;<a href="https://fsf.org/">https://fsf.org/</a>&gt;
+                    <https://fsf.org/>
+
  Everyone is permitted to copy and distribute verbatim copies
  of this license document, but changing it is not allowed.
 
@@ -237,7 +48,7 @@ authors' reputations.
 
   The precise terms and conditions for copying, distribution and
 modification follow.
-
+
                     GNU GENERAL PUBLIC LICENSE
    TERMS AND CONDITIONS FOR COPYING, DISTRIBUTION AND MODIFICATION
 
@@ -288,7 +99,7 @@ it, and copy and distribute such modifications under the terms of Paragraph
 Mere aggregation of another independent work with the Program (or its
 derivative) on a volume of a storage or distribution medium does not bring
 the other work under the scope of these terms.
-
+
   3. You may copy and distribute the Program (or a portion or derivative of
 it, under Paragraph 2) in object code or executable form under the terms of
 Paragraphs 1 and 2 above provided that you also do one of the following:
@@ -334,7 +145,7 @@ Program), the recipient automatically receives a license from the original
 licensor to copy, distribute or modify the Program subject to these
 terms and conditions.  You may not impose any further restrictions on the
 recipients' exercise of the rights granted herein.
-
+
   7. The Free Software Foundation may publish revised and/or new versions
 of the General Public License from time to time.  Such new versions will
 be similar in spirit to the present version, but may differ in detail to
@@ -379,7 +190,7 @@ PROGRAMS), EVEN IF SUCH HOLDER OR OTHER PARTY HAS BEEN ADVISED OF THE
 POSSIBILITY OF SUCH DAMAGES.
 
                      END OF TERMS AND CONDITIONS
-
+
         Appendix: How to Apply These Terms to Your New Programs
 
   If you develop a new program, and you want it to be of the greatest
@@ -392,8 +203,8 @@ attach them to the start of each source file to most effectively convey
 the exclusion of warranty; and each file should have at least the
 "copyright" line and a pointer to where the full notice is found.
 
-    &lt;one line to give the program's name and a brief idea of what it does.&gt;
-    Copyright (C) 19yy  &lt;name of author&gt;
+    <one line to give the program's name and a brief idea of what it does.>
+    Copyright (C) 19yy  <name of author>
 
     This program is free software; you can redistribute it and/or modify
     it under the terms of the GNU General Public License as published by
@@ -406,8 +217,8 @@ the exclusion of warranty; and each file should have at least the
     GNU General Public License for more details.
 
     You should have received a copy of the GNU General Public License
-    along with this program; if not, see
-    &lt;<a href="https://www.gnu.org/licenses/">https://www.gnu.org/licenses/</a>&gt;.
+    along with this program; if not, see <https://www.gnu.org/licenses/>.
+
 
 Also add information on how to contact you by electronic and paper mail.
 
@@ -433,129 +244,7 @@ necessary.  Here a sample; alter the names:
   program `Gnomovision' (a program to direct compilers to make passes
   at assemblers) written by James Hacker.
 
-  &lt;signature of Moe Ghoul&gt;, 1 April 1989
+  <signature of Moe Ghoul>, 1 April 1989
   Moe Ghoul, President of Vice
 
 That's all there is to it!
-</pre>
-
-</div>
-</div>
-
-</div><!-- for id="content", starts in the include above -->
-
-              <!-- begin server/footer-text.html -->
-
-
-
-
-
-<div style="clear:both"></div>
-
-
-<div id="language-container">
- <div class="backtotop">
-  <hr class="no-display" />
-  <a href="#top"><b>&#9650;</b></a>
- </div>
- <div id="languages" class="rounded-corners">
-  <div class="button">
-   <a href="#top" class="close"><span>BACK TO TOP</span></a>
-  </div>
-  <div id="set-language" class="button">
-   <span class="gnun-split"></span>
-   <a href="/server/select-language.html?callback=/licenses/old-licenses/gpl-1.0" rel="nofollow">
-   Set language
-   <span class="gnun-split"></span>
-   </a>
-  </div>
-  <p>Available for this page:</p>
-  <div id="translations">
-<p>
-<span dir="ltr" class="original">[en]&nbsp;<a lang="en" hreflang="en" href="/licenses/old-licenses/gpl-1.0.en.html">English</a> &nbsp;</span>
-<span dir="ltr">[de]&nbsp;<a lang="de" hreflang="de" href="/licenses/old-licenses/gpl-1.0.de.html">Deutsch</a> &nbsp;</span>
-<span dir="ltr">[fr]&nbsp;<a lang="fr" hreflang="fr" href="/licenses/old-licenses/gpl-1.0.fr.html">français</a> &nbsp;</span>
-<span dir="ltr">[ja]&nbsp;<a lang="ja" hreflang="ja" href="/licenses/old-licenses/gpl-1.0.ja.html">日本語</a> &nbsp;</span>
-<span dir="ltr">[pt-br]&nbsp;<a lang="pt-br" hreflang="pt-br" href="/licenses/old-licenses/gpl-1.0.pt-br.html">português</a> &nbsp;</span>
-<span dir="ltr">[ru]&nbsp;<a lang="ru" hreflang="ru" href="/licenses/old-licenses/gpl-1.0.ru.html">русский</a> &nbsp;</span>
-<span dir="ltr">[uk]&nbsp;<a lang="uk" hreflang="uk" href="/licenses/old-licenses/gpl-1.0.uk.html">українська</a> &nbsp;</span>
-<span dir="ltr">[zh-cn]&nbsp;<a lang="zh-cn" hreflang="zh-cn" href="/licenses/old-licenses/gpl-1.0.zh-cn.html">简体中文</a> &nbsp;</span>
-</p>
-</div>
- </div>
-</div>
-
-<div id="mission-statement" role="complementary">
- <div class="backtotop">
-  <hr class="no-display" />
-  <a href="#header"><span>BACK TO TOP </span>&#9650;</a>
- </div>
-<div style="clear: both"></div>
-<blockquote>
-<p style="direction:ltr; text-align:left"><a href="//www.fsf.org"><img id="fsfbanner"
-src="/graphics/fsf-logo-notext-small.png" alt="&nbsp;[FSF logo]&nbsp;"
-width="75" height="25" /></a><strong>
-&ldquo;The Free Software Foundation (FSF) is a nonprofit with a worldwide
-mission to promote computer user freedom. We defend the rights of all
-software users.&rdquo;</strong></p>
-</blockquote>
-
-<div id="support-the-fsf" class="button">
- <a class="join" href="//www.fsf.org/associate/support_freedom?referrer=4052">JOIN</a>
- <a class="donate" href="//donate.fsf.org/">DONATE</a>
- <a class="shop" href="//shop.fsf.org/">SHOP</a>
-</div>
-</div>
-<!-- end server/footer-text.html -->
-
-
-<div id="footer" role="contentinfo">
-<div class="unprintable">
-
-<p>Please send general FSF &amp; GNU inquiries to
-<a href="mailto:gnu@gnu.org">&lt;gnu@gnu.org&gt;</a>.
-There are also <a href="/contact/">other ways to contact</a>
-the FSF.  Broken links and other corrections or suggestions can be sent
-to <a href="mailto:webmasters@gnu.org">&lt;webmasters@gnu.org&gt;</a>.</p>
-
-<p><!-- TRANSLATORS: Ignore the original text in this paragraph,
-        replace it with the translation of these two:
-
-        We work hard and do our best to provide accurate, good quality
-        translations.  However, we are not exempt from imperfection.
-        Please send your comments and general suggestions in this regard
-        to <a href="mailto:web-translators@gnu.org">
-        &lt;web-translators@gnu.org&gt;</a>.</p>
-
-        <p>For information on coordinating and contributing translations of
-        our web pages, see <a
-        href="/server/standards/README.translations.html">Translations
-        README</a>. -->
-Please see the <a
-href="/server/standards/README.translations.html">Translations
-README</a> for information on coordinating and contributing translations
-of this article.</p>
-</div>
-
-<p>Copyright notice above.</p>
-
-<!-- start of server/bottom-notes.html -->
-<div id="bottom-notes" class="unprintable">
-<p><a href="//www.fsf.org/about/dmca-notice">Copyright Infringement Notification</a></p>
-<div id="generic">
-
-
-</div>
-</div>
-<!-- end of server/bottom-notes.html -->
-
-
-<p class="unprintable">Updated:
-<!-- timestamp start -->
-$Date: 2023/11/30 09:46:01 $
-<!-- timestamp end -->
-</p>
-</div>
-</div><!-- for class="inner", starts in the banner include -->
-</body>
-</html>

--- a/licenses-generator/src/main/resources/offline-license-mirror/www.gnu.org/licenses/gpl-2.0
+++ b/licenses-generator/src/main/resources/offline-license-mirror/www.gnu.org/licenses/gpl-2.0
@@ -1,227 +1,13 @@
-<!DOCTYPE html>
-<html xmlns="http://www.w3.org/1999/xhtml" xml:lang="en" lang="en">
-<head>
-<meta http-equiv="content-type" content="text/html; charset=utf-8" />
-<link rel="author" href="mailto:webmasters@gnu.org" />
-<link rel="icon" type="image/png" href="/graphics/gnu-head-mini.png" />
-<meta name="ICBM" content="42.355469,-71.058627" />
-<link rel="stylesheet" type="text/css" href="/layout.min.css" media="screen" />
-<link rel="stylesheet" type="text/css" href="/print.min.css" media="print" />
+                    GNU GENERAL PUBLIC LICENSE
+                       Version 2, June 1991
 
+ Copyright (C) 1989, 1991 Free Software Foundation, Inc.,
+ <https://fsf.org/>
+ Everyone is permitted to copy and distribute verbatim copies
+ of this license document, but changing it is not allowed.
 
+                            Preamble
 
-<!-- Parent-Version: 1.98 -->
-<!-- This page is derived from /server/standards/boilerplate.html -->
-<title>GNU General Public License v2.0 - GNU Project - Free Software Foundation</title>
-<link rel="alternate" type="application/rdf+xml" href="gpl-2.0.rdf" /> 
-<!-- begin translist file -->
-
-<link rel="alternate" type="text/html" href="/licenses/old-licenses/gpl-2.0.html" hreflang="x-default" />
-<link rel="alternate" type="text/html" lang="en" hreflang="en" href="/licenses/old-licenses/gpl-2.0.en.html" title="English" />
-<link rel="alternate" type="text/html" lang="cs" hreflang="cs" href="/licenses/old-licenses/gpl-2.0.cs.html" title="čeština" />
-<link rel="alternate" type="text/html" lang="de" hreflang="de" href="/licenses/old-licenses/gpl-2.0.de.html" title="Deutsch" />
-<link rel="alternate" type="text/html" lang="fr" hreflang="fr" href="/licenses/old-licenses/gpl-2.0.fr.html" title="français" />
-<link rel="alternate" type="text/html" lang="ja" hreflang="ja" href="/licenses/old-licenses/gpl-2.0.ja.html" title="日本語" />
-<link rel="alternate" type="text/html" lang="pt-br" hreflang="pt-br" href="/licenses/old-licenses/gpl-2.0.pt-br.html" title="português" />
-<link rel="alternate" type="text/html" lang="ru" hreflang="ru" href="/licenses/old-licenses/gpl-2.0.ru.html" title="русский" />
-<link rel="alternate" type="text/html" lang="uk" hreflang="uk" href="/licenses/old-licenses/gpl-2.0.uk.html" title="українська" />
-<link rel="alternate" type="text/html" lang="zh-cn" hreflang="zh-cn" href="/licenses/old-licenses/gpl-2.0.zh-cn.html" title="简体中文" />
-<!-- end translist file -->
-
-<!-- start of server/banner.html -->
-<!-- start of head-include-2.html -->
-<meta name="viewport" content="width=device-width, initial-scale=1" />
-<!-- end of head-include-2.html -->
-
-</head>
-<body>
-<div class="inner">
-<!-- start of server/body-include-1.html -->
-<div id="top">
-<a class="skip" href="#content"><b>Skip to main text</b></a>
-</div>
-
-<div id="fsf-frame" role="complementary">
-<form id="fssbox" action="https://my.fsf.org/civicrm/profile/create?reset=1&amp;gid=31"
-      method="post">
- <div>
-  <input name="postURL" type="hidden" value="" />
-  <input type="hidden" name="group[25]" value="1" />
-  <input name="cancelURL" type="hidden" value="https://crm.fsf.org/civicrm/profile?reset=1&amp;gid=31" />
-  <input name="_qf_default" type="hidden" value="Edit:cancel" />
-  <label for="frmEmail">
-   <a href="//www.fsf.org/fss">Free Software Supporter</a>:
-  </label>
-  <input type="text" id="frmEmail" name="email-Primary" size="18" maxlength="80"
-         value="email address" onfocus="this.value=''"/>
-  <input type="submit" name="_qf_Edit_next" value="Sign up" />
- </div>
-</form>
-
-<div id="join-fsf" class="button"><a
-href="https://www.fsf.org/associate/support_freedom?referrer=4052">JOIN&nbsp;THE&nbsp;FSF</a>
-</div>
-</div>
-
-<div id="header" role="banner">
-<p id="gnu-banner">
- <a href="/">
- <img src="/graphics/heckert_gnu.transp.small.png" height="48" width="49"
-      alt="&nbsp;[A GNU head]&nbsp;" /><strong>GNU</strong> <span
- class="hide">Operating System</span></a><br />
- <small id="fsf-support">Supported by the
- <a href="#mission-statement">Free Software Foundation</a></small>
-</p>
-
-<div id="switches">
-<!-- begin search button -->
- <div  id="search-button" class="switch">
-  <a href="//www.gnu.org/cgi-bin/estseek.cgi">
-  <img id="search-icon" height="30" width="30"
-       src="/graphics/icons/search.png"
-       alt="&nbsp;[Search www.gnu.org]&nbsp;" /></a>
- </div>
-<!-- end search button -->
-
- <div id="language-button" class="switch">
-  <a href="#language-container">
-  <img id="language-icon" height="30" width="37"
-       src="/graphics/icons/translations.png"
-       alt="&nbsp;[Other languages]&nbsp;" /></a>
- </div>
-
-</div>
-</div>
-<!-- end of server/body-include-1.html -->
-
-<!-- start of server/body-include-2 -->
-
-
-<div style="clear: both"></div>
-
-<div id="navigation" role="navigation">
- <a id="more-links" href="#navigation" title="More...">
-   <span>Site navigation</span></a>
- <a id="less-links" href="#content"><b>Skip</b></a>
- <ul>
-
-   <li id="tabAboutGNU"><a href="/gnu/gnu.html">ABOUT&nbsp;GNU</a></li>
-
-
-  <li id="tabPhilosophy"><a href="/philosophy/philosophy.html">PHILOSOPHY</a></li>
-
-
-  <li id="tabLicenses" class="active">
-     <span class='no-display'>=</span> 
-    <a href="/licenses/licenses.html">LICENSES</a>
-    <span class="gnun-split"></span>
-     <span class='no-display'>=</span> 
-  </li>
-
-
-  <li id="tabEducation"><a href="/education/education.html">EDUCATION</a></li>
-
-
-  <li id="tabSoftware"><a href="/software/software.html">SOFTWARE</a></li>
-
-
-  <li id="tabDistros"><a href="/distros/distros.html">DISTROS</a></li>
-
-
-  <li id="tabDoc"><a href="/doc/doc.html">DOCS</a></li>
-
-
-  <li id="tabMalware"><a href="/proprietary/proprietary.html">MALWARE</a></li>
-
-
-  <li id="tabHelp"><a href="/help/help.html">HELP&nbsp;GNU</a></li>
-
-
-  <li id="tabAV"><a href="/audio-video/audio-video.html">AUDIO&nbsp;&amp;&nbsp;VIDEO</a></li>
-
-
-  <li id="tabArt"><a href="/graphics/graphics.html">GNU&nbsp;ART</a></li>
-
-
-  <li id="tabFun"><a href="/fun/humor.html">FUN</a></li>
-
-
-  <li id="tabPeople"><a href="/people/people.html">GNU'S&nbsp;WHO?</a></li>
-
-  <li><a href="//directory.fsf.org">SOFTWARE&nbsp;DIRECTORY</a></li>
-  <li><a href="https://h-node.org/">HARDWARE</a></li>
-  <li><a href="/server/sitemap.html">SITEMAP</a></li>
- </ul>
- <div style="clear: both"></div>
-</div><!-- /"navigation -->
-<!-- end of server/body-include-2 -->
-
-<div id="content" role="main">
-<!-- end of server/banner.html -->
-
-<div class="reduced-width">
-<h2>GNU General Public License, version&nbsp;2</h2>
-
-<p class="button" style="margin: 2em 1.5em">
-  <b><a href="#SEC1">Skip to license text</a></b></p>
-
-<ul>
-  <li><a href="/licenses/gpl.html">The latest version of the GPL, version 3</a></li>
-  <li><a href="/licenses/gpl-violation.html">What to do if you see a possible
-    GPL violation</a></li>
-  <li><a href="/licenses/old-licenses/gpl-2.0-translations.html">Translations
-    of GPLv2</a></li>
-  <li><a href="/licenses/old-licenses/gpl-2.0-faq.html">GPLv2 Frequently Asked
-    Questions</a></li>
-  <li>The GNU General Public License version 2 (GPLv2) in other formats: <a
-    href="/licenses/old-licenses/gpl-2.0.txt">plain text</a>, <a
-    href="/licenses/old-licenses/gpl-2.0.texi">Texinfo</a>, <a
-    href="/licenses/old-licenses/gpl-2.0.tex">LaTeX</a>, <a 
-    href="/licenses/old-licenses/gpl-2.0-standalone.html">standalone HTML</a>,  <a 
-    href="/licenses/old-licenses/gpl-2.0.dbk">Docbook</a>, <a 
-    href="/licenses/old-licenses/gpl-2.0.md">Markdown</a>,  <a 
-    href="/licenses/old-licenses/gpl-2.0.odt">ODF</a>, <a 
-    href="/licenses/old-licenses/gpl-2.0.rtf">RTF</a></li>
-</ul>
-
-<hr class="thin" />
-
-<h3>Table of Contents</h3>
-<ul>
-  <li><a id="TOC1" href="#SEC1">GNU GENERAL PUBLIC LICENSE
-    <!--TRANSLATORS: Don't translate the license; copy msgid's verbatim!--></a> 
-    <ul>
-      <li><a id="TOC2" href="#SEC2">Preamble</a></li>
-      <li><a id="TOC3" href="#SEC3">TERMS AND CONDITIONS FOR COPYING,
-        DISTRIBUTION AND MODIFICATION</a></li>
-      <li><a id="TOC4" href="#SEC4">How to Apply These Terms to Your New
-        Programs</a></li>
-    </ul>
-  </li>
-</ul>
-
-<hr class="thin" />
-
-<!-- The license text is in English and appears broken in RTL as
-Arabic, Farsi, etc. Explicitly set the direction to override the
-one defined in the translation. -->
-<div dir="ltr">
-<h3 id="SEC1">GNU GENERAL PUBLIC LICENSE</h3>
-<p>
-Version 2, June 1991
-</p>
-
-<pre>
-Copyright (C) 1989, 1991 Free Software Foundation, Inc.  
-&lt;<a href="https://fsf.org/">https://fsf.org/</a>&gt;
-Everyone is permitted to copy and distribute verbatim copies
-of this license document, but changing it is not allowed.
-</pre>
-
-<span id="SEC2"></span>
-<h4 id="preamble">Preamble</h4>
-
-<p>
   The licenses for most software are designed to take away your
 freedom to share and change it.  By contrast, the GNU General Public
 License is intended to guarantee your freedom to share and change free
@@ -231,66 +17,49 @@ Foundation's software and to any other program whose authors commit to
 using it.  (Some other Free Software Foundation software is covered by
 the GNU Lesser General Public License instead.)  You can apply it to
 your programs, too.
-</p>
 
-<p>
   When we speak of free software, we are referring to freedom, not
 price.  Our General Public Licenses are designed to make sure that you
 have the freedom to distribute copies of free software (and charge for
 this service if you wish), that you receive source code or can get it
 if you want it, that you can change the software or use pieces of it
 in new free programs; and that you know you can do these things.
-</p>
 
-<p>
   To protect your rights, we need to make restrictions that forbid
 anyone to deny you these rights or to ask you to surrender the rights.
 These restrictions translate to certain responsibilities for you if you
 distribute copies of the software, or if you modify it.
-</p>
 
-<p>
   For example, if you distribute copies of such a program, whether
 gratis or for a fee, you must give the recipients all the rights that
 you have.  You must make sure that they, too, receive or can get the
 source code.  And you must show them these terms so they know their
 rights.
-</p>
 
-<p>
   We protect your rights with two steps: (1) copyright the software, and
 (2) offer you this license which gives you legal permission to copy,
 distribute and/or modify the software.
-</p>
 
-<p>
   Also, for each author's protection and ours, we want to make certain
 that everyone understands that there is no warranty for this free
 software.  If the software is modified by someone else and passed on, we
 want its recipients to know that what they have is not the original, so
 that any problems introduced by others will not reflect on the original
 authors' reputations.
-</p>
 
-<p>
   Finally, any free program is threatened constantly by software
 patents.  We wish to avoid the danger that redistributors of a free
 program will individually obtain patent licenses, in effect making the
 program proprietary.  To prevent this, we have made it clear that any
 patent must be licensed for everyone's free use or not licensed at all.
-</p>
 
-<p>
   The precise terms and conditions for copying, distribution and
 modification follow.
-</p>
 
-<span id="SEC3"></span>
-<h4 id="terms">TERMS AND CONDITIONS FOR COPYING, DISTRIBUTION AND MODIFICATION</h4>
+                    GNU GENERAL PUBLIC LICENSE
+   TERMS AND CONDITIONS FOR COPYING, DISTRIBUTION AND MODIFICATION
 
-<p id="section0">
-<strong>0.</strong>
- This License applies to any program or other work which contains
+  0. This License applies to any program or other work which contains
 a notice placed by the copyright holder saying it may be distributed
 under the terms of this General Public License.  The "Program", below,
 refers to any such program or work, and a "work based on the Program"
@@ -299,73 +68,49 @@ that is to say, a work containing the Program or a portion of it,
 either verbatim or with modifications and/or translated into another
 language.  (Hereinafter, translation is included without limitation in
 the term "modification".)  Each licensee is addressed as "you".
-</p>
 
-<p>
 Activities other than copying, distribution and modification are not
 covered by this License; they are outside its scope.  The act of
 running the Program is not restricted, and the output from the Program
 is covered only if its contents constitute a work based on the
 Program (independent of having been made by running the Program).
 Whether that is true depends on what the Program does.
-</p>
 
-<p id="section1">
-<strong>1.</strong>
- You may copy and distribute verbatim copies of the Program's
+  1. You may copy and distribute verbatim copies of the Program's
 source code as you receive it, in any medium, provided that you
 conspicuously and appropriately publish on each copy an appropriate
 copyright notice and disclaimer of warranty; keep intact all the
 notices that refer to this License and to the absence of any warranty;
 and give any other recipients of the Program a copy of this License
 along with the Program.
-</p>
 
-<p>
 You may charge a fee for the physical act of transferring a copy, and
 you may at your option offer warranty protection in exchange for a fee.
-</p>
 
-<p id="section2">
-<strong>2.</strong>
- You may modify your copy or copies of the Program or any portion
+  2. You may modify your copy or copies of the Program or any portion
 of it, thus forming a work based on the Program, and copy and
 distribute such modifications or work under the terms of Section 1
 above, provided that you also meet all of these conditions:
-</p>
 
-<dl>
-  <dt></dt>
-    <dd>
-      <strong>a)</strong>
-      You must cause the modified files to carry prominent notices
-      stating that you changed the files and the date of any change.
-    </dd>
-  <dt></dt>
-    <dd>
-      <strong>b)</strong>
-      You must cause any work that you distribute or publish, that in
-      whole or in part contains or is derived from the Program or any
-      part thereof, to be licensed as a whole at no charge to all third
-      parties under the terms of this License.
-    </dd>
-  <dt></dt>
-    <dd>
-      <strong>c)</strong>
-      If the modified program normally reads commands interactively
-      when run, you must cause it, when started running for such
-      interactive use in the most ordinary way, to print or display an
-      announcement including an appropriate copyright notice and a
-      notice that there is no warranty (or else, saying that you provide
-      a warranty) and that users may redistribute the program under
-      these conditions, and telling the user how to view a copy of this
-      License.  (Exception: if the Program itself is interactive but
-      does not normally print such an announcement, your work based on
-      the Program is not required to print an announcement.)
-    </dd>
-</dl>
+    a) You must cause the modified files to carry prominent notices
+    stating that you changed the files and the date of any change.
 
-<p>
+    b) You must cause any work that you distribute or publish, that in
+    whole or in part contains or is derived from the Program or any
+    part thereof, to be licensed as a whole at no charge to all third
+    parties under the terms of this License.
+
+    c) If the modified program normally reads commands interactively
+    when run, you must cause it, when started running for such
+    interactive use in the most ordinary way, to print or display an
+    announcement including an appropriate copyright notice and a
+    notice that there is no warranty (or else, saying that you provide
+    a warranty) and that users may redistribute the program under
+    these conditions, and telling the user how to view a copy of this
+    License.  (Exception: if the Program itself is interactive but
+    does not normally print such an announcement, your work based on
+    the Program is not required to print an announcement.)
+
 These requirements apply to the modified work as a whole.  If
 identifiable sections of that work are not derived from the Program,
 and can be reasonably considered independent and separate works in
@@ -375,62 +120,38 @@ distribute the same sections as part of a whole which is a work based
 on the Program, the distribution of the whole must be on the terms of
 this License, whose permissions for other licensees extend to the
 entire whole, and thus to each and every part regardless of who wrote it.
-</p>
 
-<p>
 Thus, it is not the intent of this section to claim rights or contest
 your rights to work written entirely by you; rather, the intent is to
 exercise the right to control the distribution of derivative or
 collective works based on the Program.
-</p>
 
-<p>
 In addition, mere aggregation of another work not based on the Program
 with the Program (or with a work based on the Program) on a volume of
 a storage or distribution medium does not bring the other work under
 the scope of this License.
-</p>
 
-<p id="section3">
-<strong>3.</strong>
- You may copy and distribute the Program (or a work based on it,
+  3. You may copy and distribute the Program (or a work based on it,
 under Section 2) in object code or executable form under the terms of
 Sections 1 and 2 above provided that you also do one of the following:
-</p>
 
-<!-- we use this doubled UL to get the sub-sections indented, -->
-<!-- while making the bullets as unobvious as possible. -->
+    a) Accompany it with the complete corresponding machine-readable
+    source code, which must be distributed under the terms of Sections
+    1 and 2 above on a medium customarily used for software interchange; or,
 
-<dl>
-  <dt></dt>
-    <dd>
-      <strong>a)</strong>
-      Accompany it with the complete corresponding machine-readable
-      source code, which must be distributed under the terms of Sections
-      1 and 2 above on a medium customarily used for software interchange; or,
-    </dd>
-  <dt></dt>
-    <dd>
-      <strong>b)</strong>
-      Accompany it with a written offer, valid for at least three
-      years, to give any third party, for a charge no more than your
-      cost of physically performing source distribution, a complete
-      machine-readable copy of the corresponding source code, to be
-      distributed under the terms of Sections 1 and 2 above on a medium
-      customarily used for software interchange; or,
-    </dd>
-  <dt></dt>
-    <dd>
-      <strong>c)</strong>
-      Accompany it with the information you received as to the offer
-      to distribute corresponding source code.  (This alternative is
-      allowed only for noncommercial distribution and only if you
-      received the program in object code or executable form with such
-      an offer, in accord with Subsection b above.)
-    </dd>
-</dl>
+    b) Accompany it with a written offer, valid for at least three
+    years, to give any third party, for a charge no more than your
+    cost of physically performing source distribution, a complete
+    machine-readable copy of the corresponding source code, to be
+    distributed under the terms of Sections 1 and 2 above on a medium
+    customarily used for software interchange; or,
 
-<p>
+    c) Accompany it with the information you received as to the offer
+    to distribute corresponding source code.  (This alternative is
+    allowed only for noncommercial distribution and only if you
+    received the program in object code or executable form with such
+    an offer, in accord with Subsection b above.)
+
 The source code for a work means the preferred form of the work for
 making modifications to it.  For an executable work, complete source
 code means all the source code for all modules it contains, plus any
@@ -441,30 +162,22 @@ anything that is normally distributed (in either source or binary
 form) with the major components (compiler, kernel, and so on) of the
 operating system on which the executable runs, unless that component
 itself accompanies the executable.
-</p>
 
-<p>
 If distribution of executable or object code is made by offering
 access to copy from a designated place, then offering equivalent
 access to copy the source code from the same place counts as
 distribution of the source code, even though third parties are not
 compelled to copy the source along with the object code.
-</p>
 
-<p id="section4">
-<strong>4.</strong>
- You may not copy, modify, sublicense, or distribute the Program
+  4. You may not copy, modify, sublicense, or distribute the Program
 except as expressly provided under this License.  Any attempt
 otherwise to copy, modify, sublicense or distribute the Program is
 void, and will automatically terminate your rights under this License.
 However, parties who have received copies, or rights, from you under
 this License will not have their licenses terminated so long as such
 parties remain in full compliance.
-</p>
 
-<p id="section5">
-<strong>5.</strong>
- You are not required to accept this License, since you have not
+  5. You are not required to accept this License, since you have not
 signed it.  However, nothing else grants you permission to modify or
 distribute the Program or its derivative works.  These actions are
 prohibited by law if you do not accept this License.  Therefore, by
@@ -472,22 +185,16 @@ modifying or distributing the Program (or any work based on the
 Program), you indicate your acceptance of this License to do so, and
 all its terms and conditions for copying, distributing or modifying
 the Program or works based on it.
-</p>
 
-<p id="section6">
-<strong>6.</strong>
- Each time you redistribute the Program (or any work based on the
+  6. Each time you redistribute the Program (or any work based on the
 Program), the recipient automatically receives a license from the
 original licensor to copy, distribute or modify the Program subject to
 these terms and conditions.  You may not impose any further
 restrictions on the recipients' exercise of the rights granted herein.
 You are not responsible for enforcing compliance by third parties to
 this License.
-</p>
 
-<p id="section7">
-<strong>7.</strong>
- If, as a consequence of a court judgment or allegation of patent
+  7. If, as a consequence of a court judgment or allegation of patent
 infringement or for any other reason (not limited to patent issues),
 conditions are imposed on you (whether by court order, agreement or
 otherwise) that contradict the conditions of this License, they do not
@@ -499,16 +206,12 @@ license would not permit royalty-free redistribution of the Program by
 all those who receive copies directly or indirectly through you, then
 the only way you could satisfy both it and this License would be to
 refrain entirely from distribution of the Program.
-</p>
 
-<p>
 If any portion of this section is held invalid or unenforceable under
 any particular circumstance, the balance of the section is intended to
 apply and the section as a whole is intended to apply in other
 circumstances.
-</p>
 
-<p>
 It is not the purpose of this section to induce you to infringe any
 patents or other property right claims or to contest validity of any
 such claims; this section has the sole purpose of protecting the
@@ -519,33 +222,23 @@ through that system in reliance on consistent application of that
 system; it is up to the author/donor to decide if he or she is willing
 to distribute software through any other system and a licensee cannot
 impose that choice.
-</p>
 
-<p>
 This section is intended to make thoroughly clear what is believed to
 be a consequence of the rest of this License.
-</p>
 
-<p id="section8">
-<strong>8.</strong>
- If the distribution and/or use of the Program is restricted in
+  8. If the distribution and/or use of the Program is restricted in
 certain countries either by patents or by copyrighted interfaces, the
 original copyright holder who places the Program under this License
 may add an explicit geographical distribution limitation excluding
 those countries, so that distribution is permitted only in or among
 countries not thus excluded.  In such case, this License incorporates
 the limitation as if written in the body of this License.
-</p>
 
-<p id="section9">
-<strong>9.</strong>
- The Free Software Foundation may publish revised and/or new versions
+  9. The Free Software Foundation may publish revised and/or new versions
 of the General Public License from time to time.  Such new versions will
 be similar in spirit to the present version, but may differ in detail to
 address new problems or concerns.
-</p>
 
-<p>
 Each version is given a distinguishing version number.  If the Program
 specifies a version number of this License which applies to it and "any
 later version", you have the option of following the terms and conditions
@@ -553,24 +246,18 @@ either of that version or of any later version published by the Free
 Software Foundation.  If the Program does not specify a version number of
 this License, you may choose any version ever published by the Free Software
 Foundation.
-</p>
 
-<p id="section10">
-<strong>10.</strong>
- If you wish to incorporate parts of the Program into other free
+  10. If you wish to incorporate parts of the Program into other free
 programs whose distribution conditions are different, write to the author
 to ask for permission.  For software which is copyrighted by the Free
 Software Foundation, write to the Free Software Foundation; we sometimes
 make exceptions for this.  Our decision will be guided by the two goals
 of preserving the free status of all derivatives of our free software and
 of promoting the sharing and reuse of software generally.
-</p>
 
-<p id="section11"><strong>NO WARRANTY</strong></p>
+                            NO WARRANTY
 
-<p>
-<strong>11.</strong>
- BECAUSE THE PROGRAM IS LICENSED FREE OF CHARGE, THERE IS NO WARRANTY
+  11. BECAUSE THE PROGRAM IS LICENSED FREE OF CHARGE, THERE IS NO WARRANTY
 FOR THE PROGRAM, TO THE EXTENT PERMITTED BY APPLICABLE LAW.  EXCEPT WHEN
 OTHERWISE STATED IN WRITING THE COPYRIGHT HOLDERS AND/OR OTHER PARTIES
 PROVIDE THE PROGRAM "AS IS" WITHOUT WARRANTY OF ANY KIND, EITHER EXPRESSED
@@ -579,11 +266,8 @@ MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE.  THE ENTIRE RISK AS
 TO THE QUALITY AND PERFORMANCE OF THE PROGRAM IS WITH YOU.  SHOULD THE
 PROGRAM PROVE DEFECTIVE, YOU ASSUME THE COST OF ALL NECESSARY SERVICING,
 REPAIR OR CORRECTION.
-</p>
 
-<p id="section12">
-<strong>12.</strong>
- IN NO EVENT UNLESS REQUIRED BY APPLICABLE LAW OR AGREED TO IN WRITING
+  12. IN NO EVENT UNLESS REQUIRED BY APPLICABLE LAW OR AGREED TO IN WRITING
 WILL ANY COPYRIGHT HOLDER, OR ANY OTHER PARTY WHO MAY MODIFY AND/OR
 REDISTRIBUTE THE PROGRAM AS PERMITTED ABOVE, BE LIABLE TO YOU FOR DAMAGES,
 INCLUDING ANY GENERAL, SPECIAL, INCIDENTAL OR CONSEQUENTIAL DAMAGES ARISING
@@ -592,213 +276,63 @@ TO LOSS OF DATA OR DATA BEING RENDERED INACCURATE OR LOSSES SUSTAINED BY
 YOU OR THIRD PARTIES OR A FAILURE OF THE PROGRAM TO OPERATE WITH ANY OTHER
 PROGRAMS), EVEN IF SUCH HOLDER OR OTHER PARTY HAS BEEN ADVISED OF THE
 POSSIBILITY OF SUCH DAMAGES.
-</p>
 
-<h4>END OF TERMS AND CONDITIONS</h4>
+                     END OF TERMS AND CONDITIONS
 
-<span id="SEC4"></span>
-<h4 id="howto">How to Apply These Terms to Your New Programs</h4>
+            How to Apply These Terms to Your New Programs
 
-<p>
   If you develop a new program, and you want it to be of the greatest
 possible use to the public, the best way to achieve this is to make it
 free software which everyone can redistribute and change under these terms.
-</p>
 
-<p>
   To do so, attach the following notices to the program.  It is safest
 to attach them to the start of each source file to most effectively
 convey the exclusion of warranty; and each file should have at least
 the "copyright" line and a pointer to where the full notice is found.
-</p>
 
-<pre>
-<var>one line to give the program's name and an idea of what it does.</var>
-Copyright (C) <var>yyyy</var>  <var>name of author</var>
+    <one line to give the program's name and a brief idea of what it does.>
+    Copyright (C) <year>  <name of author>
 
-This program is free software; you can redistribute it and/or
-modify it under the terms of the GNU General Public License
-as published by the Free Software Foundation; either version 2
-of the License, or (at your option) any later version.
+    This program is free software; you can redistribute it and/or modify
+    it under the terms of the GNU General Public License as published by
+    the Free Software Foundation; either version 2 of the License, or
+    (at your option) any later version.
 
-This program is distributed in the hope that it will be useful,
-but WITHOUT ANY WARRANTY; without even the implied warranty of
-MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
-GNU General Public License for more details.
+    This program is distributed in the hope that it will be useful,
+    but WITHOUT ANY WARRANTY; without even the implied warranty of
+    MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+    GNU General Public License for more details.
 
-You should have received a copy of the GNU General Public License
-along with this program; if not, see
-&lt;<a href="https://www.gnu.org/licenses/">https://www.gnu.org/licenses/</a>&gt;.
-</pre>
+    You should have received a copy of the GNU General Public License along
+    with this program; if not, see <https://www.gnu.org/licenses/>.
 
-<p>
 Also add information on how to contact you by electronic and paper mail.
-</p>
 
-<p>
 If the program is interactive, make it output a short notice like this
 when it starts in an interactive mode:
-</p>
 
-<pre>
-Gnomovision version 69, Copyright (C) <var>year</var> <var>name of author</var>
-Gnomovision comes with ABSOLUTELY NO WARRANTY; for details
-type `show w'.  This is free software, and you are welcome
-to redistribute it under certain conditions; type `show c' 
-for details.
-</pre>
+    Gnomovision version 69, Copyright (C) year name of author
+    Gnomovision comes with ABSOLUTELY NO WARRANTY; for details type `show w'.
+    This is free software, and you are welcome to redistribute it
+    under certain conditions; type `show c' for details.
 
-<p>
-The hypothetical commands <samp>`show w'</samp> and <samp>`show c'</samp> should show
-the appropriate parts of the General Public License.  Of course, the
-commands you use may be called something other than <samp>`show w'</samp> and
-<samp>`show c'</samp>; they could even be mouse-clicks or menu items--whatever
-suits your program.
-</p>
+The hypothetical commands `show w' and `show c' should show the appropriate
+parts of the General Public License.  Of course, the commands you use may
+be called something other than `show w' and `show c'; they could even be
+mouse-clicks or menu items--whatever suits your program.
 
-<p>
 You should also get your employer (if you work as a programmer) or your
 school, if any, to sign a "copyright disclaimer" for the program, if
 necessary.  Here is a sample; alter the names:
-</p>
 
+  Yoyodyne, Inc., hereby disclaims all copyright interest in the program
+  `Gnomovision' (which makes passes at compilers) written by James Hacker.
 
-<pre>
-Yoyodyne, Inc., hereby disclaims all copyright
-interest in the program `Gnomovision'
-(which makes passes at compilers) written 
-by James Hacker.
+  <signature of Moe Ghoul>, 1 April 1989
+  Moe Ghoul, President of Vice
 
-<var>signature of Moe Ghoul</var>, 1 April 1989
-Moe Ghoul, President of Vice
-</pre>
-
-<p>
 This General Public License does not permit incorporating your program into
 proprietary programs.  If your program is a subroutine library, you may
 consider it more useful to permit linking proprietary applications with the
-library.  If this is what you want to do, use the 
-<a href="https://www.gnu.org/licenses/lgpl.html">GNU Lesser General Public License</a>
-instead of this License.
-</p>
-
-</div>
-</div>
-
-</div><!-- for id="content", starts in the include above -->
-
-              <!-- begin server/footer-text.html -->
-
-
-
-
-
-<div style="clear:both"></div>
-
-
-<div id="language-container">
- <div class="backtotop">
-  <hr class="no-display" />
-  <a href="#top"><b>&#9650;</b></a>
- </div>
- <div id="languages" class="rounded-corners">
-  <div class="button">
-   <a href="#top" class="close"><span>BACK TO TOP</span></a>
-  </div>
-  <div id="set-language" class="button">
-   <span class="gnun-split"></span>
-   <a href="/server/select-language.html?callback=/licenses/old-licenses/gpl-2.0" rel="nofollow">
-   Set language
-   <span class="gnun-split"></span>
-   </a>
-  </div>
-  <p>Available for this page:</p>
-  <div id="translations">
-<p>
-<span dir="ltr" class="original">[en]&nbsp;<a lang="en" hreflang="en" href="/licenses/old-licenses/gpl-2.0.en.html">English</a> &nbsp;</span>
-<span dir="ltr">[cs]&nbsp;<a lang="cs" hreflang="cs" href="/licenses/old-licenses/gpl-2.0.cs.html">čeština</a> &nbsp;</span>
-<span dir="ltr">[de]&nbsp;<a lang="de" hreflang="de" href="/licenses/old-licenses/gpl-2.0.de.html">Deutsch</a> &nbsp;</span>
-<span dir="ltr">[fr]&nbsp;<a lang="fr" hreflang="fr" href="/licenses/old-licenses/gpl-2.0.fr.html">français</a> &nbsp;</span>
-<span dir="ltr">[ja]&nbsp;<a lang="ja" hreflang="ja" href="/licenses/old-licenses/gpl-2.0.ja.html">日本語</a> &nbsp;</span>
-<span dir="ltr">[pt-br]&nbsp;<a lang="pt-br" hreflang="pt-br" href="/licenses/old-licenses/gpl-2.0.pt-br.html">português</a> &nbsp;</span>
-<span dir="ltr">[ru]&nbsp;<a lang="ru" hreflang="ru" href="/licenses/old-licenses/gpl-2.0.ru.html">русский</a> &nbsp;</span>
-<span dir="ltr">[uk]&nbsp;<a lang="uk" hreflang="uk" href="/licenses/old-licenses/gpl-2.0.uk.html">українська</a> &nbsp;</span>
-<span dir="ltr">[zh-cn]&nbsp;<a lang="zh-cn" hreflang="zh-cn" href="/licenses/old-licenses/gpl-2.0.zh-cn.html">简体中文</a> &nbsp;</span>
-</p>
-</div>
- </div>
-</div>
-
-<div id="mission-statement" role="complementary">
- <div class="backtotop">
-  <hr class="no-display" />
-  <a href="#header"><span>BACK TO TOP </span>&#9650;</a>
- </div>
-<div style="clear: both"></div>
-<blockquote>
-<p style="direction:ltr; text-align:left"><a href="//www.fsf.org"><img id="fsfbanner"
-src="/graphics/fsf-logo-notext-small.png" alt="&nbsp;[FSF logo]&nbsp;"
-width="75" height="25" /></a><strong>
-&ldquo;The Free Software Foundation (FSF) is a nonprofit with a worldwide
-mission to promote computer user freedom. We defend the rights of all
-software users.&rdquo;</strong></p>
-</blockquote>
-
-<div id="support-the-fsf" class="button">
- <a class="join" href="//www.fsf.org/associate/support_freedom?referrer=4052">JOIN</a>
- <a class="donate" href="//donate.fsf.org/">DONATE</a>
- <a class="shop" href="//shop.fsf.org/">SHOP</a>
-</div>
-</div>
-<!-- end server/footer-text.html -->
-
-
-<div id="footer" role="contentinfo">
-<div class="unprintable">
-
-<p>Please send general FSF &amp; GNU inquiries to
-<a href="mailto:gnu@gnu.org">&lt;gnu@gnu.org&gt;</a>.
-There are also <a href="/contact/">other ways to contact</a>
-the FSF.  Broken links and other corrections or suggestions can be sent
-to <a href="mailto:webmasters@gnu.org">&lt;webmasters@gnu.org&gt;</a>.</p>
-
-<p><!-- TRANSLATORS: Ignore the original text in this paragraph,
-        replace it with the translation of these two:
-
-        We work hard and do our best to provide accurate, good quality
-        translations.  However, we are not exempt from imperfection.
-        Please send your comments and general suggestions in this regard
-        to <a href="mailto:web-translators@gnu.org">
-        &lt;web-translators@gnu.org&gt;</a>.</p>
-
-        <p>For information on coordinating and contributing translations of
-        our web pages, see <a
-        href="/server/standards/README.translations.html">Translations
-        README</a>. -->
-Please see the <a
-href="/server/standards/README.translations.html">Translations
-README</a> for information on coordinating and contributing translations
-of this article.</p>
-</div>
-
-<p>Copyright notice above.</p>
-
-<!-- start of server/bottom-notes.html -->
-<div id="bottom-notes" class="unprintable">
-<p><a href="//www.fsf.org/about/dmca-notice">Copyright Infringement Notification</a></p>
-<div id="generic">
-
-
-</div>
-</div>
-<!-- end of server/bottom-notes.html -->
-
-
-<p class="unprintable">Updated:
-<!-- timestamp start -->
-$Date: 2023/11/30 09:46:01 $
-<!-- timestamp end --></p>
-</div>
-</div><!-- for class="inner", starts in the banner include -->
-</body>
-</html>
+library.  If this is what you want to do, use the GNU Lesser General
+Public License instead of this License.

--- a/licenses-generator/src/main/resources/offline-license-mirror/www.gnu.org/licenses/gpl-3.0
+++ b/licenses-generator/src/main/resources/offline-license-mirror/www.gnu.org/licenses/gpl-3.0
@@ -1,266 +1,53 @@
-<!DOCTYPE html>
-<html xmlns="http://www.w3.org/1999/xhtml" xml:lang="en" lang="en">
-<head>
-<meta http-equiv="content-type" content="text/html; charset=utf-8" />
-<link rel="author" href="mailto:webmasters@gnu.org" />
-<link rel="icon" type="image/png" href="/graphics/gnu-head-mini.png" />
-<meta name="ICBM" content="42.355469,-71.058627" />
-<link rel="stylesheet" type="text/css" href="/layout.min.css" media="screen" />
-<link rel="stylesheet" type="text/css" href="/print.min.css" media="print" />
+                    GNU GENERAL PUBLIC LICENSE
+                       Version 3, 29 June 2007
 
-
-
-<!-- Parent-Version: 1.98 -->
-<!-- This page is derived from /server/standards/boilerplate.html -->
-<title>The GNU General Public License v3.0
-- GNU Project - Free Software Foundation</title>
-<style type="text/css" media="screen"><!--
-#content .button { margin: 2em 1.5em; }
-@media (max-width:30em) { #content img.imgright { display: none; }}
---></style>
-<link rel="alternate" type="application/rdf+xml"
-      href="/licenses/gpl-3.0.rdf" /> 
-<!-- begin translist file -->
-
-<link rel="alternate" type="text/html" href="/licenses/gpl-3.0.html" hreflang="x-default" />
-<link rel="alternate" type="text/html" lang="en" hreflang="en" href="/licenses/gpl-3.0.en.html" title="English" />
-<link rel="alternate" type="text/html" lang="ar" hreflang="ar" href="/licenses/gpl-3.0.ar.html" title="العربية" />
-<link rel="alternate" type="text/html" lang="ca" hreflang="ca" href="/licenses/gpl-3.0.ca.html" title="català" />
-<link rel="alternate" type="text/html" lang="de" hreflang="de" href="/licenses/gpl-3.0.de.html" title="Deutsch" />
-<link rel="alternate" type="text/html" lang="fr" hreflang="fr" href="/licenses/gpl-3.0.fr.html" title="français" />
-<link rel="alternate" type="text/html" lang="ja" hreflang="ja" href="/licenses/gpl-3.0.ja.html" title="日本語" />
-<link rel="alternate" type="text/html" lang="nl" hreflang="nl" href="/licenses/gpl-3.0.nl.html" title="Nederlands" />
-<link rel="alternate" type="text/html" lang="pt-br" hreflang="pt-br" href="/licenses/gpl-3.0.pt-br.html" title="português" />
-<link rel="alternate" type="text/html" lang="ru" hreflang="ru" href="/licenses/gpl-3.0.ru.html" title="русский" />
-<link rel="alternate" type="text/html" lang="tr" hreflang="tr" href="/licenses/gpl-3.0.tr.html" title="Türkçe" />
-<link rel="alternate" type="text/html" lang="uk" hreflang="uk" href="/licenses/gpl-3.0.uk.html" title="українська" />
-<link rel="alternate" type="text/html" lang="zh-cn" hreflang="zh-cn" href="/licenses/gpl-3.0.zh-cn.html" title="简体中文" />
-<link rel="alternate" type="text/html" lang="zh-tw" hreflang="zh-tw" href="/licenses/gpl-3.0.zh-tw.html" title="繁體中文" />
-<!-- end translist file -->
-
-<!-- start of server/banner.html -->
-<!-- start of head-include-2.html -->
-<meta name="viewport" content="width=device-width, initial-scale=1" />
-<!-- end of head-include-2.html -->
-
-</head>
-<body>
-<div class="inner">
-<!-- start of server/body-include-1.html -->
-<div id="top">
-<a class="skip" href="#content"><b>Skip to main text</b></a>
-</div>
-
-<div id="fsf-frame" role="complementary">
-<form id="fssbox" action="https://my.fsf.org/civicrm/profile/create?reset=1&amp;gid=31"
-      method="post">
- <div>
-  <input name="postURL" type="hidden" value="" />
-  <input type="hidden" name="group[25]" value="1" />
-  <input name="cancelURL" type="hidden" value="https://crm.fsf.org/civicrm/profile?reset=1&amp;gid=31" />
-  <input name="_qf_default" type="hidden" value="Edit:cancel" />
-  <label for="frmEmail">
-   <a href="//www.fsf.org/fss">Free Software Supporter</a>:
-  </label>
-  <input type="text" id="frmEmail" name="email-Primary" size="18" maxlength="80"
-         value="email address" onfocus="this.value=''"/>
-  <input type="submit" name="_qf_Edit_next" value="Sign up" />
- </div>
-</form>
-
-<div id="join-fsf" class="button"><a
-href="https://www.fsf.org/associate/support_freedom?referrer=4052">JOIN&nbsp;THE&nbsp;FSF</a>
-</div>
-</div>
-
-<div id="header" role="banner">
-<p id="gnu-banner">
- <a href="/">
- <img src="/graphics/heckert_gnu.transp.small.png" height="48" width="49"
-      alt="&nbsp;[A GNU head]&nbsp;" /><strong>GNU</strong> <span
- class="hide">Operating System</span></a><br />
- <small id="fsf-support">Supported by the
- <a href="#mission-statement">Free Software Foundation</a></small>
-</p>
-
-<div id="switches">
-<!-- begin search button -->
- <div  id="search-button" class="switch">
-  <a href="//www.gnu.org/cgi-bin/estseek.cgi">
-  <img id="search-icon" height="30" width="30"
-       src="/graphics/icons/search.png"
-       alt="&nbsp;[Search www.gnu.org]&nbsp;" /></a>
- </div>
-<!-- end search button -->
-
- <div id="language-button" class="switch">
-  <a href="#language-container">
-  <img id="language-icon" height="30" width="37"
-       src="/graphics/icons/translations.png"
-       alt="&nbsp;[Other languages]&nbsp;" /></a>
- </div>
-
-</div>
-</div>
-<!-- end of server/body-include-1.html -->
-
-<!-- start of server/body-include-2 -->
-
-
-<div style="clear: both"></div>
-
-<div id="navigation" role="navigation">
- <a id="more-links" href="#navigation" title="More...">
-   <span>Site navigation</span></a>
- <a id="less-links" href="#content"><b>Skip</b></a>
- <ul>
-
-   <li id="tabAboutGNU"><a href="/gnu/gnu.html">ABOUT&nbsp;GNU</a></li>
-
-
-  <li id="tabPhilosophy"><a href="/philosophy/philosophy.html">PHILOSOPHY</a></li>
-
-
-  <li id="tabLicenses" class="active">
-     <span class='no-display'>=</span> 
-    <a href="/licenses/licenses.html">LICENSES</a>
-    <span class="gnun-split"></span>
-     <span class='no-display'>=</span> 
-  </li>
-
-
-  <li id="tabEducation"><a href="/education/education.html">EDUCATION</a></li>
-
-
-  <li id="tabSoftware"><a href="/software/software.html">SOFTWARE</a></li>
-
-
-  <li id="tabDistros"><a href="/distros/distros.html">DISTROS</a></li>
-
-
-  <li id="tabDoc"><a href="/doc/doc.html">DOCS</a></li>
-
-
-  <li id="tabMalware"><a href="/proprietary/proprietary.html">MALWARE</a></li>
-
-
-  <li id="tabHelp"><a href="/help/help.html">HELP&nbsp;GNU</a></li>
-
-
-  <li id="tabAV"><a href="/audio-video/audio-video.html">AUDIO&nbsp;&amp;&nbsp;VIDEO</a></li>
-
-
-  <li id="tabArt"><a href="/graphics/graphics.html">GNU&nbsp;ART</a></li>
-
-
-  <li id="tabFun"><a href="/fun/humor.html">FUN</a></li>
-
-
-  <li id="tabPeople"><a href="/people/people.html">GNU'S&nbsp;WHO?</a></li>
-
-  <li><a href="//directory.fsf.org">SOFTWARE&nbsp;DIRECTORY</a></li>
-  <li><a href="https://h-node.org/">HARDWARE</a></li>
-  <li><a href="/server/sitemap.html">SITEMAP</a></li>
- </ul>
- <div style="clear: both"></div>
-</div><!-- /"navigation -->
-<!-- end of server/body-include-2 -->
-
-<div id="content" role="main">
-<!-- end of server/banner.html -->
-
-<div class="reduced-width">
-<h2>GNU General Public License</h2>
-
-<img class="imgright" src="/graphics/gplv3-127x51.png" alt=" [GPLv3 Logo] " />
-<p class="button"><b><a href="#license-text">Skip to license text</a></b></p>
-
-<ul>
-  <li><a href="/licenses/quick-guide-gplv3.html">A Quick Guide to GPLv3</a></li>
-  <li><a href="/licenses/rms-why-gplv3.html">Why Upgrade to GPLv3</a></li>
-  <li><a href="/licenses/gpl-faq.html">Frequently Asked Questions about
-       the GNU licenses</a></li>
-  <li><a href="/licenses/gpl-howto.html">How to use GNU licenses for your
-       own software</a></li>
-  <li><a href="/licenses/translations.html">Translations
-       of the GPL</a></li>
-  <li>The GPL in other formats: 
-       <a href="/licenses/gpl-3.0.txt">plain text</a>,
-       <a href="/licenses/gpl-3.0.texi">Texinfo</a>,
-       <a href="/licenses/gpl-3.0.tex">LaTeX</a>,
-       <a href="/licenses/gpl-3.0-standalone.html">standalone HTML</a>,
-       <a href="/licenses/gpl-3.0.odt">ODF</a>,
-      Docbook <a href="/licenses/gpl-3.0.dbk">v4</a> or
-       <a href="/licenses/gpl-3.0.xml">v5</a>,
-       <a href="/licenses/gpl-3.0.rst">reStructuredText</a>,
-       <a href="/licenses/gpl-3.0.md">Markdown</a>, and
-       <a href="/licenses/gpl-3.0.rtf">RTF</a>.
-       </li>
-  <li><a href="/graphics/license-logos.html">GPLv3 logos</a> to use
-       with your project</li>
-  <li><a href="/licenses/old-licenses/old-licenses.html#GPL">Old
-       versions of the GNU GPL</a></li>
-  <li><a href="/licenses/gpl-violation.html">What to do if you see a
-       possible GPL violation</a></li>
-</ul>
-
-<hr class="thin" />
-
-<!-- The license text is in English and appears broken in RTL as
-     Arabic, Farsi, etc.  Explicitly set the direction to override the
-     one defined in the translation. -->
-<div id="license-text" dir="ltr">
-<h3 style="text-align: center;">GNU GENERAL PUBLIC LICENSE</h3>
-<p style="text-align: center;">Version 3, 29 June 2007</p>
-
-<p>Copyright &copy; 2007 Free Software Foundation, Inc.
- &lt;<a href="https://fsf.org/">https://fsf.org/</a>&gt;</p><p>
+ Copyright (C) 2007 Free Software Foundation, Inc. <https://fsf.org/>
  Everyone is permitted to copy and distribute verbatim copies
- of this license document, but changing it is not allowed.</p>
+ of this license document, but changing it is not allowed.
 
-<h4 id="preamble">Preamble</h4>
+                            Preamble
 
-<p>The GNU General Public License is a free, copyleft license for
-software and other kinds of works.</p>
+  The GNU General Public License is a free, copyleft license for
+software and other kinds of works.
 
-<p>The licenses for most software and other practical works are designed
+  The licenses for most software and other practical works are designed
 to take away your freedom to share and change the works.  By contrast,
 the GNU General Public License is intended to guarantee your freedom to
 share and change all versions of a program--to make sure it remains free
 software for all its users.  We, the Free Software Foundation, use the
 GNU General Public License for most of our software; it applies also to
 any other work released this way by its authors.  You can apply it to
-your programs, too.</p>
+your programs, too.
 
-<p>When we speak of free software, we are referring to freedom, not
+  When we speak of free software, we are referring to freedom, not
 price.  Our General Public Licenses are designed to make sure that you
 have the freedom to distribute copies of free software (and charge for
 them if you wish), that you receive source code or can get it if you
 want it, that you can change the software or use pieces of it in new
-free programs, and that you know you can do these things.</p>
+free programs, and that you know you can do these things.
 
-<p>To protect your rights, we need to prevent others from denying you
+  To protect your rights, we need to prevent others from denying you
 these rights or asking you to surrender the rights.  Therefore, you have
 certain responsibilities if you distribute copies of the software, or if
-you modify it: responsibilities to respect the freedom of others.</p>
+you modify it: responsibilities to respect the freedom of others.
 
-<p>For example, if you distribute copies of such a program, whether
+  For example, if you distribute copies of such a program, whether
 gratis or for a fee, you must pass on to the recipients the same
 freedoms that you received.  You must make sure that they, too, receive
 or can get the source code.  And you must show them these terms so they
-know their rights.</p>
+know their rights.
 
-<p>Developers that use the GNU GPL protect your rights with two steps:
+  Developers that use the GNU GPL protect your rights with two steps:
 (1) assert copyright on the software, and (2) offer you this License
-giving you legal permission to copy, distribute and/or modify it.</p>
+giving you legal permission to copy, distribute and/or modify it.
 
-<p>For the developers' and authors' protection, the GPL clearly explains
+  For the developers' and authors' protection, the GPL clearly explains
 that there is no warranty for this free software.  For both users' and
 authors' sake, the GPL requires that modified versions be marked as
 changed, so that their problems will not be attributed erroneously to
-authors of previous versions.</p>
+authors of previous versions.
 
-<p>Some devices are designed to deny users access to install or run
+  Some devices are designed to deny users access to install or run
 modified versions of the software inside them, although the manufacturer
 can do so.  This is fundamentally incompatible with the aim of
 protecting users' freedom to change the software.  The systematic
@@ -269,82 +56,82 @@ use, which is precisely where it is most unacceptable.  Therefore, we
 have designed this version of the GPL to prohibit the practice for those
 products.  If such problems arise substantially in other domains, we
 stand ready to extend this provision to those domains in future versions
-of the GPL, as needed to protect the freedom of users.</p>
+of the GPL, as needed to protect the freedom of users.
 
-<p>Finally, every program is threatened constantly by software patents.
+  Finally, every program is threatened constantly by software patents.
 States should not allow patents to restrict development and use of
 software on general-purpose computers, but in those that do, we wish to
 avoid the special danger that patents applied to a free program could
 make it effectively proprietary.  To prevent this, the GPL assures that
-patents cannot be used to render the program non-free.</p>
+patents cannot be used to render the program non-free.
 
-<p>The precise terms and conditions for copying, distribution and
-modification follow.</p>
+  The precise terms and conditions for copying, distribution and
+modification follow.
 
-<h4 id="terms">TERMS AND CONDITIONS</h4>
+                       TERMS AND CONDITIONS
 
-<h5 id="section0">0. Definitions.</h5>
+  0. Definitions.
 
-<p>&ldquo;This License&rdquo; refers to version 3 of the GNU General Public License.</p>
+  "This License" refers to version 3 of the GNU General Public License.
 
-<p>&ldquo;Copyright&rdquo; also means copyright-like laws that apply to other kinds of
-works, such as semiconductor masks.</p>
- 
-<p>&ldquo;The Program&rdquo; refers to any copyrightable work licensed under this
-License.  Each licensee is addressed as &ldquo;you&rdquo;.  &ldquo;Licensees&rdquo; and
-&ldquo;recipients&rdquo; may be individuals or organizations.</p>
+  "Copyright" also means copyright-like laws that apply to other kinds of
+works, such as semiconductor masks.
 
-<p>To &ldquo;modify&rdquo; a work means to copy from or adapt all or part of the work
+  "The Program" refers to any copyrightable work licensed under this
+License.  Each licensee is addressed as "you".  "Licensees" and
+"recipients" may be individuals or organizations.
+
+  To "modify" a work means to copy from or adapt all or part of the work
 in a fashion requiring copyright permission, other than the making of an
-exact copy.  The resulting work is called a &ldquo;modified version&rdquo; of the
-earlier work or a work &ldquo;based on&rdquo; the earlier work.</p>
+exact copy.  The resulting work is called a "modified version" of the
+earlier work or a work "based on" the earlier work.
 
-<p>A &ldquo;covered work&rdquo; means either the unmodified Program or a work based
-on the Program.</p>
+  A "covered work" means either the unmodified Program or a work based
+on the Program.
 
-<p>To &ldquo;propagate&rdquo; a work means to do anything with it that, without
+  To "propagate" a work means to do anything with it that, without
 permission, would make you directly or secondarily liable for
 infringement under applicable copyright law, except executing it on a
 computer or modifying a private copy.  Propagation includes copying,
 distribution (with or without modification), making available to the
-public, and in some countries other activities as well.</p>
+public, and in some countries other activities as well.
 
-<p>To &ldquo;convey&rdquo; a work means any kind of propagation that enables other
+  To "convey" a work means any kind of propagation that enables other
 parties to make or receive copies.  Mere interaction with a user through
-a computer network, with no transfer of a copy, is not conveying.</p>
+a computer network, with no transfer of a copy, is not conveying.
 
-<p>An interactive user interface displays &ldquo;Appropriate Legal Notices&rdquo;
+  An interactive user interface displays "Appropriate Legal Notices"
 to the extent that it includes a convenient and prominently visible
 feature that (1) displays an appropriate copyright notice, and (2)
 tells the user that there is no warranty for the work (except to the
 extent that warranties are provided), that licensees may convey the
 work under this License, and how to view a copy of this License.  If
 the interface presents a list of user commands or options, such as a
-menu, a prominent item in the list meets this criterion.</p>
+menu, a prominent item in the list meets this criterion.
 
-<h5 id="section1">1. Source Code.</h5>
+  1. Source Code.
 
-<p>The &ldquo;source code&rdquo; for a work means the preferred form of the work
-for making modifications to it.  &ldquo;Object code&rdquo; means any non-source
-form of a work.</p>
+  The "source code" for a work means the preferred form of the work
+for making modifications to it.  "Object code" means any non-source
+form of a work.
 
-<p>A &ldquo;Standard Interface&rdquo; means an interface that either is an official
+  A "Standard Interface" means an interface that either is an official
 standard defined by a recognized standards body, or, in the case of
 interfaces specified for a particular programming language, one that
-is widely used among developers working in that language.</p>
+is widely used among developers working in that language.
 
-<p>The &ldquo;System Libraries&rdquo; of an executable work include anything, other
+  The "System Libraries" of an executable work include anything, other
 than the work as a whole, that (a) is included in the normal form of
 packaging a Major Component, but which is not part of that Major
 Component, and (b) serves only to enable use of the work with that
 Major Component, or to implement a Standard Interface for which an
 implementation is available to the public in source code form.  A
-&ldquo;Major Component&rdquo;, in this context, means a major essential component
+"Major Component", in this context, means a major essential component
 (kernel, window system, and so on) of the specific operating system
 (if any) on which the executable work runs, or a compiler used to
-produce the work, or an object code interpreter used to run it.</p>
+produce the work, or an object code interpreter used to run it.
 
-<p>The &ldquo;Corresponding Source&rdquo; for a work in object code form means all
+  The "Corresponding Source" for a work in object code form means all
 the source code needed to generate, install, and (for an executable
 work) run the object code and to modify the work, including scripts to
 control those activities.  However, it does not include the work's
@@ -355,26 +142,26 @@ includes interface definition files associated with source files for
 the work, and the source code for shared libraries and dynamically
 linked subprograms that the work is specifically designed to require,
 such as by intimate data communication or control flow between those
-subprograms and other parts of the work.</p>
+subprograms and other parts of the work.
 
-<p>The Corresponding Source need not include anything that users
+  The Corresponding Source need not include anything that users
 can regenerate automatically from other parts of the Corresponding
-Source.</p>
+Source.
 
-<p>The Corresponding Source for a work in source code form is that
-same work.</p>
+  The Corresponding Source for a work in source code form is that
+same work.
 
-<h5 id="section2">2. Basic Permissions.</h5>
+  2. Basic Permissions.
 
-<p>All rights granted under this License are granted for the term of
+  All rights granted under this License are granted for the term of
 copyright on the Program, and are irrevocable provided the stated
 conditions are met.  This License explicitly affirms your unlimited
 permission to run the unmodified Program.  The output from running a
 covered work is covered by this License only if the output, given its
 content, constitutes a covered work.  This License acknowledges your
-rights of fair use or other equivalent, as provided by copyright law.</p>
+rights of fair use or other equivalent, as provided by copyright law.
 
-<p>You may make, run and propagate covered works that you do not
+  You may make, run and propagate covered works that you do not
 convey, without conditions so long as your license otherwise remains
 in force.  You may convey covered works to others for the sole purpose
 of having them make modifications exclusively for you, or provide you
@@ -383,94 +170,91 @@ the terms of this License in conveying all material for which you do
 not control copyright.  Those thus making or running the covered works
 for you must do so exclusively on your behalf, under your direction
 and control, on terms that prohibit them from making any copies of
-your copyrighted material outside their relationship with you.</p>
+your copyrighted material outside their relationship with you.
 
-<p>Conveying under any other circumstances is permitted solely under
+  Conveying under any other circumstances is permitted solely under
 the conditions stated below.  Sublicensing is not allowed; section 10
-makes it unnecessary.</p>
+makes it unnecessary.
 
-<h5 id="section3">3. Protecting Users' Legal Rights From Anti-Circumvention Law.</h5>
+  3. Protecting Users' Legal Rights From Anti-Circumvention Law.
 
-<p>No covered work shall be deemed part of an effective technological
+  No covered work shall be deemed part of an effective technological
 measure under any applicable law fulfilling obligations under article
 11 of the WIPO copyright treaty adopted on 20 December 1996, or
 similar laws prohibiting or restricting circumvention of such
-measures.</p>
+measures.
 
-<p>When you convey a covered work, you waive any legal power to forbid
+  When you convey a covered work, you waive any legal power to forbid
 circumvention of technological measures to the extent such circumvention
 is effected by exercising rights under this License with respect to
 the covered work, and you disclaim any intention to limit operation or
 modification of the work as a means of enforcing, against the work's
 users, your or third parties' legal rights to forbid circumvention of
-technological measures.</p>
+technological measures.
 
-<h5 id="section4">4. Conveying Verbatim Copies.</h5>
+  4. Conveying Verbatim Copies.
 
-<p>You may convey verbatim copies of the Program's source code as you
+  You may convey verbatim copies of the Program's source code as you
 receive it, in any medium, provided that you conspicuously and
 appropriately publish on each copy an appropriate copyright notice;
 keep intact all notices stating that this License and any
 non-permissive terms added in accord with section 7 apply to the code;
 keep intact all notices of the absence of any warranty; and give all
-recipients a copy of this License along with the Program.</p>
+recipients a copy of this License along with the Program.
 
-<p>You may charge any price or no price for each copy that you convey,
-and you may offer support or warranty protection for a fee.</p>
+  You may charge any price or no price for each copy that you convey,
+and you may offer support or warranty protection for a fee.
 
-<h5 id="section5">5. Conveying Modified Source Versions.</h5>
+  5. Conveying Modified Source Versions.
 
-<p>You may convey a work based on the Program, or the modifications to
+  You may convey a work based on the Program, or the modifications to
 produce it from the Program, in the form of source code under the
-terms of section 4, provided that you also meet all of these conditions:</p>
+terms of section 4, provided that you also meet all of these conditions:
 
-<ul>
-<li>a) The work must carry prominent notices stating that you modified
-    it, and giving a relevant date.</li>
+    a) The work must carry prominent notices stating that you modified
+    it, and giving a relevant date.
 
-<li>b) The work must carry prominent notices stating that it is
+    b) The work must carry prominent notices stating that it is
     released under this License and any conditions added under section
     7.  This requirement modifies the requirement in section 4 to
-    &ldquo;keep intact all notices&rdquo;.</li>
+    "keep intact all notices".
 
-<li>c) You must license the entire work, as a whole, under this
+    c) You must license the entire work, as a whole, under this
     License to anyone who comes into possession of a copy.  This
     License will therefore apply, along with any applicable section 7
     additional terms, to the whole of the work, and all its parts,
     regardless of how they are packaged.  This License gives no
     permission to license the work in any other way, but it does not
-    invalidate such permission if you have separately received it.</li>
+    invalidate such permission if you have separately received it.
 
-<li>d) If the work has interactive user interfaces, each must display
+    d) If the work has interactive user interfaces, each must display
     Appropriate Legal Notices; however, if the Program has interactive
     interfaces that do not display Appropriate Legal Notices, your
-    work need not make them do so.</li>
-</ul>
+    work need not make them do so.
 
-<p>A compilation of a covered work with other separate and independent
+  A compilation of a covered work with other separate and independent
 works, which are not by their nature extensions of the covered work,
 and which are not combined with it such as to form a larger program,
 in or on a volume of a storage or distribution medium, is called an
-&ldquo;aggregate&rdquo; if the compilation and its resulting copyright are not
+"aggregate" if the compilation and its resulting copyright are not
 used to limit the access or legal rights of the compilation's users
 beyond what the individual works permit.  Inclusion of a covered work
 in an aggregate does not cause this License to apply to the other
-parts of the aggregate.</p>
+parts of the aggregate.
 
-<h5 id="section6">6. Conveying Non-Source Forms.</h5>
+  6. Conveying Non-Source Forms.
 
-<p>You may convey a covered work in object code form under the terms
+  You may convey a covered work in object code form under the terms
 of sections 4 and 5, provided that you also convey the
 machine-readable Corresponding Source under the terms of this License,
-in one of these ways:</p>
+in one of these ways:
 
-<ul>
-<li>a) Convey the object code in, or embodied in, a physical product
+    a) Convey the object code in, or embodied in, a physical product
     (including a physical distribution medium), accompanied by the
     Corresponding Source fixed on a durable physical medium
-    customarily used for software interchange.</li>
+    customarily used for software interchange.
 
-<li>b) Convey the object code in, or embodied in, a physical product
+    b) Convey the object code in, or embodied in, a physical product
     (including a physical distribution medium), accompanied by a
     written offer, valid for at least three years and valid for as
     long as you offer spare parts or customer support for that product
@@ -480,15 +264,15 @@ in one of these ways:</p>
     medium customarily used for software interchange, for a price no
     more than your reasonable cost of physically performing this
     conveying of source, or (2) access to copy the
-    Corresponding Source from a network server at no charge.</li>
+    Corresponding Source from a network server at no charge.
 
-<li>c) Convey individual copies of the object code with a copy of the
+    c) Convey individual copies of the object code with a copy of the
     written offer to provide the Corresponding Source.  This
     alternative is allowed only occasionally and noncommercially, and
     only if you received the object code with such an offer, in accord
-    with subsection 6b.</li>
+    with subsection 6b.
 
-<li>d) Convey the object code by offering access from a designated
+    d) Convey the object code by offering access from a designated
     place (gratis or for a charge), and offer equivalent access to the
     Corresponding Source in the same way through the same place at no
     further charge.  You need not require recipients to copy the
@@ -499,40 +283,39 @@ in one of these ways:</p>
     clear directions next to the object code saying where to find the
     Corresponding Source.  Regardless of what server hosts the
     Corresponding Source, you remain obligated to ensure that it is
-    available for as long as needed to satisfy these requirements.</li>
+    available for as long as needed to satisfy these requirements.
 
-<li>e) Convey the object code using peer-to-peer transmission, provided
+    e) Convey the object code using peer-to-peer transmission, provided
     you inform other peers where the object code and Corresponding
     Source of the work are being offered to the general public at no
-    charge under subsection 6d.</li>
-</ul>
+    charge under subsection 6d.
 
-<p>A separable portion of the object code, whose source code is excluded
+  A separable portion of the object code, whose source code is excluded
 from the Corresponding Source as a System Library, need not be
-included in conveying the object code work.</p>
+included in conveying the object code work.
 
-<p>A &ldquo;User Product&rdquo; is either (1) a &ldquo;consumer product&rdquo;, which means any
+  A "User Product" is either (1) a "consumer product", which means any
 tangible personal property which is normally used for personal, family,
 or household purposes, or (2) anything designed or sold for incorporation
 into a dwelling.  In determining whether a product is a consumer product,
 doubtful cases shall be resolved in favor of coverage.  For a particular
-product received by a particular user, &ldquo;normally used&rdquo; refers to a
+product received by a particular user, "normally used" refers to a
 typical or common use of that class of product, regardless of the status
 of the particular user or of the way in which the particular user
 actually uses, or expects or is expected to use, the product.  A product
 is a consumer product regardless of whether the product has substantial
 commercial, industrial or non-consumer uses, unless such uses represent
-the only significant mode of use of the product.</p>
+the only significant mode of use of the product.
 
-<p>&ldquo;Installation Information&rdquo; for a User Product means any methods,
+  "Installation Information" for a User Product means any methods,
 procedures, authorization keys, or other information required to install
 and execute modified versions of a covered work in that User Product from
 a modified version of its Corresponding Source.  The information must
 suffice to ensure that the continued functioning of the modified object
 code is in no case prevented or interfered with solely because
-modification has been made.</p>
+modification has been made.
 
-<p>If you convey an object code work under this section in, or with, or
+  If you convey an object code work under this section in, or with, or
 specifically for use in, a User Product, and the conveying occurs as
 part of a transaction in which the right of possession and use of the
 User Product is transferred to the recipient in perpetuity or for a
@@ -541,135 +324,133 @@ Corresponding Source conveyed under this section must be accompanied
 by the Installation Information.  But this requirement does not apply
 if neither you nor any third party retains the ability to install
 modified object code on the User Product (for example, the work has
-been installed in ROM).</p>
+been installed in ROM).
 
-<p>The requirement to provide Installation Information does not include a
+  The requirement to provide Installation Information does not include a
 requirement to continue to provide support service, warranty, or updates
 for a work that has been modified or installed by the recipient, or for
 the User Product in which it has been modified or installed.  Access to a
 network may be denied when the modification itself materially and
 adversely affects the operation of the network or violates the rules and
-protocols for communication across the network.</p>
+protocols for communication across the network.
 
-<p>Corresponding Source conveyed, and Installation Information provided,
+  Corresponding Source conveyed, and Installation Information provided,
 in accord with this section must be in a format that is publicly
 documented (and with an implementation available to the public in
 source code form), and must require no special password or key for
-unpacking, reading or copying.</p>
+unpacking, reading or copying.
 
-<h5 id="section7">7. Additional Terms.</h5>
+  7. Additional Terms.
 
-<p>&ldquo;Additional permissions&rdquo; are terms that supplement the terms of this
+  "Additional permissions" are terms that supplement the terms of this
 License by making exceptions from one or more of its conditions.
 Additional permissions that are applicable to the entire Program shall
 be treated as though they were included in this License, to the extent
 that they are valid under applicable law.  If additional permissions
 apply only to part of the Program, that part may be used separately
 under those permissions, but the entire Program remains governed by
-this License without regard to the additional permissions.</p>
+this License without regard to the additional permissions.
 
-<p>When you convey a copy of a covered work, you may at your option
+  When you convey a copy of a covered work, you may at your option
 remove any additional permissions from that copy, or from any part of
 it.  (Additional permissions may be written to require their own
 removal in certain cases when you modify the work.)  You may place
 additional permissions on material, added by you to a covered work,
-for which you have or can give appropriate copyright permission.</p>
+for which you have or can give appropriate copyright permission.
 
-<p>Notwithstanding any other provision of this License, for material you
+  Notwithstanding any other provision of this License, for material you
 add to a covered work, you may (if authorized by the copyright holders of
-that material) supplement the terms of this License with terms:</p>
+that material) supplement the terms of this License with terms:
 
-<ul>
-<li>a) Disclaiming warranty or limiting liability differently from the
-    terms of sections 15 and 16 of this License; or</li>
+    a) Disclaiming warranty or limiting liability differently from the
+    terms of sections 15 and 16 of this License; or
 
-<li>b) Requiring preservation of specified reasonable legal notices or
+    b) Requiring preservation of specified reasonable legal notices or
     author attributions in that material or in the Appropriate Legal
-    Notices displayed by works containing it; or</li>
+    Notices displayed by works containing it; or
 
-<li>c) Prohibiting misrepresentation of the origin of that material, or
+    c) Prohibiting misrepresentation of the origin of that material, or
     requiring that modified versions of such material be marked in
-    reasonable ways as different from the original version; or</li>
+    reasonable ways as different from the original version; or
 
-<li>d) Limiting the use for publicity purposes of names of licensors or
-    authors of the material; or</li>
+    d) Limiting the use for publicity purposes of names of licensors or
+    authors of the material; or
 
-<li>e) Declining to grant rights under trademark law for use of some
-    trade names, trademarks, or service marks; or</li>
+    e) Declining to grant rights under trademark law for use of some
+    trade names, trademarks, or service marks; or
 
-<li>f) Requiring indemnification of licensors and authors of that
+    f) Requiring indemnification of licensors and authors of that
     material by anyone who conveys the material (or modified versions of
     it) with contractual assumptions of liability to the recipient, for
     any liability that these contractual assumptions directly impose on
-    those licensors and authors.</li>
-</ul>
+    those licensors and authors.
 
-<p>All other non-permissive additional terms are considered &ldquo;further
-restrictions&rdquo; within the meaning of section 10.  If the Program as you
+  All other non-permissive additional terms are considered "further
+restrictions" within the meaning of section 10.  If the Program as you
 received it, or any part of it, contains a notice stating that it is
 governed by this License along with a term that is a further
 restriction, you may remove that term.  If a license document contains
 a further restriction but permits relicensing or conveying under this
 License, you may add to a covered work material governed by the terms
 of that license document, provided that the further restriction does
-not survive such relicensing or conveying.</p>
+not survive such relicensing or conveying.
 
-<p>If you add terms to a covered work in accord with this section, you
+  If you add terms to a covered work in accord with this section, you
 must place, in the relevant source files, a statement of the
 additional terms that apply to those files, or a notice indicating
-where to find the applicable terms.</p>
+where to find the applicable terms.
 
-<p>Additional terms, permissive or non-permissive, may be stated in the
+  Additional terms, permissive or non-permissive, may be stated in the
 form of a separately written license, or stated as exceptions;
-the above requirements apply either way.</p>
+the above requirements apply either way.
 
-<h5 id="section8">8. Termination.</h5>
+  8. Termination.
 
-<p>You may not propagate or modify a covered work except as expressly
+  You may not propagate or modify a covered work except as expressly
 provided under this License.  Any attempt otherwise to propagate or
 modify it is void, and will automatically terminate your rights under
 this License (including any patent licenses granted under the third
-paragraph of section 11).</p>
+paragraph of section 11).
 
-<p>However, if you cease all violation of this License, then your
+  However, if you cease all violation of this License, then your
 license from a particular copyright holder is reinstated (a)
 provisionally, unless and until the copyright holder explicitly and
 finally terminates your license, and (b) permanently, if the copyright
 holder fails to notify you of the violation by some reasonable means
-prior to 60 days after the cessation.</p>
+prior to 60 days after the cessation.
 
-<p>Moreover, your license from a particular copyright holder is
+  Moreover, your license from a particular copyright holder is
 reinstated permanently if the copyright holder notifies you of the
 violation by some reasonable means, this is the first time you have
 received notice of violation of this License (for any work) from that
 copyright holder, and you cure the violation prior to 30 days after
-your receipt of the notice.</p>
+your receipt of the notice.
 
-<p>Termination of your rights under this section does not terminate the
+  Termination of your rights under this section does not terminate the
 licenses of parties who have received copies or rights from you under
 this License.  If your rights have been terminated and not permanently
 reinstated, you do not qualify to receive new licenses for the same
-material under section 10.</p>
+material under section 10.
 
-<h5 id="section9">9. Acceptance Not Required for Having Copies.</h5>
+  9. Acceptance Not Required for Having Copies.
 
-<p>You are not required to accept this License in order to receive or
+  You are not required to accept this License in order to receive or
 run a copy of the Program.  Ancillary propagation of a covered work
 occurring solely as a consequence of using peer-to-peer transmission
 to receive a copy likewise does not require acceptance.  However,
 nothing other than this License grants you permission to propagate or
 modify any covered work.  These actions infringe copyright if you do
 not accept this License.  Therefore, by modifying or propagating a
-covered work, you indicate your acceptance of this License to do so.</p>
+covered work, you indicate your acceptance of this License to do so.
 
-<h5 id="section10">10. Automatic Licensing of Downstream Recipients.</h5>
+  10. Automatic Licensing of Downstream Recipients.
 
-<p>Each time you convey a covered work, the recipient automatically
+  Each time you convey a covered work, the recipient automatically
 receives a license from the original licensors, to run, modify and
 propagate that work, subject to this License.  You are not responsible
-for enforcing compliance by third parties with this License.</p>
+for enforcing compliance by third parties with this License.
 
-<p>An &ldquo;entity transaction&rdquo; is a transaction transferring control of an
+  An "entity transaction" is a transaction transferring control of an
 organization, or substantially all assets of one, or subdividing an
 organization, or merging organizations.  If propagation of a covered
 work results from an entity transaction, each party to that
@@ -677,45 +458,45 @@ transaction who receives a copy of the work also receives whatever
 licenses to the work the party's predecessor in interest had or could
 give under the previous paragraph, plus a right to possession of the
 Corresponding Source of the work from the predecessor in interest, if
-the predecessor has it or can get it with reasonable efforts.</p>
+the predecessor has it or can get it with reasonable efforts.
 
-<p>You may not impose any further restrictions on the exercise of the
+  You may not impose any further restrictions on the exercise of the
 rights granted or affirmed under this License.  For example, you may
 not impose a license fee, royalty, or other charge for exercise of
 rights granted under this License, and you may not initiate litigation
 (including a cross-claim or counterclaim in a lawsuit) alleging that
 any patent claim is infringed by making, using, selling, offering for
-sale, or importing the Program or any portion of it.</p>
+sale, or importing the Program or any portion of it.
 
-<h5 id="section11">11. Patents.</h5>
+  11. Patents.
 
-<p>A &ldquo;contributor&rdquo; is a copyright holder who authorizes use under this
+  A "contributor" is a copyright holder who authorizes use under this
 License of the Program or a work on which the Program is based.  The
-work thus licensed is called the contributor's &ldquo;contributor version&rdquo;.</p>
+work thus licensed is called the contributor's "contributor version".
 
-<p>A contributor's &ldquo;essential patent claims&rdquo; are all patent claims
+  A contributor's "essential patent claims" are all patent claims
 owned or controlled by the contributor, whether already acquired or
 hereafter acquired, that would be infringed by some manner, permitted
 by this License, of making, using, or selling its contributor version,
 but do not include claims that would be infringed only as a
 consequence of further modification of the contributor version.  For
-purposes of this definition, &ldquo;control&rdquo; includes the right to grant
+purposes of this definition, "control" includes the right to grant
 patent sublicenses in a manner consistent with the requirements of
-this License.</p>
+this License.
 
-<p>Each contributor grants you a non-exclusive, worldwide, royalty-free
+  Each contributor grants you a non-exclusive, worldwide, royalty-free
 patent license under the contributor's essential patent claims, to
 make, use, sell, offer for sale, import and otherwise run, modify and
-propagate the contents of its contributor version.</p>
+propagate the contents of its contributor version.
 
-<p>In the following three paragraphs, a &ldquo;patent license&rdquo; is any express
+  In the following three paragraphs, a "patent license" is any express
 agreement or commitment, however denominated, not to enforce a patent
 (such as an express permission to practice a patent or covenant not to
-sue for patent infringement).  To &ldquo;grant&rdquo; such a patent license to a
+sue for patent infringement).  To "grant" such a patent license to a
 party means to make such an agreement or commitment not to enforce a
-patent against the party.</p>
+patent against the party.
 
-<p>If you convey a covered work, knowingly relying on a patent license,
+  If you convey a covered work, knowingly relying on a patent license,
 and the Corresponding Source of the work is not available for anyone
 to copy, free of charge and under the terms of this License, through a
 publicly available network server or other readily accessible means,
@@ -723,21 +504,21 @@ then you must either (1) cause the Corresponding Source to be so
 available, or (2) arrange to deprive yourself of the benefit of the
 patent license for this particular work, or (3) arrange, in a manner
 consistent with the requirements of this License, to extend the patent
-license to downstream recipients.  &ldquo;Knowingly relying&rdquo; means you have
+license to downstream recipients.  "Knowingly relying" means you have
 actual knowledge that, but for the patent license, your conveying the
 covered work in a country, or your recipient's use of the covered work
 in a country, would infringe one or more identifiable patents in that
-country that you have reason to believe are valid.</p>
-  
-<p>If, pursuant to or in connection with a single transaction or
+country that you have reason to believe are valid.
+
+  If, pursuant to or in connection with a single transaction or
 arrangement, you convey, or propagate by procuring conveyance of, a
 covered work, and grant a patent license to some of the parties
 receiving the covered work authorizing them to use, propagate, modify
 or convey a specific copy of the covered work, then the patent license
 you grant is automatically extended to all recipients of the covered
-work and works based on it.</p>
+work and works based on it.
 
-<p>A patent license is &ldquo;discriminatory&rdquo; if it does not include within
+  A patent license is "discriminatory" if it does not include within
 the scope of its coverage, prohibits the exercise of, or is
 conditioned on the non-exercise of one or more of the rights that are
 specifically granted under this License.  You may not convey a covered
@@ -750,15 +531,15 @@ patent license (a) in connection with copies of the covered work
 conveyed by you (or copies made from those copies), or (b) primarily
 for and in connection with specific products or compilations that
 contain the covered work, unless you entered into that arrangement,
-or that patent license was granted, prior to 28 March 2007.</p>
+or that patent license was granted, prior to 28 March 2007.
 
-<p>Nothing in this License shall be construed as excluding or limiting
+  Nothing in this License shall be construed as excluding or limiting
 any implied license or other defenses to infringement that may
-otherwise be available to you under applicable patent law.</p>
+otherwise be available to you under applicable patent law.
 
-<h5 id="section12">12. No Surrender of Others' Freedom.</h5>
+  12. No Surrender of Others' Freedom.
 
-<p>If conditions are imposed on you (whether by court order, agreement or
+  If conditions are imposed on you (whether by court order, agreement or
 otherwise) that contradict the conditions of this License, they do not
 excuse you from the conditions of this License.  If you cannot convey a
 covered work so as to satisfy simultaneously your obligations under this
@@ -766,59 +547,59 @@ License and any other pertinent obligations, then as a consequence you may
 not convey it at all.  For example, if you agree to terms that obligate you
 to collect a royalty for further conveying from those to whom you convey
 the Program, the only way you could satisfy both those terms and this
-License would be to refrain entirely from conveying the Program.</p>
+License would be to refrain entirely from conveying the Program.
 
-<h5 id="section13">13. Use with the GNU Affero General Public License.</h5>
+  13. Use with the GNU Affero General Public License.
 
-<p>Notwithstanding any other provision of this License, you have
+  Notwithstanding any other provision of this License, you have
 permission to link or combine any covered work with a work licensed
 under version 3 of the GNU Affero General Public License into a single
 combined work, and to convey the resulting work.  The terms of this
 License will continue to apply to the part which is the covered work,
 but the special requirements of the GNU Affero General Public License,
 section 13, concerning interaction through a network will apply to the
-combination as such.</p>
+combination as such.
 
-<h5 id="section14">14. Revised Versions of this License.</h5>
+  14. Revised Versions of this License.
 
-<p>The Free Software Foundation may publish revised and/or new versions of
+  The Free Software Foundation may publish revised and/or new versions of
 the GNU General Public License from time to time.  Such new versions will
 be similar in spirit to the present version, but may differ in detail to
-address new problems or concerns.</p>
+address new problems or concerns.
 
-<p>Each version is given a distinguishing version number.  If the
+  Each version is given a distinguishing version number.  If the
 Program specifies that a certain numbered version of the GNU General
-Public License &ldquo;or any later version&rdquo; applies to it, you have the
+Public License "or any later version" applies to it, you have the
 option of following the terms and conditions either of that numbered
 version or of any later version published by the Free Software
 Foundation.  If the Program does not specify a version number of the
 GNU General Public License, you may choose any version ever published
-by the Free Software Foundation.</p>
+by the Free Software Foundation.
 
-<p>If the Program specifies that a proxy can decide which future
+  If the Program specifies that a proxy can decide which future
 versions of the GNU General Public License can be used, that proxy's
 public statement of acceptance of a version permanently authorizes you
-to choose that version for the Program.</p>
+to choose that version for the Program.
 
-<p>Later license versions may give you additional or different
+  Later license versions may give you additional or different
 permissions.  However, no additional obligations are imposed on any
 author or copyright holder as a result of your choosing to follow a
-later version.</p>
+later version.
 
-<h5 id="section15">15. Disclaimer of Warranty.</h5>
+  15. Disclaimer of Warranty.
 
-<p>THERE IS NO WARRANTY FOR THE PROGRAM, TO THE EXTENT PERMITTED BY
+  THERE IS NO WARRANTY FOR THE PROGRAM, TO THE EXTENT PERMITTED BY
 APPLICABLE LAW.  EXCEPT WHEN OTHERWISE STATED IN WRITING THE COPYRIGHT
-HOLDERS AND/OR OTHER PARTIES PROVIDE THE PROGRAM &ldquo;AS IS&rdquo; WITHOUT WARRANTY
+HOLDERS AND/OR OTHER PARTIES PROVIDE THE PROGRAM "AS IS" WITHOUT WARRANTY
 OF ANY KIND, EITHER EXPRESSED OR IMPLIED, INCLUDING, BUT NOT LIMITED TO,
 THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR
 PURPOSE.  THE ENTIRE RISK AS TO THE QUALITY AND PERFORMANCE OF THE PROGRAM
 IS WITH YOU.  SHOULD THE PROGRAM PROVE DEFECTIVE, YOU ASSUME THE COST OF
-ALL NECESSARY SERVICING, REPAIR OR CORRECTION.</p>
+ALL NECESSARY SERVICING, REPAIR OR CORRECTION.
 
-<h5 id="section16">16. Limitation of Liability.</h5>
+  16. Limitation of Liability.
 
-<p>IN NO EVENT UNLESS REQUIRED BY APPLICABLE LAW OR AGREED TO IN WRITING
+  IN NO EVENT UNLESS REQUIRED BY APPLICABLE LAW OR AGREED TO IN WRITING
 WILL ANY COPYRIGHT HOLDER, OR ANY OTHER PARTY WHO MODIFIES AND/OR CONVEYS
 THE PROGRAM AS PERMITTED ABOVE, BE LIABLE TO YOU FOR DAMAGES, INCLUDING ANY
 GENERAL, SPECIAL, INCIDENTAL OR CONSEQUENTIAL DAMAGES ARISING OUT OF THE
@@ -826,32 +607,32 @@ USE OR INABILITY TO USE THE PROGRAM (INCLUDING BUT NOT LIMITED TO LOSS OF
 DATA OR DATA BEING RENDERED INACCURATE OR LOSSES SUSTAINED BY YOU OR THIRD
 PARTIES OR A FAILURE OF THE PROGRAM TO OPERATE WITH ANY OTHER PROGRAMS),
 EVEN IF SUCH HOLDER OR OTHER PARTY HAS BEEN ADVISED OF THE POSSIBILITY OF
-SUCH DAMAGES.</p>
+SUCH DAMAGES.
 
-<h5 id="section17">17. Interpretation of Sections 15 and 16.</h5>
+  17. Interpretation of Sections 15 and 16.
 
-<p>If the disclaimer of warranty and limitation of liability provided
+  If the disclaimer of warranty and limitation of liability provided
 above cannot be given local legal effect according to their terms,
 reviewing courts shall apply local law that most closely approximates
 an absolute waiver of all civil liability in connection with the
 Program, unless a warranty or assumption of liability accompanies a
-copy of the Program in return for a fee.</p>
+copy of the Program in return for a fee.
 
-<p>END OF TERMS AND CONDITIONS</p>
+                     END OF TERMS AND CONDITIONS
 
-<h4 id="howto">How to Apply These Terms to Your New Programs</h4>
+            How to Apply These Terms to Your New Programs
 
-<p>If you develop a new program, and you want it to be of the greatest
+  If you develop a new program, and you want it to be of the greatest
 possible use to the public, the best way to achieve this is to make it
-free software which everyone can redistribute and change under these terms.</p>
+free software which everyone can redistribute and change under these terms.
 
-<p>To do so, attach the following notices to the program.  It is safest
+  To do so, attach the following notices to the program.  It is safest
 to attach them to the start of each source file to most effectively
 state the exclusion of warranty; and each file should have at least
-the &ldquo;copyright&rdquo; line and a pointer to where the full notice is found.</p>
+the "copyright" line and a pointer to where the full notice is found.
 
-<pre>    &lt;one line to give the program's name and a brief idea of what it does.&gt;
-    Copyright (C) &lt;year&gt;  &lt;name of author&gt;
+    <one line to give the program's name and a brief idea of what it does.>
+    Copyright (C) <year>  <name of author>
 
     This program is free software: you can redistribute it and/or modify
     it under the terms of the GNU General Public License as published by
@@ -864,163 +645,30 @@ the &ldquo;copyright&rdquo; line and a pointer to where the full notice is found
     GNU General Public License for more details.
 
     You should have received a copy of the GNU General Public License
-    along with this program.  If not, see &lt;https://www.gnu.org/licenses/&gt;.
-</pre>
+    along with this program.  If not, see <https://www.gnu.org/licenses/>.
 
-<p>Also add information on how to contact you by electronic and paper mail.</p>
+Also add information on how to contact you by electronic and paper mail.
 
-<p>If the program does terminal interaction, make it output a short
-notice like this when it starts in an interactive mode:</p>
+  If the program does terminal interaction, make it output a short
+notice like this when it starts in an interactive mode:
 
-<pre>    &lt;program&gt;  Copyright (C) &lt;year&gt;  &lt;name of author&gt;
+    <program>  Copyright (C) <year>  <name of author>
     This program comes with ABSOLUTELY NO WARRANTY; for details type `show w'.
     This is free software, and you are welcome to redistribute it
     under certain conditions; type `show c' for details.
-</pre>
 
-<p>The hypothetical commands `show w' and `show c' should show the appropriate
+The hypothetical commands `show w' and `show c' should show the appropriate
 parts of the General Public License.  Of course, your program's commands
-might be different; for a GUI interface, you would use an &ldquo;about box&rdquo;.</p>
+might be different; for a GUI interface, you would use an "about box".
 
-<p>You should also get your employer (if you work as a programmer) or school,
-if any, to sign a &ldquo;copyright disclaimer&rdquo; for the program, if necessary.
+  You should also get your employer (if you work as a programmer) or school,
+if any, to sign a "copyright disclaimer" for the program, if necessary.
 For more information on this, and how to apply and follow the GNU GPL, see
-&lt;<a href="https://www.gnu.org/licenses/">https://www.gnu.org/licenses/</a>&gt;.</p>
+<https://www.gnu.org/licenses/>.
 
-<p>The GNU General Public License does not permit incorporating your program
+  The GNU General Public License does not permit incorporating your program
 into proprietary programs.  If your program is a subroutine library, you
 may consider it more useful to permit linking proprietary applications with
 the library.  If this is what you want to do, use the GNU Lesser General
 Public License instead of this License.  But first, please read
-&lt;<a href="https://www.gnu.org/licenses/why-not-lgpl.html">https://www.gnu.org/licenses/why-not-lgpl.html</a>&gt;.</p>
-
-</div>
-</div>
-
-</div><!-- for id="content", starts in the include above -->
-
-              <!-- begin server/footer-text.html -->
-
-
-
-
-
-<div style="clear:both"></div>
-
-
-<div id="language-container">
- <div class="backtotop">
-  <hr class="no-display" />
-  <a href="#top"><b>&#9650;</b></a>
- </div>
- <div id="languages" class="rounded-corners">
-  <div class="button">
-   <a href="#top" class="close"><span>BACK TO TOP</span></a>
-  </div>
-  <div id="set-language" class="button">
-   <span class="gnun-split"></span>
-   <a href="/server/select-language.html?callback=/licenses/gpl-3.0" rel="nofollow">
-   Set language
-   <span class="gnun-split"></span>
-   </a>
-  </div>
-  <p>Available for this page:</p>
-  <div id="translations">
-<p>
-<span dir="ltr" class="original">[en]&nbsp;<a lang="en" hreflang="en" href="/licenses/gpl-3.0.en.html">English</a> &nbsp;</span>
-<span dir="ltr">[ar]&nbsp;<a lang="ar" hreflang="ar" href="/licenses/gpl-3.0.ar.html">العربية</a> &nbsp;</span>
-<span dir="ltr">[ca]&nbsp;<a lang="ca" hreflang="ca" href="/licenses/gpl-3.0.ca.html">català</a> &nbsp;</span>
-<span dir="ltr">[de]&nbsp;<a lang="de" hreflang="de" href="/licenses/gpl-3.0.de.html">Deutsch</a> &nbsp;</span>
-<span dir="ltr">[fr]&nbsp;<a lang="fr" hreflang="fr" href="/licenses/gpl-3.0.fr.html">français</a> &nbsp;</span>
-<span dir="ltr">[ja]&nbsp;<a lang="ja" hreflang="ja" href="/licenses/gpl-3.0.ja.html">日本語</a> &nbsp;</span>
-<span dir="ltr">[nl]&nbsp;<a lang="nl" hreflang="nl" href="/licenses/gpl-3.0.nl.html">Nederlands</a> &nbsp;</span>
-<span dir="ltr">[pt-br]&nbsp;<a lang="pt-br" hreflang="pt-br" href="/licenses/gpl-3.0.pt-br.html">português</a> &nbsp;</span>
-<span dir="ltr">[ru]&nbsp;<a lang="ru" hreflang="ru" href="/licenses/gpl-3.0.ru.html">русский</a> &nbsp;</span>
-<span dir="ltr">[tr]&nbsp;<a lang="tr" hreflang="tr" href="/licenses/gpl-3.0.tr.html">Türkçe</a> &nbsp;</span>
-<span dir="ltr">[uk]&nbsp;<a lang="uk" hreflang="uk" href="/licenses/gpl-3.0.uk.html">українська</a> &nbsp;</span>
-<span dir="ltr">[zh-cn]&nbsp;<a lang="zh-cn" hreflang="zh-cn" href="/licenses/gpl-3.0.zh-cn.html">简体中文</a> &nbsp;</span>
-<span dir="ltr">[zh-tw]&nbsp;<a lang="zh-tw" hreflang="zh-tw" href="/licenses/gpl-3.0.zh-tw.html">繁體中文</a> &nbsp;</span>
-</p>
-</div>
- </div>
-</div>
-
-<div id="mission-statement" role="complementary">
- <div class="backtotop">
-  <hr class="no-display" />
-  <a href="#header"><span>BACK TO TOP </span>&#9650;</a>
- </div>
-<div style="clear: both"></div>
-<blockquote>
-<p style="direction:ltr; text-align:left"><a href="//www.fsf.org"><img id="fsfbanner"
-src="/graphics/fsf-logo-notext-small.png" alt="&nbsp;[FSF logo]&nbsp;"
-width="75" height="25" /></a><strong>
-&ldquo;The Free Software Foundation (FSF) is a nonprofit with a worldwide
-mission to promote computer user freedom. We defend the rights of all
-software users.&rdquo;</strong></p>
-</blockquote>
-
-<div id="support-the-fsf" class="button">
- <a class="join" href="//www.fsf.org/associate/support_freedom?referrer=4052">JOIN</a>
- <a class="donate" href="//donate.fsf.org/">DONATE</a>
- <a class="shop" href="//shop.fsf.org/">SHOP</a>
-</div>
-</div>
-<!-- end server/footer-text.html -->
-
-
-<div id="footer" role="contentinfo">
-<div class="unprintable">
-
-<p>Please send general FSF &amp; GNU inquiries to
-<a href="mailto:gnu@gnu.org">&lt;gnu@gnu.org&gt;</a>.
-There are also <a href="/contact/">other ways to contact</a>
-the FSF.  Broken links and other corrections or suggestions can be sent
-to <a href="mailto:webmasters@gnu.org">&lt;webmasters@gnu.org&gt;</a>.</p>
-
-<p><!-- TRANSLATORS: Ignore the original text in this paragraph,
-        replace it with the translation of these two:
-
-        We work hard and do our best to provide accurate, good quality
-        translations.  However, we are not exempt from imperfection.
-        Please send your comments and general suggestions in this regard
-        to <a href="mailto:web-translators@gnu.org">
-        &lt;web-translators@gnu.org&gt;</a>.</p>
-
-        <p>For information on coordinating and contributing translations of
-        our web pages, see <a
-        href="/server/standards/README.translations.html">Translations
-        README</a>. -->
-Please see the <a
-href="/server/standards/README.translations.html">Translations
-README</a> for information on coordinating and contributing translations
-of this article.</p>
-</div>
-
-<p>Copyright notice above.</p>
-
-<p>
-Everyone is permitted to copy and distribute verbatim copies of this license
-document, but changing it is not allowed.
-</p>
-
-<!-- start of server/bottom-notes.html -->
-<div id="bottom-notes" class="unprintable">
-<p><a href="//www.fsf.org/about/dmca-notice">Copyright Infringement Notification</a></p>
-<div id="generic">
-
-
-</div>
-</div>
-<!-- end of server/bottom-notes.html -->
-
-
-<p class="unprintable">Updated:
-<!-- timestamp start -->
-$Date: 2023/11/30 09:46:01 $
-<!-- timestamp end -->
-</p>
-</div>
-</div><!-- for class="inner", starts in the banner include -->
-</body>
-</html>
+<https://www.gnu.org/licenses/why-not-lgpl.html>.

--- a/licenses-generator/src/main/resources/offline-license-mirror/www.gnu.org/licenses/lgpl-2.1
+++ b/licenses-generator/src/main/resources/offline-license-mirror/www.gnu.org/licenses/lgpl-2.1
@@ -1,252 +1,29 @@
-<!DOCTYPE html>
-<html xmlns="http://www.w3.org/1999/xhtml" xml:lang="en" lang="en">
-<head>
-<meta http-equiv="content-type" content="text/html; charset=utf-8" />
-<link rel="author" href="mailto:webmasters@gnu.org" />
-<link rel="icon" type="image/png" href="/graphics/gnu-head-mini.png" />
-<meta name="ICBM" content="42.355469,-71.058627" />
-<link rel="stylesheet" type="text/css" href="/layout.min.css" media="screen" />
-<link rel="stylesheet" type="text/css" href="/print.min.css" media="print" />
+                  GNU LESSER GENERAL PUBLIC LICENSE
+                       Version 2.1, February 1999
 
-
-
-<!-- Parent-Version: 1.98 -->
-<!-- This page is derived from /server/standards/boilerplate.html -->
-<title>GNU Lesser General Public License v2.1 - GNU Project - Free Software Foundation</title>
-<link rel="alternate" type="application/rdf+xml" href="lgpl-2.1.rdf" /> 
-<!-- begin translist file -->
-
-<link rel="alternate" type="text/html" href="/licenses/old-licenses/lgpl-2.1.html" hreflang="x-default" />
-<link rel="alternate" type="text/html" lang="en" hreflang="en" href="/licenses/old-licenses/lgpl-2.1.en.html" title="English" />
-<link rel="alternate" type="text/html" lang="de" hreflang="de" href="/licenses/old-licenses/lgpl-2.1.de.html" title="Deutsch" />
-<link rel="alternate" type="text/html" lang="fr" hreflang="fr" href="/licenses/old-licenses/lgpl-2.1.fr.html" title="français" />
-<link rel="alternate" type="text/html" lang="ja" hreflang="ja" href="/licenses/old-licenses/lgpl-2.1.ja.html" title="日本語" />
-<link rel="alternate" type="text/html" lang="pt-br" hreflang="pt-br" href="/licenses/old-licenses/lgpl-2.1.pt-br.html" title="português" />
-<link rel="alternate" type="text/html" lang="ru" hreflang="ru" href="/licenses/old-licenses/lgpl-2.1.ru.html" title="русский" />
-<link rel="alternate" type="text/html" lang="uk" hreflang="uk" href="/licenses/old-licenses/lgpl-2.1.uk.html" title="українська" />
-<link rel="alternate" type="text/html" lang="zh-cn" hreflang="zh-cn" href="/licenses/old-licenses/lgpl-2.1.zh-cn.html" title="简体中文" />
-<!-- end translist file -->
-
-<!-- start of server/banner.html -->
-<!-- start of head-include-2.html -->
-<meta name="viewport" content="width=device-width, initial-scale=1" />
-<!-- end of head-include-2.html -->
-
-</head>
-<body>
-<div class="inner">
-<!-- start of server/body-include-1.html -->
-<div id="top">
-<a class="skip" href="#content"><b>Skip to main text</b></a>
-</div>
-
-<div id="fsf-frame" role="complementary">
-<form id="fssbox" action="https://my.fsf.org/civicrm/profile/create?reset=1&amp;gid=31"
-      method="post">
- <div>
-  <input name="postURL" type="hidden" value="" />
-  <input type="hidden" name="group[25]" value="1" />
-  <input name="cancelURL" type="hidden" value="https://crm.fsf.org/civicrm/profile?reset=1&amp;gid=31" />
-  <input name="_qf_default" type="hidden" value="Edit:cancel" />
-  <label for="frmEmail">
-   <a href="//www.fsf.org/fss">Free Software Supporter</a>:
-  </label>
-  <input type="text" id="frmEmail" name="email-Primary" size="18" maxlength="80"
-         value="email address" onfocus="this.value=''"/>
-  <input type="submit" name="_qf_Edit_next" value="Sign up" />
- </div>
-</form>
-
-<div id="join-fsf" class="button"><a
-href="https://www.fsf.org/associate/support_freedom?referrer=4052">JOIN&nbsp;THE&nbsp;FSF</a>
-</div>
-</div>
-
-<div id="header" role="banner">
-<p id="gnu-banner">
- <a href="/">
- <img src="/graphics/heckert_gnu.transp.small.png" height="48" width="49"
-      alt="&nbsp;[A GNU head]&nbsp;" /><strong>GNU</strong> <span
- class="hide">Operating System</span></a><br />
- <small id="fsf-support">Supported by the
- <a href="#mission-statement">Free Software Foundation</a></small>
-</p>
-
-<div id="switches">
-<!-- begin search button -->
- <div  id="search-button" class="switch">
-  <a href="//www.gnu.org/cgi-bin/estseek.cgi">
-  <img id="search-icon" height="30" width="30"
-       src="/graphics/icons/search.png"
-       alt="&nbsp;[Search www.gnu.org]&nbsp;" /></a>
- </div>
-<!-- end search button -->
-
- <div id="language-button" class="switch">
-  <a href="#language-container">
-  <img id="language-icon" height="30" width="37"
-       src="/graphics/icons/translations.png"
-       alt="&nbsp;[Other languages]&nbsp;" /></a>
- </div>
-
-</div>
-</div>
-<!-- end of server/body-include-1.html -->
-
-<!-- start of server/body-include-2 -->
-
-
-<div style="clear: both"></div>
-
-<div id="navigation" role="navigation">
- <a id="more-links" href="#navigation" title="More...">
-   <span>Site navigation</span></a>
- <a id="less-links" href="#content"><b>Skip</b></a>
- <ul>
-
-   <li id="tabAboutGNU"><a href="/gnu/gnu.html">ABOUT&nbsp;GNU</a></li>
-
-
-  <li id="tabPhilosophy"><a href="/philosophy/philosophy.html">PHILOSOPHY</a></li>
-
-
-  <li id="tabLicenses" class="active">
-     <span class='no-display'>=</span> 
-    <a href="/licenses/licenses.html">LICENSES</a>
-    <span class="gnun-split"></span>
-     <span class='no-display'>=</span> 
-  </li>
-
-
-  <li id="tabEducation"><a href="/education/education.html">EDUCATION</a></li>
-
-
-  <li id="tabSoftware"><a href="/software/software.html">SOFTWARE</a></li>
-
-
-  <li id="tabDistros"><a href="/distros/distros.html">DISTROS</a></li>
-
-
-  <li id="tabDoc"><a href="/doc/doc.html">DOCS</a></li>
-
-
-  <li id="tabMalware"><a href="/proprietary/proprietary.html">MALWARE</a></li>
-
-
-  <li id="tabHelp"><a href="/help/help.html">HELP&nbsp;GNU</a></li>
-
-
-  <li id="tabAV"><a href="/audio-video/audio-video.html">AUDIO&nbsp;&amp;&nbsp;VIDEO</a></li>
-
-
-  <li id="tabArt"><a href="/graphics/graphics.html">GNU&nbsp;ART</a></li>
-
-
-  <li id="tabFun"><a href="/fun/humor.html">FUN</a></li>
-
-
-  <li id="tabPeople"><a href="/people/people.html">GNU'S&nbsp;WHO?</a></li>
-
-  <li><a href="//directory.fsf.org">SOFTWARE&nbsp;DIRECTORY</a></li>
-  <li><a href="https://h-node.org/">HARDWARE</a></li>
-  <li><a href="/server/sitemap.html">SITEMAP</a></li>
- </ul>
- <div style="clear: both"></div>
-</div><!-- /"navigation -->
-<!-- end of server/body-include-2 -->
-
-<div id="content" role="main">
-<!-- end of server/banner.html -->
-
-<div class="reduced-width">
-<h2>GNU Lesser General Public License, version&nbsp;2.1</h2>
-
-<p class="button" style="margin: 2em 1.5em">
-  <b><a href="#SEC1">Skip to license text</a></b></p>
-
-<ul>
-  <li><a href="/licenses/lgpl.html">The latest version of the LGPL, version
-    3</a></li>
-  <li><a href="/licenses/why-not-lgpl.html">Why you shouldn't use the Lesser
-    GPL for your next library</a></li>
-  <li><a href="/licenses/gpl-violation.html">What to do if you see a possible
-    LGPL violation</a></li>
-  <li><a href="/licenses/old-licenses/lgpl-2.1-translations.html">Translations
-    of LGPLv2.1</a></li>
-  <li>The GNU Lesser General Public License version 2.1 (LGPLv2.1) in other
-    formats: <a href="/licenses/old-licenses/lgpl-2.1.txt">plain text</a>, <a
-    href="/licenses/old-licenses/lgpl-2.1.texi">Texinfo</a>, <a
-    href="/licenses/old-licenses/lgpl-2.1-standalone.html">standalone HTML</a>, <a
-    href="/licenses/old-licenses/lgpl-2.1.dbk">Docbook</a>, 
-    <a href="/licenses/old-licenses/lgpl-2.1.md">Markdown</a>, 
-    <a href="/licenses/old-licenses/lgpl-2.1.odt">ODF</a>, 
-    <a href="/licenses/old-licenses/lgpl-2.1.rtf">RTF</a>, and
-    <a href="/licenses/old-licenses/lgpl-2.1.tex">LaTeX</a>
-</li>
-  <li><a href="/licenses/old-licenses/old-licenses.html#LGPL">Old versions of
-    the LGPL</a></li>
-</ul>
-
-<div class="thin"></div>
-
-<p>This GNU Lesser General Public License counts as the successor of the GNU
-Library General Public License. For an explanation of why this change was
-necessary, read the <a href="/licenses/why-not-lgpl.html">Why you shouldn't use
-the Lesser GPL for your next library</a> article.</p>
-
-<h3>Table of Contents</h3>
-<ul>
-  <li><a id="TOC1" href="#SEC1">GNU LESSER GENERAL PUBLIC LICENSE</a> 
-    <ul>
-      <li><a id="TOC2" href="#SEC2">Preamble</a></li>
-      <li><a id="TOC3" href="#SEC3">TERMS AND CONDITIONS FOR COPYING,
-        DISTRIBUTION AND MODIFICATION</a></li>
-      <li><a id="TOC4" href="#SEC4">How to Apply These Terms to Your New
-        Libraries</a></li>
-    </ul>
-  </li>
-</ul>
-
-<hr class="thin" />
-
-<!-- The license text is in English and appears broken in RTL as
-Arabic, Farsi, etc. Explicitly set the direction to override the
-one defined in the translation. -->
-<div dir="ltr">
-<h3 id="SEC1">GNU LESSER GENERAL PUBLIC LICENSE</h3>
-<p>
-Version 2.1, February 1999
-</p>
-
-<pre>
-Copyright (C) 1991, 1999 Free Software Foundation, Inc.
-&lt;<a href="https://fsf.org/">https://fsf.org/</a>&gt;
-Everyone is permitted to copy and distribute verbatim copies
-of this license document, but changing it is not allowed.
+ Copyright (C) 1991, 1999 Free Software Foundation, Inc.
+ <https://fsf.org/>
+ Everyone is permitted to copy and distribute verbatim copies
+ of this license document, but changing it is not allowed.
 
 [This is the first released version of the Lesser GPL.  It also counts
  as the successor of the GNU Library Public License, version 2, hence
  the version number 2.1.]
-</pre>
 
+                            Preamble
 
-<h4 id="SEC2">Preamble</h4>
-
-<p>
   The licenses for most software are designed to take away your
 freedom to share and change it.  By contrast, the GNU General Public
 Licenses are intended to guarantee your freedom to share and change
 free software--to make sure the software is free for all its users.
-</p>
-<p>
+
   This license, the Lesser General Public License, applies to some
 specially designated software packages--typically libraries--of the
 Free Software Foundation and other authors who decide to use it.  You
 can use it too, but we suggest you first think carefully about whether
 this license or the ordinary General Public License is the better
 strategy to use in any particular case, based on the explanations below.
-</p>
-<p>
+
   When we speak of free software, we are referring to freedom of use,
 not price.  Our General Public Licenses are designed to make sure that
 you have the freedom to distribute copies of free software (and charge
@@ -254,14 +31,12 @@ for this service if you wish); that you receive source code or can get
 it if you want it; that you can change the software and use pieces of
 it in new free programs; and that you are informed that you can do
 these things.
-</p>
-<p>
+
   To protect your rights, we need to make restrictions that forbid
 distributors to deny you these rights or to ask you to surrender these
 rights.  These restrictions translate to certain responsibilities for
 you if you distribute copies of the library or if you modify it.
-</p>
-<p>
+
   For example, if you distribute copies of the library, whether gratis
 or for a fee, you must give the recipients all the rights that we gave
 you.  You must make sure that they, too, receive or can get the source
@@ -269,37 +44,32 @@ code.  If you link other code with the library, you must provide
 complete object files to the recipients, so that they can relink them
 with the library after making changes to the library and recompiling
 it.  And you must show them these terms so they know their rights.
-</p>
-<p>
+
   We protect your rights with a two-step method: (1) we copyright the
 library, and (2) we offer you this license, which gives you legal
 permission to copy, distribute and/or modify the library.
-</p>
-<p>
+
   To protect each distributor, we want to make it very clear that
 there is no warranty for the free library.  Also, if the library is
 modified by someone else and passed on, the recipients should know
 that what they have is not the original version, so that the original
 author's reputation will not be affected by problems that might be
 introduced by others.
-</p>
-<p>
+
   Finally, software patents pose a constant threat to the existence of
 any free program.  We wish to make sure that a company cannot
 effectively restrict the users of a free program by obtaining a
 restrictive license from a patent holder.  Therefore, we insist that
 any patent license obtained for a version of the library must be
 consistent with the full freedom of use specified in this license.
-</p>
-<p>
+
   Most GNU software, including some libraries, is covered by the
 ordinary GNU General Public License.  This license, the GNU Lesser
 General Public License, applies to certain designated libraries, and
 is quite different from the ordinary General Public License.  We use
 this license for certain libraries in order to permit linking those
 libraries into non-free programs.
-</p>
-<p>
+
   When a program is linked with a library, whether statically or using
 a shared library, the combination of the two is legally speaking a
 combined work, a derivative of the original library.  The ordinary
@@ -307,8 +77,7 @@ General Public License therefore permits such linking only if the
 entire combination fits its criteria of freedom.  The Lesser General
 Public License permits more lax criteria for linking other code with
 the library.
-</p>
-<p>
+
   We call this license the "Lesser" General Public License because it
 does Less to protect the user's freedom than the ordinary General
 Public License.  It also provides other free software developers Less
@@ -316,8 +85,7 @@ of an advantage over competing non-free programs.  These disadvantages
 are the reason we use the ordinary General Public License for many
 libraries.  However, the Lesser license provides advantages in certain
 special circumstances.
-</p>
-<p>
+
   For example, on rare occasions, there may be a special need to
 encourage the widest possible use of a certain library, so that it becomes
 a de-facto standard.  To achieve this, non-free programs must be
@@ -325,46 +93,38 @@ allowed to use the library.  A more frequent case is that a free
 library does the same job as widely used non-free libraries.  In this
 case, there is little to gain by limiting the free library to free
 software only, so we use the Lesser General Public License.
-</p>
-<p>
+
   In other cases, permission to use a particular library in non-free
 programs enables a greater number of people to use a large body of
 free software.  For example, permission to use the GNU C Library in
 non-free programs enables many more people to use the whole GNU
 operating system, as well as its variant, the GNU/Linux operating
 system.
-</p>
-<p>
+
   Although the Lesser General Public License is Less protective of the
 users' freedom, it does ensure that the user of a program that is
 linked with the Library has the freedom and the wherewithal to run
 that program using a modified version of the Library.
-</p>
-<p>
+
   The precise terms and conditions for copying, distribution and
 modification follow.  Pay close attention to the difference between a
 "work based on the library" and a "work that uses the library".  The
 former contains code derived from the library, whereas the latter must
 be combined with the library in order to run.
-</p>
+
+                  GNU LESSER GENERAL PUBLIC LICENSE
+   TERMS AND CONDITIONS FOR COPYING, DISTRIBUTION AND MODIFICATION
 
-<h4 id="SEC3">TERMS AND CONDITIONS FOR COPYING, DISTRIBUTION AND MODIFICATION</h4>
-
-
-<p>
-<strong>0.</strong>
-This License Agreement applies to any software library or other
+  0. This License Agreement applies to any software library or other
 program which contains a notice placed by the copyright holder or
 other authorized party saying it may be distributed under the terms of
 this Lesser General Public License (also called "this License").
 Each licensee is addressed as "you".
-</p>
-<p>
+
   A "library" means a collection of software functions and/or data
 prepared so as to be conveniently linked with application programs
 (which use some of those functions and data) to form executables.
-</p>
-<p>
+
   The "Library", below, refers to any such software library or work
 which has been distributed under these terms.  A "work based on the
 Library" means either the Library or any derivative work under
@@ -372,15 +132,13 @@ copyright law: that is to say, a work containing the Library or a
 portion of it, either verbatim or with modifications and/or translated
 straightforwardly into another language.  (Hereinafter, translation is
 included without limitation in the term "modification".)
-</p>
-<p>
+
   "Source code" for a work means the preferred form of the work for
 making modifications to it.  For a library, complete source code means
 all the source code for all modules it contains, plus any associated
 interface definition files, plus the scripts used to control compilation
 and installation of the library.
-</p>
-<p>
+
   Activities other than copying, distribution and modification are not
 covered by this License; they are outside its scope.  The act of
 running a program using the Library is not restricted, and output from
@@ -388,84 +146,69 @@ such a program is covered only if its contents constitute a work based
 on the Library (independent of the use of the Library in a tool for
 writing it).  Whether that is true depends on what the Library does
 and what the program that uses the Library does.
-</p>
-<p>
-<strong>1.</strong>
-You may copy and distribute verbatim copies of the Library's
+
+  1. You may copy and distribute verbatim copies of the Library's
 complete source code as you receive it, in any medium, provided that
 you conspicuously and appropriately publish on each copy an
 appropriate copyright notice and disclaimer of warranty; keep intact
 all the notices that refer to this License and to the absence of any
 warranty; and distribute a copy of this License along with the
 Library.
-</p>
-<p>
+
   You may charge a fee for the physical act of transferring a copy,
 and you may at your option offer warranty protection in exchange for a
 fee.
-</p>
-<p>
-<strong>2.</strong>
-You may modify your copy or copies of the Library or any portion
+
+  2. You may modify your copy or copies of the Library or any portion
 of it, thus forming a work based on the Library, and copy and
 distribute such modifications or work under the terms of Section 1
 above, provided that you also meet all of these conditions:
-</p>
 
-<ul>
-  <li><strong>a)</strong>
-       The modified work must itself be a software library.</li>
-  <li><strong>b)</strong>
-       You must cause the files modified to carry prominent notices
-       stating that you changed the files and the date of any change.</li>
+    a) The modified work must itself be a software library.
 
-  <li><strong>c)</strong>
-       You must cause the whole of the work to be licensed at no
-       charge to all third parties under the terms of this License.</li>
+    b) You must cause the files modified to carry prominent notices
+    stating that you changed the files and the date of any change.
 
-  <li><strong>d)</strong>
-       If a facility in the modified Library refers to a function or a
-       table of data to be supplied by an application program that uses
-       the facility, other than as an argument passed when the facility
-       is invoked, then you must make a good faith effort to ensure that,
-       in the event an application does not supply such function or
-       table, the facility still operates, and performs whatever part of
-       its purpose remains meaningful.
-       <p>
-       (For example, a function in a library to compute square roots has
-       a purpose that is entirely well-defined independent of the
-       application.  Therefore, Subsection 2d requires that any
-       application-supplied function or table used by this function must
-       be optional: if the application does not supply it, the square
-       root function must still compute square roots.)</p></li>
-</ul>
+    c) You must cause the whole of the work to be licensed at no
+    charge to all third parties under the terms of this License.
 
-<p>
-These requirements apply to the modified work as a whole.  If identifiable
-sections of that work are not derived from the Library, and can be
-reasonably considered independent and separate works in themselves, then
-this License, and its terms, do not apply to those sections when you
-distribute them as separate works.  But when you distribute the same
-sections as part of a whole which is a work based on the Library, the
-distribution of the whole must be on the terms of this License, whose
-permissions for other licensees extend to the entire whole, and thus to
-each and every part regardless of who wrote it.
-</p>
-<p>
-Thus, it is not the intent of this section to claim rights or contest your
-rights to work written entirely by you; rather, the intent is to exercise
-the right to control the distribution of derivative or collective works
-based on the Library.
-</p>
-<p>
-In addition, mere aggregation of another work not based on the Library with
-the Library (or with a work based on the Library) on a volume of a storage
-or distribution medium does not bring the other work under the scope of
-this License.
-</p>
-<p>
-<strong>3.</strong>
-You may opt to apply the terms of the ordinary GNU General Public
+    d) If a facility in the modified Library refers to a function or a
+    table of data to be supplied by an application program that uses
+    the facility, other than as an argument passed when the facility
+    is invoked, then you must make a good faith effort to ensure that,
+    in the event an application does not supply such function or
+    table, the facility still operates, and performs whatever part of
+    its purpose remains meaningful.
+
+    (For example, a function in a library to compute square roots has
+    a purpose that is entirely well-defined independent of the
+    application.  Therefore, Subsection 2d requires that any
+    application-supplied function or table used by this function must
+    be optional: if the application does not supply it, the square
+    root function must still compute square roots.)
+
+These requirements apply to the modified work as a whole.  If
+identifiable sections of that work are not derived from the Library,
+and can be reasonably considered independent and separate works in
+themselves, then this License, and its terms, do not apply to those
+sections when you distribute them as separate works.  But when you
+distribute the same sections as part of a whole which is a work based
+on the Library, the distribution of the whole must be on the terms of
+this License, whose permissions for other licensees extend to the
+entire whole, and thus to each and every part regardless of who wrote
+it.
+
+Thus, it is not the intent of this section to claim rights or contest
+your rights to work written entirely by you; rather, the intent is to
+exercise the right to control the distribution of derivative or
+collective works based on the Library.
+
+In addition, mere aggregation of another work not based on the Library
+with the Library (or with a work based on the Library) on a volume of
+a storage or distribution medium does not bring the other work under
+the scope of this License.
+
+  3. You may opt to apply the terms of the ordinary GNU General Public
 License instead of this License to a given copy of the Library.  To do
 this, you must alter all the notices that refer to this License, so
 that they refer to the ordinary GNU General Public License, version 2,
@@ -473,79 +216,65 @@ instead of to this License.  (If a newer version than version 2 of the
 ordinary GNU General Public License has appeared, then you can specify
 that version instead if you wish.)  Do not make any other change in
 these notices.
-</p>
-<p>
+
   Once this change is made in a given copy, it is irreversible for
 that copy, so the ordinary GNU General Public License applies to all
 subsequent copies and derivative works made from that copy.
-</p>
-<p>
+
   This option is useful when you wish to copy part of the code of
 the Library into a program that is not a library.
-</p>
-<p>
-<strong>4.</strong>
-You may copy and distribute the Library (or a portion or
+
+  4. You may copy and distribute the Library (or a portion or
 derivative of it, under Section 2) in object code or executable form
 under the terms of Sections 1 and 2 above provided that you accompany
 it with the complete corresponding machine-readable source code, which
 must be distributed under the terms of Sections 1 and 2 above on a
 medium customarily used for software interchange.
-</p>
-<p>
+
   If distribution of object code is made by offering access to copy
 from a designated place, then offering equivalent access to copy the
 source code from the same place satisfies the requirement to
 distribute the source code, even though third parties are not
 compelled to copy the source along with the object code.
-</p>
-<p>
-<strong>5.</strong>
-A program that contains no derivative of any portion of the
+
+  5. A program that contains no derivative of any portion of the
 Library, but is designed to work with the Library by being compiled or
 linked with it, is called a "work that uses the Library".  Such a
 work, in isolation, is not a derivative work of the Library, and
 therefore falls outside the scope of this License.
-</p>
-<p>
+
   However, linking a "work that uses the Library" with the Library
 creates an executable that is a derivative of the Library (because it
 contains portions of the Library), rather than a "work that uses the
 library".  The executable is therefore covered by this License.
 Section 6 states terms for distribution of such executables.
-</p>
-<p>
+
   When a "work that uses the Library" uses material from a header file
 that is part of the Library, the object code for the work may be a
 derivative work of the Library even though the source code is not.
 Whether this is true is especially significant if the work can be
 linked without the Library, or if the work is itself a library.  The
 threshold for this to be true is not precisely defined by law.
-</p>
-<p>
+
   If such an object file uses only numerical parameters, data
 structure layouts and accessors, and small macros and small inline
 functions (ten lines or less in length), then the use of the object
 file is unrestricted, regardless of whether it is legally a derivative
 work.  (Executables containing this object code plus portions of the
 Library will still fall under Section 6.)
-</p>
-<p>
+
   Otherwise, if the work is a derivative of the Library, you may
 distribute the object code for the work under the terms of Section 6.
 Any executables containing that work also fall under Section 6,
 whether or not they are linked directly with the Library itself.
-</p>
-<p>
-<strong>6.</strong>
-As an exception to the Sections above, you may also combine or
+
+  6. As an exception to the Sections above, you may also combine or
 link a "work that uses the Library" with the Library to produce a
 work containing portions of the Library, and distribute that work
 under terms of your choice, provided that the terms permit
 modification of the work for the customer's own use and reverse
 engineering for debugging such modifications.
-</p>
-<p>
+
   You must give prominent notice with each copy of the work that the
 Library is used in it and that the Library and its use are covered by
 this License.  You must supply a copy of this License.  If the work
@@ -553,47 +282,39 @@ during execution displays copyright notices, you must include the
 copyright notice for the Library among them, as well as a reference
 directing the user to the copy of this License.  Also, you must do one
 of these things:
-</p>
 
-<ul>
-    <li><strong>a)</strong> Accompany the work with the complete
-    corresponding machine-readable source code for the Library
-    including whatever changes were used in the work (which must be
-    distributed under Sections 1 and 2 above); and, if the work is an
-    executable linked with the Library, with the complete
-    machine-readable "work that uses the Library", as object code
-    and/or source code, so that the user can modify the Library and
-    then relink to produce a modified executable containing the
-    modified Library.  (It is understood that the user who changes the
-    contents of definitions files in the Library will not necessarily
-    be able to recompile the application to use the modified
-    definitions.)</li>
+    a) Accompany the work with the complete corresponding
+    machine-readable source code for the Library including whatever
+    changes were used in the work (which must be distributed under
+    Sections 1 and 2 above); and, if the work is an executable linked
+    with the Library, with the complete machine-readable "work that
+    uses the Library", as object code and/or source code, so that the
+    user can modify the Library and then relink to produce a modified
+    executable containing the modified Library.  (It is understood
+    that the user who changes the contents of definitions files in the
+    Library will not necessarily be able to recompile the application
+    to use the modified definitions.)
 
-    <li><strong>b)</strong> Use a suitable shared library mechanism
-    for linking with the Library.  A suitable mechanism is one that
-    (1) uses at run time a copy of the library already present on the
-    user's computer system, rather than copying library functions into
-    the executable, and (2) will operate properly with a modified
-    version of the library, if the user installs one, as long as the
-    modified version is interface-compatible with the version that the
-    work was made with.</li>
+    b) Use a suitable shared library mechanism for linking with the
+    Library.  A suitable mechanism is one that (1) uses at run time a
+    copy of the library already present on the user's computer system,
+    rather than copying library functions into the executable, and (2)
+    will operate properly with a modified version of the library, if
+    the user installs one, as long as the modified version is
+    interface-compatible with the version that the work was made with.
 
-    <li><strong>c)</strong> Accompany the work with a written offer,
-    valid for at least three years, to give the same user the
-    materials specified in Subsection 6a, above, for a charge no more
-    than the cost of performing this distribution.</li>
+    c) Accompany the work with a written offer, valid for at
+    least three years, to give the same user the materials
+    specified in Subsection 6a, above, for a charge no more
+    than the cost of performing this distribution.
 
-    <li><strong>d)</strong> If distribution of the work is made by
-    offering access to copy from a designated place, offer equivalent
-    access to copy the above specified materials from the same
-    place.</li>
+    d) If distribution of the work is made by offering access to copy
+    from a designated place, offer equivalent access to copy the above
+    specified materials from the same place.
 
-    <li><strong>e)</strong> Verify that the user has already received
-    a copy of these materials or that you have already sent this user
-    a copy.</li>
-</ul>
+    e) Verify that the user has already received a copy of these
+    materials or that you have already sent this user a copy.
 
-<p>
   For an executable, the required form of the "work that uses the
 Library" must include any data and utility programs needed for
 reproducing the executable from it.  However, as a special exception,
@@ -602,48 +323,38 @@ normally distributed (in either source or binary form) with the major
 components (compiler, kernel, and so on) of the operating system on
 which the executable runs, unless that component itself accompanies
 the executable.
-</p>
-<p>
+
   It may happen that this requirement contradicts the license
 restrictions of other proprietary libraries that do not normally
 accompany the operating system.  Such a contradiction means you cannot
 use both them and the Library together in an executable that you
 distribute.
-</p>
-<p>
-<strong>7.</strong> You may place library facilities that are a work
-based on the Library side-by-side in a single library together with
-other library facilities not covered by this License, and distribute
-such a combined library, provided that the separate distribution of
-the work based on the Library and of the other library facilities is
-otherwise permitted, and provided that you do these two things:
-</p>
+
+  7. You may place library facilities that are a work based on the
+Library side-by-side in a single library together with other library
+facilities not covered by this License, and distribute such a combined
+library, provided that the separate distribution of the work based on
+the Library and of the other library facilities is otherwise
+permitted, and provided that you do these two things:
 
-<ul>
-    <li><strong>a)</strong> Accompany the combined library with a copy
-    of the same work based on the Library, uncombined with any other
-    library facilities.  This must be distributed under the terms of
-    the Sections above.</li>
+    a) Accompany the combined library with a copy of the same work
+    based on the Library, uncombined with any other library
+    facilities.  This must be distributed under the terms of the
+    Sections above.
 
-    <li><strong>b)</strong> Give prominent notice with the combined
-    library of the fact that part of it is a work based on the
-    Library, and explaining where to find the accompanying uncombined
-    form of the same work.</li>
-</ul>
+    b) Give prominent notice with the combined library of the fact
+    that part of it is a work based on the Library, and explaining
+    where to find the accompanying uncombined form of the same work.
 
-<p>
-<strong>8.</strong> You may not copy, modify, sublicense, link with,
-or distribute the Library except as expressly provided under this
-License.  Any attempt otherwise to copy, modify, sublicense, link
-with, or distribute the Library is void, and will automatically
-terminate your rights under this License.  However, parties who have
-received copies, or rights, from you under this License will not have
-their licenses terminated so long as such parties remain in full
-compliance.
-</p>
-<p>
-<strong>9.</strong>
-You are not required to accept this License, since you have not
+  8. You may not copy, modify, sublicense, link with, or distribute
+the Library except as expressly provided under this License.  Any
+attempt otherwise to copy, modify, sublicense, link with, or
+distribute the Library is void, and will automatically terminate your
+rights under this License.  However, parties who have received copies,
+or rights, from you under this License will not have their licenses
+terminated so long as such parties remain in full compliance.
+
+  9. You are not required to accept this License, since you have not
 signed it.  However, nothing else grants you permission to modify or
 distribute the Library or its derivative works.  These actions are
 prohibited by law if you do not accept this License.  Therefore, by
@@ -651,20 +362,16 @@ modifying or distributing the Library (or any work based on the
 Library), you indicate your acceptance of this License to do so, and
 all its terms and conditions for copying, distributing or modifying
 the Library or works based on it.
-</p>
-<p>
-<strong>10.</strong>
-Each time you redistribute the Library (or any work based on the
+
+  10. Each time you redistribute the Library (or any work based on the
 Library), the recipient automatically receives a license from the
 original licensor to copy, distribute, link with or modify the Library
 subject to these terms and conditions.  You may not impose any further
 restrictions on the recipients' exercise of the rights granted herein.
 You are not responsible for enforcing compliance by third parties with
 this License.
-</p>
-<p>
-<strong>11.</strong>
-If, as a consequence of a court judgment or allegation of patent
+
+  11. If, as a consequence of a court judgment or allegation of patent
 infringement or for any other reason (not limited to patent issues),
 conditions are imposed on you (whether by court order, agreement or
 otherwise) that contradict the conditions of this License, they do not
@@ -676,13 +383,11 @@ license would not permit royalty-free redistribution of the Library by
 all those who receive copies directly or indirectly through you, then
 the only way you could satisfy both it and this License would be to
 refrain entirely from distribution of the Library.
-</p>
-<p>
+
 If any portion of this section is held invalid or unenforceable under any
 particular circumstance, the balance of the section is intended to apply,
 and the section as a whole is intended to apply in other circumstances.
-</p>
-<p>
+
 It is not the purpose of this section to induce you to infringe any
 patents or other property right claims or to contest validity of any
 such claims; this section has the sole purpose of protecting the
@@ -693,29 +398,23 @@ through that system in reliance on consistent application of that
 system; it is up to the author/donor to decide if he or she is willing
 to distribute software through any other system and a licensee cannot
 impose that choice.
-</p>
-<p>
+
 This section is intended to make thoroughly clear what is believed to
 be a consequence of the rest of this License.
-</p>
-<p>
-<strong>12.</strong>
-If the distribution and/or use of the Library is restricted in
+
+  12. If the distribution and/or use of the Library is restricted in
 certain countries either by patents or by copyrighted interfaces, the
 original copyright holder who places the Library under this License may add
 an explicit geographical distribution limitation excluding those countries,
 so that distribution is permitted only in or among countries not thus
 excluded.  In such case, this License incorporates the limitation as if
 written in the body of this License.
-</p>
-<p>
-<strong>13.</strong>
-The Free Software Foundation may publish revised and/or new
+
+  13. The Free Software Foundation may publish revised and/or new
 versions of the Lesser General Public License from time to time.
 Such new versions will be similar in spirit to the present version,
 but may differ in detail to address new problems or concerns.
-</p>
-<p>
+
 Each version is given a distinguishing version number.  If the Library
 specifies a version number of this License which applies to it and
 "any later version", you have the option of following the terms and
@@ -723,10 +422,8 @@ conditions either of that version or of any later version published by
 the Free Software Foundation.  If the Library does not specify a
 license version number, you may choose any version ever published by
 the Free Software Foundation.
-</p>
-<p>
-<strong>14.</strong>
-If you wish to incorporate parts of the Library into other free
+
+  14. If you wish to incorporate parts of the Library into other free
 programs whose distribution conditions are incompatible with these,
 write to the author to ask for permission.  For software which is
 copyrighted by the Free Software Foundation, write to the Free
@@ -734,13 +431,10 @@ Software Foundation; we sometimes make exceptions for this.  Our
 decision will be guided by the two goals of preserving the free status
 of all derivatives of our free software and of promoting the sharing
 and reuse of software generally.
-</p>
-<p>
-<strong>NO WARRANTY</strong>
-</p>
-<p>
-<strong>15.</strong>
-BECAUSE THE LIBRARY IS LICENSED FREE OF CHARGE, THERE IS NO
+
+                            NO WARRANTY
+
+  15. BECAUSE THE LIBRARY IS LICENSED FREE OF CHARGE, THERE IS NO
 WARRANTY FOR THE LIBRARY, TO THE EXTENT PERMITTED BY APPLICABLE LAW.
 EXCEPT WHEN OTHERWISE STATED IN WRITING THE COPYRIGHT HOLDERS AND/OR
 OTHER PARTIES PROVIDE THE LIBRARY "AS IS" WITHOUT WARRANTY OF ANY
@@ -749,10 +443,8 @@ IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR
 PURPOSE.  THE ENTIRE RISK AS TO THE QUALITY AND PERFORMANCE OF THE
 LIBRARY IS WITH YOU.  SHOULD THE LIBRARY PROVE DEFECTIVE, YOU ASSUME
 THE COST OF ALL NECESSARY SERVICING, REPAIR OR CORRECTION.
-</p>
-<p>
-<strong>16.</strong>
-IN NO EVENT UNLESS REQUIRED BY APPLICABLE LAW OR AGREED TO IN
+
+  16. IN NO EVENT UNLESS REQUIRED BY APPLICABLE LAW OR AGREED TO IN
 WRITING WILL ANY COPYRIGHT HOLDER, OR ANY OTHER PARTY WHO MAY MODIFY
 AND/OR REDISTRIBUTE THE LIBRARY AS PERMITTED ABOVE, BE LIABLE TO YOU
 FOR DAMAGES, INCLUDING ANY GENERAL, SPECIAL, INCIDENTAL OR
@@ -762,181 +454,48 @@ RENDERED INACCURATE OR LOSSES SUSTAINED BY YOU OR THIRD PARTIES OR A
 FAILURE OF THE LIBRARY TO OPERATE WITH ANY OTHER SOFTWARE), EVEN IF
 SUCH HOLDER OR OTHER PARTY HAS BEEN ADVISED OF THE POSSIBILITY OF SUCH
 DAMAGES.
-</p>
 
-<h4>END OF TERMS AND CONDITIONS</h4>
+                     END OF TERMS AND CONDITIONS
+
+           How to Apply These Terms to Your New Libraries
 
-<h4 id="SEC4">How to Apply These Terms to Your New Libraries</h4>
-<p>
   If you develop a new library, and you want it to be of the greatest
 possible use to the public, we recommend making it free software that
 everyone can redistribute and change.  You can do so by permitting
 redistribution under these terms (or, alternatively, under the terms of the
 ordinary General Public License).
-</p>
-<p>
+
   To apply these terms, attach the following notices to the library.  It is
 safest to attach them to the start of each source file to most effectively
 convey the exclusion of warranty; and each file should have at least the
 "copyright" line and a pointer to where the full notice is found.
-</p>
 
-<pre>
-<var>one line to give the library's name and an idea of what it does.</var>
-Copyright (C) <var>year</var>  <var>name of author</var>
+    <one line to give the library's name and a brief idea of what it does.>
+    Copyright (C) <year>  <name of author>
 
-This library is free software; you can redistribute it and/or
-modify it under the terms of the GNU Lesser General Public
-License as published by the Free Software Foundation; either
-version 2.1 of the License, or (at your option) any later version.
+    This library is free software; you can redistribute it and/or
+    modify it under the terms of the GNU Lesser General Public
+    License as published by the Free Software Foundation; either
+    version 2.1 of the License, or (at your option) any later version.
 
-This library is distributed in the hope that it will be useful,
-but WITHOUT ANY WARRANTY; without even the implied warranty of
-MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
-Lesser General Public License for more details.
+    This library is distributed in the hope that it will be useful,
+    but WITHOUT ANY WARRANTY; without even the implied warranty of
+    MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+    Lesser General Public License for more details.
 
-You should have received a copy of the GNU Lesser General Public
-License along with this library; if not, see
-&lt;<a href="https://www.gnu.org/licenses/">https://www.gnu.org/licenses/</a>&gt;.
-</pre>
+    You should have received a copy of the GNU Lesser General Public
+    License along with this library; if not, see <https://www.gnu.org/licenses/>.
 
-<p>
 Also add information on how to contact you by electronic and paper mail.
-</p>
-<p>
+
 You should also get your employer (if you work as a programmer) or your
 school, if any, to sign a "copyright disclaimer" for the library, if
 necessary.  Here is a sample; alter the names:
-</p>
 
-<pre>
-Yoyodyne, Inc., hereby disclaims all copyright interest in
-the library `Frob' (a library for tweaking knobs) written
-by James Random Hacker.
+  Yoyodyne, Inc., hereby disclaims all copyright interest in the
+  library `Frob' (a library for tweaking knobs) written by James Random Hacker.
 
-<var>signature of Moe Ghoul</var>, 1 April 1990
-Moe Ghoul, President of Vice
-</pre>
+  <signature of Moe Ghoul>, 1 April 1990
+  Moe Ghoul, President of Vice
 
-<p>
-That's all there is to it!</p>
-
-</div>
-</div>
-
-</div><!-- for id="content", starts in the include above -->
-
-              <!-- begin server/footer-text.html -->
-
-
-
-
-
-<div style="clear:both"></div>
-
-
-<div id="language-container">
- <div class="backtotop">
-  <hr class="no-display" />
-  <a href="#top"><b>&#9650;</b></a>
- </div>
- <div id="languages" class="rounded-corners">
-  <div class="button">
-   <a href="#top" class="close"><span>BACK TO TOP</span></a>
-  </div>
-  <div id="set-language" class="button">
-   <span class="gnun-split"></span>
-   <a href="/server/select-language.html?callback=/licenses/old-licenses/lgpl-2.1" rel="nofollow">
-   Set language
-   <span class="gnun-split"></span>
-   </a>
-  </div>
-  <p>Available for this page:</p>
-  <div id="translations">
-<p>
-<span dir="ltr" class="original">[en]&nbsp;<a lang="en" hreflang="en" href="/licenses/old-licenses/lgpl-2.1.en.html">English</a> &nbsp;</span>
-<span dir="ltr">[de]&nbsp;<a lang="de" hreflang="de" href="/licenses/old-licenses/lgpl-2.1.de.html">Deutsch</a> &nbsp;</span>
-<span dir="ltr">[fr]&nbsp;<a lang="fr" hreflang="fr" href="/licenses/old-licenses/lgpl-2.1.fr.html">français</a> &nbsp;</span>
-<span dir="ltr">[ja]&nbsp;<a lang="ja" hreflang="ja" href="/licenses/old-licenses/lgpl-2.1.ja.html">日本語</a> &nbsp;</span>
-<span dir="ltr">[pt-br]&nbsp;<a lang="pt-br" hreflang="pt-br" href="/licenses/old-licenses/lgpl-2.1.pt-br.html">português</a> &nbsp;</span>
-<span dir="ltr">[ru]&nbsp;<a lang="ru" hreflang="ru" href="/licenses/old-licenses/lgpl-2.1.ru.html">русский</a> &nbsp;</span>
-<span dir="ltr">[uk]&nbsp;<a lang="uk" hreflang="uk" href="/licenses/old-licenses/lgpl-2.1.uk.html">українська</a> &nbsp;</span>
-<span dir="ltr">[zh-cn]&nbsp;<a lang="zh-cn" hreflang="zh-cn" href="/licenses/old-licenses/lgpl-2.1.zh-cn.html">简体中文</a> &nbsp;</span>
-</p>
-</div>
- </div>
-</div>
-
-<div id="mission-statement" role="complementary">
- <div class="backtotop">
-  <hr class="no-display" />
-  <a href="#header"><span>BACK TO TOP </span>&#9650;</a>
- </div>
-<div style="clear: both"></div>
-<blockquote>
-<p style="direction:ltr; text-align:left"><a href="//www.fsf.org"><img id="fsfbanner"
-src="/graphics/fsf-logo-notext-small.png" alt="&nbsp;[FSF logo]&nbsp;"
-width="75" height="25" /></a><strong>
-&ldquo;The Free Software Foundation (FSF) is a nonprofit with a worldwide
-mission to promote computer user freedom. We defend the rights of all
-software users.&rdquo;</strong></p>
-</blockquote>
-
-<div id="support-the-fsf" class="button">
- <a class="join" href="//www.fsf.org/associate/support_freedom?referrer=4052">JOIN</a>
- <a class="donate" href="//donate.fsf.org/">DONATE</a>
- <a class="shop" href="//shop.fsf.org/">SHOP</a>
-</div>
-</div>
-<!-- end server/footer-text.html -->
-
-
-<div id="footer" role="contentinfo">
-<div class="unprintable">
-
-<p>Please send general FSF &amp; GNU inquiries to
-<a href="mailto:gnu@gnu.org">&lt;gnu@gnu.org&gt;</a>.
-There are also <a href="/contact/">other ways to contact</a>
-the FSF.  Broken links and other corrections or suggestions can be sent
-to <a href="mailto:webmasters@gnu.org">&lt;webmasters@gnu.org&gt;</a>.</p>
-
-<p><!-- TRANSLATORS: Ignore the original text in this paragraph,
-        replace it with the translation of these two:
-
-        We work hard and do our best to provide accurate, good quality
-        translations.  However, we are not exempt from imperfection.
-        Please send your comments and general suggestions in this regard
-        to <a href="mailto:web-translators@gnu.org">
-        &lt;web-translators@gnu.org&gt;</a>.</p>
-
-        <p>For information on coordinating and contributing translations of
-        our web pages, see <a
-        href="/server/standards/README.translations.html">Translations
-        README</a>. -->
-Please see the <a
-href="/server/standards/README.translations.html">Translations
-README</a> for information on coordinating and contributing translations
-of this article.</p>
-</div>
-
-<p>Copyright notice above.</p>
-
-<!-- start of server/bottom-notes.html -->
-<div id="bottom-notes" class="unprintable">
-<p><a href="//www.fsf.org/about/dmca-notice">Copyright Infringement Notification</a></p>
-<div id="generic">
-
-
-</div>
-</div>
-<!-- end of server/bottom-notes.html -->
-
-
-<p class="unprintable">Updated:
-<!-- timestamp start -->
-$Date: 2023/11/30 09:46:01 $
-<!-- timestamp end --></p>
-</div>
-</div><!-- for class="inner", starts in the banner include -->
-</body>
-</html>
+That's all there is to it!

--- a/licenses-generator/src/main/resources/offline-license-mirror/www.gnu.org/licenses/lgpl-3.0
+++ b/licenses-generator/src/main/resources/offline-license-mirror/www.gnu.org/licenses/lgpl-3.0
@@ -1,341 +1,119 @@
-<!DOCTYPE html>
-<html xmlns="http://www.w3.org/1999/xhtml" xml:lang="en" lang="en">
-<head>
-<meta http-equiv="content-type" content="text/html; charset=utf-8" />
-<link rel="author" href="mailto:webmasters@gnu.org" />
-<link rel="icon" type="image/png" href="/graphics/gnu-head-mini.png" />
-<meta name="ICBM" content="42.355469,-71.058627" />
-<link rel="stylesheet" type="text/css" href="/layout.min.css" media="screen" />
-<link rel="stylesheet" type="text/css" href="/print.min.css" media="print" />
+                   GNU LESSER GENERAL PUBLIC LICENSE
+                       Version 3, 29 June 2007
 
-
-
-<!-- Parent-Version: 1.98 -->
-<!-- This page is derived from /server/standards/boilerplate.html -->
-<title>GNU Lesser General Public License v3.0
-- GNU Project - Free Software Foundation</title>
-<style type="text/css" media="screen"><!--
-#content .button { margin: 2em 1.5em; }
-@media (max-width:30em) { #content img.imgright { display: none; }}
---></style>
-<link rel="alternate" type="application/rdf+xml"
-      href="/licenses/lgpl-3.0.rdf" /> 
-<!-- begin translist file -->
-
-<link rel="alternate" type="text/html" href="/licenses/lgpl-3.0.html" hreflang="x-default" />
-<link rel="alternate" type="text/html" lang="en" hreflang="en" href="/licenses/lgpl-3.0.en.html" title="English" />
-<link rel="alternate" type="text/html" lang="ca" hreflang="ca" href="/licenses/lgpl-3.0.ca.html" title="català" />
-<link rel="alternate" type="text/html" lang="de" hreflang="de" href="/licenses/lgpl-3.0.de.html" title="Deutsch" />
-<link rel="alternate" type="text/html" lang="fr" hreflang="fr" href="/licenses/lgpl-3.0.fr.html" title="français" />
-<link rel="alternate" type="text/html" lang="ja" hreflang="ja" href="/licenses/lgpl-3.0.ja.html" title="日本語" />
-<link rel="alternate" type="text/html" lang="nl" hreflang="nl" href="/licenses/lgpl-3.0.nl.html" title="Nederlands" />
-<link rel="alternate" type="text/html" lang="pt-br" hreflang="pt-br" href="/licenses/lgpl-3.0.pt-br.html" title="português" />
-<link rel="alternate" type="text/html" lang="ru" hreflang="ru" href="/licenses/lgpl-3.0.ru.html" title="русский" />
-<link rel="alternate" type="text/html" lang="tr" hreflang="tr" href="/licenses/lgpl-3.0.tr.html" title="Türkçe" />
-<link rel="alternate" type="text/html" lang="uk" hreflang="uk" href="/licenses/lgpl-3.0.uk.html" title="українська" />
-<link rel="alternate" type="text/html" lang="zh-cn" hreflang="zh-cn" href="/licenses/lgpl-3.0.zh-cn.html" title="简体中文" />
-<link rel="alternate" type="text/html" lang="zh-tw" hreflang="zh-tw" href="/licenses/lgpl-3.0.zh-tw.html" title="繁體中文" />
-<!-- end translist file -->
-
-<!-- start of server/banner.html -->
-<!-- start of head-include-2.html -->
-<meta name="viewport" content="width=device-width, initial-scale=1" />
-<!-- end of head-include-2.html -->
-
-</head>
-<body>
-<div class="inner">
-<!-- start of server/body-include-1.html -->
-<div id="top">
-<a class="skip" href="#content"><b>Skip to main text</b></a>
-</div>
-
-<div id="fsf-frame" role="complementary">
-<form id="fssbox" action="https://my.fsf.org/civicrm/profile/create?reset=1&amp;gid=31"
-      method="post">
- <div>
-  <input name="postURL" type="hidden" value="" />
-  <input type="hidden" name="group[25]" value="1" />
-  <input name="cancelURL" type="hidden" value="https://crm.fsf.org/civicrm/profile?reset=1&amp;gid=31" />
-  <input name="_qf_default" type="hidden" value="Edit:cancel" />
-  <label for="frmEmail">
-   <a href="//www.fsf.org/fss">Free Software Supporter</a>:
-  </label>
-  <input type="text" id="frmEmail" name="email-Primary" size="18" maxlength="80"
-         value="email address" onfocus="this.value=''"/>
-  <input type="submit" name="_qf_Edit_next" value="Sign up" />
- </div>
-</form>
-
-<div id="join-fsf" class="button"><a
-href="https://www.fsf.org/associate/support_freedom?referrer=4052">JOIN&nbsp;THE&nbsp;FSF</a>
-</div>
-</div>
-
-<div id="header" role="banner">
-<p id="gnu-banner">
- <a href="/">
- <img src="/graphics/heckert_gnu.transp.small.png" height="48" width="49"
-      alt="&nbsp;[A GNU head]&nbsp;" /><strong>GNU</strong> <span
- class="hide">Operating System</span></a><br />
- <small id="fsf-support">Supported by the
- <a href="#mission-statement">Free Software Foundation</a></small>
-</p>
-
-<div id="switches">
-<!-- begin search button -->
- <div  id="search-button" class="switch">
-  <a href="//www.gnu.org/cgi-bin/estseek.cgi">
-  <img id="search-icon" height="30" width="30"
-       src="/graphics/icons/search.png"
-       alt="&nbsp;[Search www.gnu.org]&nbsp;" /></a>
- </div>
-<!-- end search button -->
-
- <div id="language-button" class="switch">
-  <a href="#language-container">
-  <img id="language-icon" height="30" width="37"
-       src="/graphics/icons/translations.png"
-       alt="&nbsp;[Other languages]&nbsp;" /></a>
- </div>
-
-</div>
-</div>
-<!-- end of server/body-include-1.html -->
-
-<!-- start of server/body-include-2 -->
-
-
-<div style="clear: both"></div>
-
-<div id="navigation" role="navigation">
- <a id="more-links" href="#navigation" title="More...">
-   <span>Site navigation</span></a>
- <a id="less-links" href="#content"><b>Skip</b></a>
- <ul>
-
-   <li id="tabAboutGNU"><a href="/gnu/gnu.html">ABOUT&nbsp;GNU</a></li>
-
-
-  <li id="tabPhilosophy"><a href="/philosophy/philosophy.html">PHILOSOPHY</a></li>
-
-
-  <li id="tabLicenses" class="active">
-     <span class='no-display'>=</span> 
-    <a href="/licenses/licenses.html">LICENSES</a>
-    <span class="gnun-split"></span>
-     <span class='no-display'>=</span> 
-  </li>
-
-
-  <li id="tabEducation"><a href="/education/education.html">EDUCATION</a></li>
-
-
-  <li id="tabSoftware"><a href="/software/software.html">SOFTWARE</a></li>
-
-
-  <li id="tabDistros"><a href="/distros/distros.html">DISTROS</a></li>
-
-
-  <li id="tabDoc"><a href="/doc/doc.html">DOCS</a></li>
-
-
-  <li id="tabMalware"><a href="/proprietary/proprietary.html">MALWARE</a></li>
-
-
-  <li id="tabHelp"><a href="/help/help.html">HELP&nbsp;GNU</a></li>
-
-
-  <li id="tabAV"><a href="/audio-video/audio-video.html">AUDIO&nbsp;&amp;&nbsp;VIDEO</a></li>
-
-
-  <li id="tabArt"><a href="/graphics/graphics.html">GNU&nbsp;ART</a></li>
-
-
-  <li id="tabFun"><a href="/fun/humor.html">FUN</a></li>
-
-
-  <li id="tabPeople"><a href="/people/people.html">GNU'S&nbsp;WHO?</a></li>
-
-  <li><a href="//directory.fsf.org">SOFTWARE&nbsp;DIRECTORY</a></li>
-  <li><a href="https://h-node.org/">HARDWARE</a></li>
-  <li><a href="/server/sitemap.html">SITEMAP</a></li>
- </ul>
- <div style="clear: both"></div>
-</div><!-- /"navigation -->
-<!-- end of server/body-include-2 -->
-
-<div id="content" role="main">
-<!-- end of server/banner.html -->
-
-<div class="article reduced-width">
-<h2>GNU Lesser General Public License</h2>
-
-<img class="imgright" src="/graphics/lgplv3-147x51.png" alt=" [LGPLv3 Logo] " />
-<p class="button"><b><a href="#license-text">Skip to license text</a></b></p>
-
-<ul>
-  <li><a href="/licenses/why-not-lgpl.html">Why you shouldn't use the
-       Lesser GPL for your next library</a></li>
-  <li><a href="/licenses/gpl-faq.html">Frequently Asked Questions about
-       the GNU licenses</a></li>
-  <li><a href="/licenses/gpl-howto.html">How to use GNU licenses for your
-       own software</a></li>
-  <li><a href="/licenses/translations.html">Translations
-       of the LGPL</a></li>
-  <li>The GNU LGPL in other formats: 
-       <a href="/licenses/lgpl-3.0.txt">plain text</a>,
-       <a href="/licenses/lgpl-3.0.dbk">Docbook</a>,
-       <a href="/licenses/lgpl-3.0-standalone.html">standalone HTML</a>,
-       <a href="/licenses/lgpl-3.0.tex">LaTeX</a>,
-       <a href="/licenses/lgpl-3.0.texi">Texinfo</a>, 
-       <a href="/licenses/lgpl-3.0.md">Markdown</a>, 
-       <a href="/licenses/lgpl-3.0.odt">ODF</a>, 
-       <a href="/licenses/lgpl-3.0.rtf">RTF</a>,
-       <a href="/licenses/lgpl+gpl-3.0.txt">LGPL+GPL</a></li>
-  <li><a href="/graphics/license-logos.html">LGPLv3 logos</a> to use
-       with your project</li>
-  <li><a href="/licenses/old-licenses/old-licenses.html#LGPL">Old
-       versions of the GNU LGPL</a></li>
-  <li><a href="/licenses/gpl-violation.html">What to do if you see a
-       possible LGPL violation</a></li>
-</ul>
-
-<p>This license is a set of additional permissions added to <a
-href="/licenses/gpl-3.0.html">version 3 of the GNU General Public
-License</a>.  For more information about how to release your own software
-under this license, please see our <a href="/licenses/gpl-howto.html">page
-of instructions</a>.</p>
-
-<hr class="thin" />
-
-<!-- The license text is in English and appears broken in RTL as
-     Arabic, Farsi, etc.  Explicitly set the direction to override the
-     one defined in the translation. -->
-<div id="license-text" dir="ltr">
-<h3 style="text-align: center;">GNU LESSER GENERAL PUBLIC LICENSE</h3>
-<p style="text-align: center;">Version 3, 29 June 2007</p>
-
-<p>Copyright &copy; 2007 Free Software Foundation, Inc.
- &lt;<a href="https://fsf.org/">https://fsf.org/</a>&gt;</p><p>
+ Copyright (C) 2007 Free Software Foundation, Inc. <https://fsf.org/>
  Everyone is permitted to copy and distribute verbatim copies
- of this license document, but changing it is not allowed.</p>
+ of this license document, but changing it is not allowed.
 
-<p>This version of the GNU Lesser General Public License incorporates
+
+  This version of the GNU Lesser General Public License incorporates
 the terms and conditions of version 3 of the GNU General Public
-License, supplemented by the additional permissions listed below.</p>
+License, supplemented by the additional permissions listed below.
 
-<h4 id="section0">0. Additional Definitions.</h4>
+  0. Additional Definitions.
 
-<p>As used herein, &ldquo;this License&rdquo; refers to version 3 of the GNU Lesser
-General Public License, and the &ldquo;GNU GPL&rdquo; refers to version 3 of the GNU
-General Public License.</p>
+  As used herein, "this License" refers to version 3 of the GNU Lesser
+General Public License, and the "GNU GPL" refers to version 3 of the GNU
+General Public License.
 
-<p>&ldquo;The Library&rdquo; refers to a covered work governed by this License,
-other than an Application or a Combined Work as defined below.</p>
+  "The Library" refers to a covered work governed by this License,
+other than an Application or a Combined Work as defined below.
 
-<p>An &ldquo;Application&rdquo; is any work that makes use of an interface provided
+  An "Application" is any work that makes use of an interface provided
 by the Library, but which is not otherwise based on the Library.
 Defining a subclass of a class defined by the Library is deemed a mode
-of using an interface provided by the Library.</p>
+of using an interface provided by the Library.
 
-<p>A &ldquo;Combined Work&rdquo; is a work produced by combining or linking an
+  A "Combined Work" is a work produced by combining or linking an
 Application with the Library.  The particular version of the Library
-with which the Combined Work was made is also called the &ldquo;Linked
-Version&rdquo;.</p>
+with which the Combined Work was made is also called the "Linked
+Version".
 
-<p>The &ldquo;Minimal Corresponding Source&rdquo; for a Combined Work means the
+  The "Minimal Corresponding Source" for a Combined Work means the
 Corresponding Source for the Combined Work, excluding any source code
 for portions of the Combined Work that, considered in isolation, are
-based on the Application, and not on the Linked Version.</p>
+based on the Application, and not on the Linked Version.
 
-<p>The &ldquo;Corresponding Application Code&rdquo; for a Combined Work means the
+  The "Corresponding Application Code" for a Combined Work means the
 object code and/or source code for the Application, including any data
 and utility programs needed for reproducing the Combined Work from the
-Application, but excluding the System Libraries of the Combined Work.</p>
+Application, but excluding the System Libraries of the Combined Work.
 
-<h4 id="section1">1. Exception to Section 3 of the GNU GPL.</h4>
+  1. Exception to Section 3 of the GNU GPL.
 
-<p>You may convey a covered work under sections 3 and 4 of this License
-without being bound by section 3 of the GNU GPL.</p>
+  You may convey a covered work under sections 3 and 4 of this License
+without being bound by section 3 of the GNU GPL.
 
-<h4 id="section2">2. Conveying Modified Versions.</h4>
+  2. Conveying Modified Versions.
 
-<p>If you modify a copy of the Library, and, in your modifications, a
+  If you modify a copy of the Library, and, in your modifications, a
 facility refers to a function or data to be supplied by an Application
 that uses the facility (other than as an argument passed when the
 facility is invoked), then you may convey a copy of the modified
-version:</p>
+version:
 
-<ul>
-<li>a) under this License, provided that you make a good faith effort to
+   a) under this License, provided that you make a good faith effort to
    ensure that, in the event an Application does not supply the
    function or data, the facility still operates, and performs
-   whatever part of its purpose remains meaningful, or</li>
+   whatever part of its purpose remains meaningful, or
 
-<li>b) under the GNU GPL, with none of the additional permissions of
-   this License applicable to that copy.</li>
-</ul>
+   b) under the GNU GPL, with none of the additional permissions of
+   this License applicable to that copy.
 
-<h4 id="section3">3. Object Code Incorporating Material from Library Header Files.</h4>
+  3. Object Code Incorporating Material from Library Header Files.
 
-<p>The object code form of an Application may incorporate material from
+  The object code form of an Application may incorporate material from
 a header file that is part of the Library.  You may convey such object
 code under terms of your choice, provided that, if the incorporated
 material is not limited to numerical parameters, data structure
 layouts and accessors, or small macros, inline functions and templates
-(ten or fewer lines in length), you do both of the following:</p>
+(ten or fewer lines in length), you do both of the following:
 
-<ul>
-<li>a) Give prominent notice with each copy of the object code that the
+   a) Give prominent notice with each copy of the object code that the
    Library is used in it and that the Library and its use are
-   covered by this License.</li>
+   covered by this License.
 
-<li>b) Accompany the object code with a copy of the GNU GPL and this license
-   document.</li>
-</ul>
+   b) Accompany the object code with a copy of the GNU GPL and this license
+   document.
 
-<h4 id="section4">4. Combined Works.</h4>
+  4. Combined Works.
 
-<p>You may convey a Combined Work under terms of your choice that,
+  You may convey a Combined Work under terms of your choice that,
 taken together, effectively do not restrict modification of the
 portions of the Library contained in the Combined Work and reverse
 engineering for debugging such modifications, if you also do each of
-the following:</p>
+the following:
 
-<ul>
-<li>a) Give prominent notice with each copy of the Combined Work that
+   a) Give prominent notice with each copy of the Combined Work that
    the Library is used in it and that the Library and its use are
-   covered by this License.</li>
+   covered by this License.
 
-<li>b) Accompany the Combined Work with a copy of the GNU GPL and this license
-   document.</li>
+   b) Accompany the Combined Work with a copy of the GNU GPL and this license
+   document.
 
-<li>c) For a Combined Work that displays copyright notices during
+   c) For a Combined Work that displays copyright notices during
    execution, include the copyright notice for the Library among
    these notices, as well as a reference directing the user to the
-   copies of the GNU GPL and this license document.</li>
+   copies of the GNU GPL and this license document.
 
-<li>d) Do one of the following:
+   d) Do one of the following:
 
-<ul>
-<li>0) Convey the Minimal Corresponding Source under the terms of this
+       0) Convey the Minimal Corresponding Source under the terms of this
        License, and the Corresponding Application Code in a form
        suitable for, and under terms that permit, the user to
        recombine or relink the Application with a modified version of
        the Linked Version to produce a modified Combined Work, in the
        manner specified by section 6 of the GNU GPL for conveying
-       Corresponding Source.</li>
+       Corresponding Source.
 
-<li>1) Use a suitable shared library mechanism for linking with the
+       1) Use a suitable shared library mechanism for linking with the
        Library.  A suitable mechanism is one that (a) uses at run time
        a copy of the Library already present on the user's computer
        system, and (b) will operate properly with a modified version
        of the Library that is interface-compatible with the Linked
-       Version.</li>
-</ul></li>
+       Version.
 
-<li>e) Provide Installation Information, but only if you would otherwise
+   e) Provide Installation Information, but only if you would otherwise
    be required to provide such information under section 6 of the
    GNU GPL, and only to the extent that such information is
    necessary to install and execute a modified version of the
@@ -345,176 +123,43 @@ the following:</p>
    the Minimal Corresponding Source and Corresponding Application
    Code. If you use option 4d1, you must provide the Installation
    Information in the manner specified by section 6 of the GNU GPL
-   for conveying Corresponding Source.)</li>
-</ul>
+   for conveying Corresponding Source.)
 
-<h4 id="section5">5. Combined Libraries.</h4>
+  5. Combined Libraries.
 
-<p>You may place library facilities that are a work based on the
+  You may place library facilities that are a work based on the
 Library side by side in a single library together with other library
 facilities that are not Applications and are not covered by this
 License, and convey such a combined library under terms of your
-choice, if you do both of the following:</p>
+choice, if you do both of the following:
 
-<ul>
-<li>a) Accompany the combined library with a copy of the same work based
+   a) Accompany the combined library with a copy of the same work based
    on the Library, uncombined with any other library facilities,
-   conveyed under the terms of this License.</li>
+   conveyed under the terms of this License.
 
-<li>b) Give prominent notice with the combined library that part of it
+   b) Give prominent notice with the combined library that part of it
    is a work based on the Library, and explaining where to find the
-   accompanying uncombined form of the same work.</li>
-</ul>
+   accompanying uncombined form of the same work.
 
-<h4 id="section6">6. Revised Versions of the GNU Lesser General Public License.</h4>
+  6. Revised Versions of the GNU Lesser General Public License.
 
-<p>The Free Software Foundation may publish revised and/or new versions
+  The Free Software Foundation may publish revised and/or new versions
 of the GNU Lesser General Public License from time to time. Such new
 versions will be similar in spirit to the present version, but may
-differ in detail to address new problems or concerns.</p>
+differ in detail to address new problems or concerns.
 
-<p>Each version is given a distinguishing version number. If the
+  Each version is given a distinguishing version number. If the
 Library as you received it specifies that a certain numbered version
-of the GNU Lesser General Public License &ldquo;or any later version&rdquo;
+of the GNU Lesser General Public License "or any later version"
 applies to it, you have the option of following the terms and
 conditions either of that published version or of any later version
 published by the Free Software Foundation. If the Library as you
 received it does not specify a version number of the GNU Lesser
 General Public License, you may choose any version of the GNU Lesser
-General Public License ever published by the Free Software Foundation.</p>
+General Public License ever published by the Free Software Foundation.
 
-<p>If the Library as you received it specifies that a proxy can decide
+  If the Library as you received it specifies that a proxy can decide
 whether future versions of the GNU Lesser General Public License shall
 apply, that proxy's public statement of acceptance of any version is
 permanent authorization for you to choose that version for the
-Library.</p>
-
-</div>
-</div>
-
-</div><!-- for id="content", starts in the include above -->
-
-              <!-- begin server/footer-text.html -->
-
-
-
-
-
-<div style="clear:both"></div>
-
-
-<div id="language-container">
- <div class="backtotop">
-  <hr class="no-display" />
-  <a href="#top"><b>&#9650;</b></a>
- </div>
- <div id="languages" class="rounded-corners">
-  <div class="button">
-   <a href="#top" class="close"><span>BACK TO TOP</span></a>
-  </div>
-  <div id="set-language" class="button">
-   <span class="gnun-split"></span>
-   <a href="/server/select-language.html?callback=/licenses/lgpl-3.0" rel="nofollow">
-   Set language
-   <span class="gnun-split"></span>
-   </a>
-  </div>
-  <p>Available for this page:</p>
-  <div id="translations">
-<p>
-<span dir="ltr" class="original">[en]&nbsp;<a lang="en" hreflang="en" href="/licenses/lgpl-3.0.en.html">English</a> &nbsp;</span>
-<span dir="ltr">[ca]&nbsp;<a lang="ca" hreflang="ca" href="/licenses/lgpl-3.0.ca.html">català</a> &nbsp;</span>
-<span dir="ltr">[de]&nbsp;<a lang="de" hreflang="de" href="/licenses/lgpl-3.0.de.html">Deutsch</a> &nbsp;</span>
-<span dir="ltr">[fr]&nbsp;<a lang="fr" hreflang="fr" href="/licenses/lgpl-3.0.fr.html">français</a> &nbsp;</span>
-<span dir="ltr">[ja]&nbsp;<a lang="ja" hreflang="ja" href="/licenses/lgpl-3.0.ja.html">日本語</a> &nbsp;</span>
-<span dir="ltr">[nl]&nbsp;<a lang="nl" hreflang="nl" href="/licenses/lgpl-3.0.nl.html">Nederlands</a> &nbsp;</span>
-<span dir="ltr">[pt-br]&nbsp;<a lang="pt-br" hreflang="pt-br" href="/licenses/lgpl-3.0.pt-br.html">português</a> &nbsp;</span>
-<span dir="ltr">[ru]&nbsp;<a lang="ru" hreflang="ru" href="/licenses/lgpl-3.0.ru.html">русский</a> &nbsp;</span>
-<span dir="ltr">[tr]&nbsp;<a lang="tr" hreflang="tr" href="/licenses/lgpl-3.0.tr.html">Türkçe</a> &nbsp;</span>
-<span dir="ltr">[uk]&nbsp;<a lang="uk" hreflang="uk" href="/licenses/lgpl-3.0.uk.html">українська</a> &nbsp;</span>
-<span dir="ltr">[zh-cn]&nbsp;<a lang="zh-cn" hreflang="zh-cn" href="/licenses/lgpl-3.0.zh-cn.html">简体中文</a> &nbsp;</span>
-<span dir="ltr">[zh-tw]&nbsp;<a lang="zh-tw" hreflang="zh-tw" href="/licenses/lgpl-3.0.zh-tw.html">繁體中文</a> &nbsp;</span>
-</p>
-</div>
- </div>
-</div>
-
-<div id="mission-statement" role="complementary">
- <div class="backtotop">
-  <hr class="no-display" />
-  <a href="#header"><span>BACK TO TOP </span>&#9650;</a>
- </div>
-<div style="clear: both"></div>
-<blockquote>
-<p style="direction:ltr; text-align:left"><a href="//www.fsf.org"><img id="fsfbanner"
-src="/graphics/fsf-logo-notext-small.png" alt="&nbsp;[FSF logo]&nbsp;"
-width="75" height="25" /></a><strong>
-&ldquo;The Free Software Foundation (FSF) is a nonprofit with a worldwide
-mission to promote computer user freedom. We defend the rights of all
-software users.&rdquo;</strong></p>
-</blockquote>
-
-<div id="support-the-fsf" class="button">
- <a class="join" href="//www.fsf.org/associate/support_freedom?referrer=4052">JOIN</a>
- <a class="donate" href="//donate.fsf.org/">DONATE</a>
- <a class="shop" href="//shop.fsf.org/">SHOP</a>
-</div>
-</div>
-<!-- end server/footer-text.html -->
-
-
-<div id="footer" role="contentinfo">
-<div class="unprintable">
-
-<p>Please send general FSF &amp; GNU inquiries to
-<a href="mailto:gnu@gnu.org">&lt;gnu@gnu.org&gt;</a>.
-There are also <a href="/contact/">other ways to contact</a>
-the FSF.  Broken links and other corrections or suggestions can be sent
-to <a href="mailto:webmasters@gnu.org">&lt;webmasters@gnu.org&gt;</a>.</p>
-
-<p><!-- TRANSLATORS: Ignore the original text in this paragraph,
-        replace it with the translation of these two:
-
-        We work hard and do our best to provide accurate, good quality
-        translations.  However, we are not exempt from imperfection.
-        Please send your comments and general suggestions in this regard
-        to <a href="mailto:web-translators@gnu.org">
-        &lt;web-translators@gnu.org&gt;</a>.</p>
-
-        <p>For information on coordinating and contributing translations of
-        our web pages, see <a
-        href="/server/standards/README.translations.html">Translations
-        README</a>. -->
-Please see the <a
-href="/server/standards/README.translations.html">Translations
-README</a> for information on coordinating and contributing translations
-of this article.</p>
-</div>
-
-<p>Copyright notice above.</p>
-
-<p>
-Everyone is permitted to copy and distribute verbatim copies of this license
-document, but changing it is not allowed.
-</p>
-
-<!-- start of server/bottom-notes.html -->
-<div id="bottom-notes" class="unprintable">
-<p><a href="//www.fsf.org/about/dmca-notice">Copyright Infringement Notification</a></p>
-<div id="generic">
-
-
-</div>
-</div>
-<!-- end of server/bottom-notes.html -->
-
-
-<p class="unprintable">Updated:
-<!-- timestamp start -->
-$Date: 2023/11/30 09:46:01 $
-<!-- timestamp end -->
-</p>
-</div>
-</div><!-- for class="inner", starts in the banner include -->
-</body>
-</html>
+Library.

--- a/licenses-generator/src/main/resources/offline-license-mirror/www.gnu.org/licenses/old-licenses/fdl-1.1
+++ b/licenses-generator/src/main/resources/offline-license-mirror/www.gnu.org/licenses/old-licenses/fdl-1.1
@@ -1,660 +1,355 @@
-<!DOCTYPE html>
-<html xmlns="http://www.w3.org/1999/xhtml" xml:lang="en" lang="en">
-<head>
-<meta http-equiv="content-type" content="text/html; charset=utf-8" />
-<link rel="author" href="mailto:webmasters@gnu.org" />
-<link rel="icon" type="image/png" href="/graphics/gnu-head-mini.png" />
-<meta name="ICBM" content="42.355469,-71.058627" />
-<link rel="stylesheet" type="text/css" href="/layout.min.css" media="screen" />
-<link rel="stylesheet" type="text/css" href="/print.min.css" media="print" />
-
-
-
-<!-- Parent-Version: 1.98 -->
-<!-- This page is derived from /server/standards/boilerplate.html -->
-<title>GNU Free Documentation License v1.1 - GNU Project - Free Software Foundation</title>
-<!-- begin translist file -->
-
-<link rel="alternate" type="text/html" href="/licenses/old-licenses/fdl-1.1.html" hreflang="x-default" />
-<link rel="alternate" type="text/html" lang="en" hreflang="en" href="/licenses/old-licenses/fdl-1.1.en.html" title="English" />
-<link rel="alternate" type="text/html" lang="de" hreflang="de" href="/licenses/old-licenses/fdl-1.1.de.html" title="Deutsch" />
-<link rel="alternate" type="text/html" lang="fr" hreflang="fr" href="/licenses/old-licenses/fdl-1.1.fr.html" title="français" />
-<link rel="alternate" type="text/html" lang="ja" hreflang="ja" href="/licenses/old-licenses/fdl-1.1.ja.html" title="日本語" />
-<link rel="alternate" type="text/html" lang="pt-br" hreflang="pt-br" href="/licenses/old-licenses/fdl-1.1.pt-br.html" title="português" />
-<link rel="alternate" type="text/html" lang="ru" hreflang="ru" href="/licenses/old-licenses/fdl-1.1.ru.html" title="русский" />
-<link rel="alternate" type="text/html" lang="uk" hreflang="uk" href="/licenses/old-licenses/fdl-1.1.uk.html" title="українська" />
-<link rel="alternate" type="text/html" lang="zh-cn" hreflang="zh-cn" href="/licenses/old-licenses/fdl-1.1.zh-cn.html" title="简体中文" />
-<!-- end translist file -->
-
-<!-- start of server/banner.html -->
-<!-- start of head-include-2.html -->
-<meta name="viewport" content="width=device-width, initial-scale=1" />
-<!-- end of head-include-2.html -->
-
-</head>
-<body>
-<div class="inner">
-<!-- start of server/body-include-1.html -->
-<div id="top">
-<a class="skip" href="#content"><b>Skip to main text</b></a>
-</div>
-
-<div id="fsf-frame" role="complementary">
-<form id="fssbox" action="https://my.fsf.org/civicrm/profile/create?reset=1&amp;gid=31"
-      method="post">
- <div>
-  <input name="postURL" type="hidden" value="" />
-  <input type="hidden" name="group[25]" value="1" />
-  <input name="cancelURL" type="hidden" value="https://crm.fsf.org/civicrm/profile?reset=1&amp;gid=31" />
-  <input name="_qf_default" type="hidden" value="Edit:cancel" />
-  <label for="frmEmail">
-   <a href="//www.fsf.org/fss">Free Software Supporter</a>:
-  </label>
-  <input type="text" id="frmEmail" name="email-Primary" size="18" maxlength="80"
-         value="email address" onfocus="this.value=''"/>
-  <input type="submit" name="_qf_Edit_next" value="Sign up" />
- </div>
-</form>
-
-<div id="join-fsf" class="button"><a
-href="https://www.fsf.org/associate/support_freedom?referrer=4052">JOIN&nbsp;THE&nbsp;FSF</a>
-</div>
-</div>
-
-<div id="header" role="banner">
-<p id="gnu-banner">
- <a href="/">
- <img src="/graphics/heckert_gnu.transp.small.png" height="48" width="49"
-      alt="&nbsp;[A GNU head]&nbsp;" /><strong>GNU</strong> <span
- class="hide">Operating System</span></a><br />
- <small id="fsf-support">Supported by the
- <a href="#mission-statement">Free Software Foundation</a></small>
-</p>
-
-<div id="switches">
-<!-- begin search button -->
- <div  id="search-button" class="switch">
-  <a href="//www.gnu.org/cgi-bin/estseek.cgi">
-  <img id="search-icon" height="30" width="30"
-       src="/graphics/icons/search.png"
-       alt="&nbsp;[Search www.gnu.org]&nbsp;" /></a>
- </div>
-<!-- end search button -->
-
- <div id="language-button" class="switch">
-  <a href="#language-container">
-  <img id="language-icon" height="30" width="37"
-       src="/graphics/icons/translations.png"
-       alt="&nbsp;[Other languages]&nbsp;" /></a>
- </div>
-
-</div>
-</div>
-<!-- end of server/body-include-1.html -->
-
-<!-- start of server/body-include-2 -->
-
-
-<div style="clear: both"></div>
-
-<div id="navigation" role="navigation">
- <a id="more-links" href="#navigation" title="More...">
-   <span>Site navigation</span></a>
- <a id="less-links" href="#content"><b>Skip</b></a>
- <ul>
-
-   <li id="tabAboutGNU"><a href="/gnu/gnu.html">ABOUT&nbsp;GNU</a></li>
-
-
-  <li id="tabPhilosophy"><a href="/philosophy/philosophy.html">PHILOSOPHY</a></li>
-
-
-  <li id="tabLicenses" class="active">
-     <span class='no-display'>=</span> 
-    <a href="/licenses/licenses.html">LICENSES</a>
-    <span class="gnun-split"></span>
-     <span class='no-display'>=</span> 
-  </li>
-
-
-  <li id="tabEducation"><a href="/education/education.html">EDUCATION</a></li>
-
-
-  <li id="tabSoftware"><a href="/software/software.html">SOFTWARE</a></li>
-
-
-  <li id="tabDistros"><a href="/distros/distros.html">DISTROS</a></li>
-
-
-  <li id="tabDoc"><a href="/doc/doc.html">DOCS</a></li>
-
-
-  <li id="tabMalware"><a href="/proprietary/proprietary.html">MALWARE</a></li>
-
-
-  <li id="tabHelp"><a href="/help/help.html">HELP&nbsp;GNU</a></li>
-
-
-  <li id="tabAV"><a href="/audio-video/audio-video.html">AUDIO&nbsp;&amp;&nbsp;VIDEO</a></li>
-
-
-  <li id="tabArt"><a href="/graphics/graphics.html">GNU&nbsp;ART</a></li>
-
-
-  <li id="tabFun"><a href="/fun/humor.html">FUN</a></li>
-
-
-  <li id="tabPeople"><a href="/people/people.html">GNU'S&nbsp;WHO?</a></li>
-
-  <li><a href="//directory.fsf.org">SOFTWARE&nbsp;DIRECTORY</a></li>
-  <li><a href="https://h-node.org/">HARDWARE</a></li>
-  <li><a href="/server/sitemap.html">SITEMAP</a></li>
- </ul>
- <div style="clear: both"></div>
-</div><!-- /"navigation -->
-<!-- end of server/body-include-2 -->
-
-<div id="content" role="main">
-<!-- end of server/banner.html -->
-
-<div class="reduced-width">
-<h2>GNU Free Documentation License, version&nbsp;1.1</h2>
-
-<p class="button" style="margin: 2em 1.5em">
-  <b><a href="#SEC1">Skip to license text</a></b></p>
-
-<ul>
-  <li><a href="/licenses/fdl.html">The latest version of the FDL,
-      version 1.3</a></li>
-  <li><a href="/philosophy/free-doc.html">Free software and free
-      documentation</a></li>
-  <li><a href="/licenses/gpl-violation.html">What to do if you see a
-      possible GFDL violation</a></li>
-  <li><a href="/licenses/why-gfdl.html">Why publishers should use the
-      GNU Free Documentation License</a></li>
-  <li><a href="/licenses/fdl-howto.html">Tips on how to use the FDL</a></li>
-  <li><a href="/licenses/fdl-howto-opt.html">Using the optional features
-      of the GFDL</a></li>
-  <li><a href="/licenses/old-licenses/fdl-1.1-translations.html">Translations
-      of GFDLv1.1</a></li>
-  <li>The GNU Free Documentation License version 1.1 (GFDLv1.1) in other
-      formats:
-      <a href="/licenses/old-licenses/fdl-1.1.txt">plain text</a>,
-      <a href="/licenses/old-licenses/fdl-1.1.texi">Texinfo</a>,
-      <a href="/licenses/old-licenses/fdl-1.1.tex">LaTeX</a>,
-  <a href="/licenses/old-licenses/fdl-1.1-standalone.html">standalone HTML</a>,
-      <a href="/licenses/old-licenses/fdl-1.1.sgml">Docbook/SGML</a>, 
-      <a href="/licenses/old-licenses/fdl-1.1.md">Markdown</a>, 
-      <a href="/licenses/old-licenses/fdl-1.1.odt">ODF</a>, 
-      <a href="/licenses/old-licenses/fdl-1.1.rtf">RTF</a>
-  </li>
-  <li><a href="/licenses/old-licenses/old-licenses.html#FDL">Old versions
-      of the GFDL</a></li>
-</ul>
-
-<hr class="thin" />
-
-<h3>Table of Contents</h3>
-
-<ul>
-  <li><a id="TOC1" href="#SEC1">GNU Free Documentation License</a></li>
-  <li><a id="TOC4" href="#SEC4">How to use this License for your
-  documents</a></li>
-</ul>
-
-<hr class="thin" />
-
-<!-- The license text is in English and appears broken in RTL as
-     Arabic, Farsi, etc.  Explicitly set the direction to override the
-     one defined in the translation. -->
-<div dir="ltr">
-<h3 id="SEC1">GNU Free Documentation License</h3>
-
-<p>Version 1.1, March 2000</p>
-<pre>Copyright (C) 2000  Free Software Foundation, Inc.
-&lt;<a href="https://www.fsf.org/">https://www.fsf.org/</a>&gt;
-Everyone is permitted to copy and distribute verbatim copies
-of this license document, but changing it is not allowed.</pre>
-
-<h4 id="section0">0. PREAMBLE</h4>
-
-<p>The purpose of this License is to make a manual, textbook, or other written
-document "free" in the sense of freedom: to assure everyone the effective
-freedom to copy and redistribute it, with or without modifying it, either
-commercially or noncommercially. Secondarily, this License preserves for the
-author and publisher a way to get credit for their work, while not being
-considered responsible for modifications made by others.</p>
-
-<p>This License is a kind of "copyleft", which means that derivative works of
-the document must themselves be free in the same sense. It complements the GNU
-General Public License, which is a copyleft license designed for free
-software.</p>
-
-<p>We have designed this License in order to use it for manuals for free
-software, because free software needs free documentation: a free program should
-come with manuals providing the same freedoms that the software does. But this
-License is not limited to software manuals; it can be used for any textual
-work, regardless of subject matter or whether it is published as a printed
-book. We recommend this License principally for works whose purpose is
-instruction or reference.</p>
-
-<h4 id="section1">1. APPLICABILITY AND DEFINITIONS</h4>
-
-<p>This License applies to any manual or other work that contains a notice
-placed by the copyright holder saying it can be distributed under the terms of
-this License. The "Document", below, refers to any such manual or work. Any
-member of the public is a licensee, and is addressed as "you".</p>
-
-<p>A "Modified Version" of the Document means any work containing the Document
-or a portion of it, either copied verbatim, or with modifications and/or
-translated into another language.</p>
-
-<p>A "Secondary Section" is a named appendix or a front-matter section of the
-Document that deals exclusively with the relationship of the publishers or
-authors of the Document to the Document's overall subject (or to related
-matters) and contains nothing that could fall directly within that overall
-subject. (For example, if the Document is in part a textbook of mathematics, a
-Secondary Section may not explain any mathematics.) The relationship could be a
-matter of historical connection with the subject or with related matters, or of
-legal, commercial, philosophical, ethical or political position regarding
-them.</p>
-
-<p>The "Invariant Sections" are certain Secondary Sections whose titles are
-designated, as being those of Invariant Sections, in the notice that says that
-the Document is released under this License.</p>
-
-<p>The "Cover Texts" are certain short passages of text that are listed, as
-Front-Cover Texts or Back-Cover Texts, in the notice that says that the
-Document is released under this License.</p>
-
-<p>A "Transparent" copy of the Document means a machine-readable copy,
-represented in a format whose specification is available to the general public,
-whose contents can be viewed and edited directly and straightforwardly with
-generic text editors or (for images composed of pixels) generic paint programs
-or (for drawings) some widely available drawing editor, and that is suitable
-for input to text formatters or for automatic translation to a variety of
-formats suitable for input to text formatters. A copy made in an otherwise
-Transparent file format whose markup has been designed to thwart or discourage
-subsequent modification by readers is not Transparent. A copy that is not
-"Transparent" is called "Opaque".</p>
-
-<p>Examples of suitable formats for Transparent copies include plain ASCII
-without markup, Texinfo input format, LaTeX input format, SGML or XML using a
-publicly available DTD, and standard-conforming simple HTML designed for human
-modification. Opaque formats include PostScript, PDF, proprietary formats that
-can be read and edited only by proprietary word processors, SGML or XML for
-which the DTD and/or processing tools are not generally available, and the
-machine-generated HTML produced by some word processors for output purposes
-only.</p>
-
-<p>The "Title Page" means, for a printed book, the title page itself, plus such
-following pages as are needed to hold, legibly, the material this License
-requires to appear in the title page. For works in formats which do not have
-any title page as such, "Title Page" means the text near the most prominent
-appearance of the work's title, preceding the beginning of the body of the
-text.</p>
-
-<h4 id="section2">2. VERBATIM COPYING</h4>
-
-<p>You may copy and distribute the Document in any medium, either commercially
-or noncommercially, provided that this License, the copyright notices, and the
-license notice saying this License applies to the Document are reproduced in
-all copies, and that you add no other conditions whatsoever to those of this
-License. You may not use technical measures to obstruct or control the reading
-or further copying of the copies you make or distribute. However, you may
-accept compensation in exchange for copies. If you distribute a large enough
-number of copies you must also follow the conditions in section 3.</p>
-
-<p>You may also lend copies, under the same conditions stated above, and you
-may publicly display copies.</p>
-
-<h4 id="section3">3. COPYING IN QUANTITY</h4>
-
-<p>If you publish printed copies of the Document numbering more than 100, and
-the Document's license notice requires Cover Texts, you must enclose the copies
-in covers that carry, clearly and legibly, all these Cover Texts: Front-Cover
-Texts on the front cover, and Back-Cover Texts on the back cover. Both covers
-must also clearly and legibly identify you as the publisher of these copies.
-The front cover must present the full title with all words of the title equally
-prominent and visible. You may add other material on the covers in addition.
-Copying with changes limited to the covers, as long as they preserve the title
-of the Document and satisfy these conditions, can be treated as verbatim
-copying in other respects.</p>
-
-<p>If the required texts for either cover are too voluminous to fit legibly,
-you should put the first ones listed (as many as fit reasonably) on the actual
-cover, and continue the rest onto adjacent pages.</p>
-
-<p>If you publish or distribute Opaque copies of the Document numbering more
-than 100, you must either include a machine-readable Transparent copy along
-with each Opaque copy, or state in or with each Opaque copy a
-publicly-accessible computer-network location containing a complete Transparent
-copy of the Document, free of added material, which the general network-using
-public has access to download anonymously at no charge using public-standard
-network protocols. If you use the latter option, you must take reasonably
-prudent steps, when you begin distribution of Opaque copies in quantity, to
-ensure that this Transparent copy will remain thus accessible at the stated
-location until at least one year after the last time you distribute an Opaque
-copy (directly or through your agents or retailers) of that edition to the
-public.</p>
-
-<p>It is requested, but not required, that you contact the authors of the
-Document well before redistributing any large number of copies, to give them a
-chance to provide you with an updated version of the Document.</p>
-
-<h4 id="section4">4. MODIFICATIONS</h4>
-
-<p>You may copy and distribute a Modified Version of the Document under the
-conditions of sections 2 and 3 above, provided that you release the Modified
-Version under precisely this License, with the Modified Version filling the
-role of the Document, thus licensing distribution and modification of the
-Modified Version to whoever possesses a copy of it. In addition, you must do
-these things in the Modified Version:</p>
-<ul>
-  <li><strong>A.</strong> Use in the Title Page (and on the covers, if any) a
-    title distinct from that of the Document, and from those of previous
-    versions (which should, if there were any, be listed in the History section
-    of the Document). You may use the same title as a previous version if the
-    original publisher of that version gives permission.</li>
-  <li><strong>B.</strong> List on the Title Page, as authors, one or more
-    persons or entities responsible for authorship of the modifications in the
-    Modified Version, together with at least five of the principal authors of
-    the Document (all of its principal authors, if it has less than five).</li>
-  <li><strong>C.</strong> State on the Title page the name of the publisher of
-    the Modified Version, as the publisher.</li>
-  <li><strong>D.</strong> Preserve all the copyright notices of the
-  Document.</li>
-  <li><strong>E.</strong> Add an appropriate copyright notice for your
-    modifications adjacent to the other copyright notices.</li>
-  <li><strong>F.</strong> Include, immediately after the copyright notices, a
-    license notice giving the public permission to use the Modified Version
-    under the terms of this License, in the form shown in the Addendum
-  below.</li>
-  <li><strong>G.</strong> Preserve in that license notice the full lists of
-    Invariant Sections and required Cover Texts given in the Document's license
-    notice.</li>
-  <li><strong>H.</strong> Include an unaltered copy of this License.</li>
-  <li><strong>I.</strong> Preserve the section entitled "History", and its
-    title, and add to it an item stating at least the title, year, new authors,
-    and publisher of the Modified Version as given on the Title Page. If there
-    is no section entitled "History" in the Document, create one stating the
-    title, year, authors, and publisher of the Document as given on its Title
-    Page, then add an item describing the Modified Version as stated in the
-    previous sentence.</li>
-  <li><strong>J.</strong> Preserve the network location, if any, given in the
-    Document for public access to a Transparent copy of the Document, and
-    likewise the network locations given in the Document for previous versions
-    it was based on. These may be placed in the "History" section. You may omit
-    a network location for a work that was published at least four years before
-    the Document itself, or if the original publisher of the version it refers
-    to gives permission.</li>
-  <li><strong>K.</strong> In any section entitled "Acknowledgements" or
-    "Dedications", preserve the section's title, and preserve in the section
-    all the substance and tone of each of the contributor acknowledgements
-    and/or dedications given therein.</li>
-  <li><strong>L.</strong> Preserve all the Invariant Sections of the Document,
-    unaltered in their text and in their titles. Section numbers or the
-    equivalent are not considered part of the section titles.</li>
-  <li><strong>M.</strong> Delete any section entitled "Endorsements". Such a
-    section may not be included in the Modified Version.</li>
-  <li><strong>N.</strong> Do not retitle any existing section as "Endorsements"
-    or to conflict in title with any Invariant Section.</li>
-</ul>
-
-<p>If the Modified Version includes new front-matter sections or appendices
-that qualify as Secondary Sections and contain no material copied from the
-Document, you may at your option designate some or all of these sections as
-invariant. To do this, add their titles to the list of Invariant Sections in
-the Modified Version's license notice. These titles must be distinct from any
-other section titles.</p>
-
-<p>You may add a section entitled "Endorsements", provided it contains nothing
-but endorsements of your Modified Version by various parties--for example,
-statements of peer review or that the text has been approved by an organization
-as the authoritative definition of a standard.</p>
-
-<p>You may add a passage of up to five words as a Front-Cover Text, and a
-passage of up to 25 words as a Back-Cover Text, to the end of the list of Cover
-Texts in the Modified Version. Only one passage of Front-Cover Text and one of
-Back-Cover Text may be added by (or through arrangements made by) any one
-entity. If the Document already includes a cover text for the same cover,
-previously added by you or by arrangement made by the same entity you are
-acting on behalf of, you may not add another; but you may replace the old one,
-on explicit permission from the previous publisher that added the old one.</p>
-
-<p>The author(s) and publisher(s) of the Document do not by this License give
-permission to use their names for publicity for or to assert or imply
-endorsement of any Modified Version.</p>
-
-<h4 id="section5">5. COMBINING DOCUMENTS</h4>
-
-<p>You may combine the Document with other documents released under this
-License, under the terms defined in section 4 above for modified versions,
-provided that you include in the combination all of the Invariant Sections of
-all of the original documents, unmodified, and list them all as Invariant
-Sections of your combined work in its license notice.</p>
-
-<p>The combined work need only contain one copy of this License, and multiple
-identical Invariant Sections may be replaced with a single copy. If there are
-multiple Invariant Sections with the same name but different contents, make the
-title of each such section unique by adding at the end of it, in parentheses,
-the name of the original author or publisher of that section if known, or else
-a unique number. Make the same adjustment to the section titles in the list of
-Invariant Sections in the license notice of the combined work.</p>
-
-<p>In the combination, you must combine any sections entitled "History" in the
-various original documents, forming one section entitled "History"; likewise
-combine any sections entitled "Acknowledgements", and any sections entitled
-"Dedications". You must delete all sections entitled "Endorsements."</p>
-
-<h4 id="section6">6. COLLECTIONS OF DOCUMENTS</h4>
-
-<p>You may make a collection consisting of the Document and other documents
-released under this License, and replace the individual copies of this License
-in the various documents with a single copy that is included in the collection,
-provided that you follow the rules of this License for verbatim copying of each
-of the documents in all other respects.</p>
-
-<p>You may extract a single document from such a collection, and distribute it
-individually under this License, provided you insert a copy of this License
-into the extracted document, and follow this License in all other respects
-regarding verbatim copying of that document.</p>
-
-<h4 id="section7">7. AGGREGATION WITH INDEPENDENT WORKS</h4>
-
-<p>A compilation of the Document or its derivatives with other separate and
-independent documents or works, in or on a volume of a storage or distribution
-medium, does not as a whole count as a Modified Version of the Document,
-provided no compilation copyright is claimed for the compilation. Such a
-compilation is called an "aggregate", and this License does not apply to the
-other self-contained works thus compiled with the Document, on account of their
-being thus compiled, if they are not themselves derivative works of the
-Document.</p>
-
-<p>If the Cover Text requirement of section 3 is applicable to these copies of
-the Document, then if the Document is less than one quarter of the entire
-aggregate, the Document's Cover Texts may be placed on covers that surround
-only the Document within the aggregate. Otherwise they must appear on covers
-around the whole aggregate.</p>
-
-<h4 id="section8">8. TRANSLATION</h4>
-
-<p>Translation is considered a kind of modification, so you may distribute
-translations of the Document under the terms of section 4. Replacing Invariant
-Sections with translations requires special permission from their copyright
-holders, but you may include translations of some or all Invariant Sections in
-addition to the original versions of these Invariant Sections. You may include
-a translation of this License provided that you also include the original
-English version of this License. In case of a disagreement between the
-translation and the original English version of this License, the original
-English version will prevail.</p>
-
-<h4 id="section9">9. TERMINATION</h4>
-
-<p>You may not copy, modify, sublicense, or distribute the Document except as
-expressly provided for under this License. Any other attempt to copy, modify,
-sublicense or distribute the Document is void, and will automatically terminate
-your rights under this License. However, parties who have received copies, or
-rights, from you under this License will not have their licenses terminated so
-long as such parties remain in full compliance.</p>
-
-<h4 id="section10">10. FUTURE REVISIONS OF THIS LICENSE</h4>
-
-<p>The Free Software Foundation may publish new, revised versions of the GNU
-Free Documentation License from time to time. Such new versions will be similar
-in spirit to the present version, but may differ in detail to address new
-problems or concerns. See https://www.gnu.org/licenses/.</p>
-
-<p>Each version of the License is given a distinguishing version number. If the
-Document specifies that a particular numbered version of this License "or any
-later version" applies to it, you have the option of following the terms and
-conditions either of that specified version or of any later version that has
-been published (not as a draft) by the Free Software Foundation. If the
-Document does not specify a version number of this License, you may choose any
-version ever published (not as a draft) by the Free Software Foundation.</p>
-
-<h4 id="SEC4">How to use this License for your documents</h4>
-
-<p>To use this License in a document you have written, include a copy of the
-License in the document and put the following copyright and license notices
-just after the title page:</p>
-<pre>      Copyright (c)  YEAR  YOUR NAME.
+                GNU Free Documentation License
+                   Version 1.1, March 2000
+
+ Copyright (C) 2000  Free Software Foundation, Inc.
+     <https://fsf.org/>
+ Everyone is permitted to copy and distribute verbatim copies
+ of this license document, but changing it is not allowed.
+
+
+0. PREAMBLE
+
+The purpose of this License is to make a manual, textbook, or other
+written document "free" in the sense of freedom: to assure everyone
+the effective freedom to copy and redistribute it, with or without
+modifying it, either commercially or noncommercially.  Secondarily,
+this License preserves for the author and publisher a way to get
+credit for their work, while not being considered responsible for
+modifications made by others.
+
+This License is a kind of "copyleft", which means that derivative
+works of the document must themselves be free in the same sense.  It
+complements the GNU General Public License, which is a copyleft
+license designed for free software.
+
+We have designed this License in order to use it for manuals for free
+software, because free software needs free documentation: a free
+program should come with manuals providing the same freedoms that the
+software does.  But this License is not limited to software manuals;
+it can be used for any textual work, regardless of subject matter or
+whether it is published as a printed book.  We recommend this License
+principally for works whose purpose is instruction or reference.
+
+
+1. APPLICABILITY AND DEFINITIONS
+
+This License applies to any manual or other work that contains a
+notice placed by the copyright holder saying it can be distributed
+under the terms of this License.  The "Document", below, refers to any
+such manual or work.  Any member of the public is a licensee, and is
+addressed as "you".
+
+A "Modified Version" of the Document means any work containing the
+Document or a portion of it, either copied verbatim, or with
+modifications and/or translated into another language.
+
+A "Secondary Section" is a named appendix or a front-matter section of
+the Document that deals exclusively with the relationship of the
+publishers or authors of the Document to the Document's overall subject
+(or to related matters) and contains nothing that could fall directly
+within that overall subject.  (For example, if the Document is in part a
+textbook of mathematics, a Secondary Section may not explain any
+mathematics.)  The relationship could be a matter of historical
+connection with the subject or with related matters, or of legal,
+commercial, philosophical, ethical or political position regarding
+them.
+
+The "Invariant Sections" are certain Secondary Sections whose titles
+are designated, as being those of Invariant Sections, in the notice
+that says that the Document is released under this License.
+
+The "Cover Texts" are certain short passages of text that are listed,
+as Front-Cover Texts or Back-Cover Texts, in the notice that says that
+the Document is released under this License.
+
+A "Transparent" copy of the Document means a machine-readable copy,
+represented in a format whose specification is available to the
+general public, whose contents can be viewed and edited directly and
+straightforwardly with generic text editors or (for images composed of
+pixels) generic paint programs or (for drawings) some widely available
+drawing editor, and that is suitable for input to text formatters or
+for automatic translation to a variety of formats suitable for input
+to text formatters.  A copy made in an otherwise Transparent file
+format whose markup has been designed to thwart or discourage
+subsequent modification by readers is not Transparent.  A copy that is
+not "Transparent" is called "Opaque".
+
+Examples of suitable formats for Transparent copies include plain
+ASCII without markup, Texinfo input format, LaTeX input format, SGML
+or XML using a publicly available DTD, and standard-conforming simple
+HTML designed for human modification.  Opaque formats include
+PostScript, PDF, proprietary formats that can be read and edited only
+by proprietary word processors, SGML or XML for which the DTD and/or
+processing tools are not generally available, and the
+machine-generated HTML produced by some word processors for output
+purposes only.
+
+The "Title Page" means, for a printed book, the title page itself,
+plus such following pages as are needed to hold, legibly, the material
+this License requires to appear in the title page.  For works in
+formats which do not have any title page as such, "Title Page" means
+the text near the most prominent appearance of the work's title,
+preceding the beginning of the body of the text.
+
+
+2. VERBATIM COPYING
+
+You may copy and distribute the Document in any medium, either
+commercially or noncommercially, provided that this License, the
+copyright notices, and the license notice saying this License applies
+to the Document are reproduced in all copies, and that you add no other
+conditions whatsoever to those of this License.  You may not use
+technical measures to obstruct or control the reading or further
+copying of the copies you make or distribute.  However, you may accept
+compensation in exchange for copies.  If you distribute a large enough
+number of copies you must also follow the conditions in section 3.
+
+You may also lend copies, under the same conditions stated above, and
+you may publicly display copies.
+
+
+3. COPYING IN QUANTITY
+
+If you publish printed copies of the Document numbering more than 100,
+and the Document's license notice requires Cover Texts, you must enclose
+the copies in covers that carry, clearly and legibly, all these Cover
+Texts: Front-Cover Texts on the front cover, and Back-Cover Texts on
+the back cover.  Both covers must also clearly and legibly identify
+you as the publisher of these copies.  The front cover must present
+the full title with all words of the title equally prominent and
+visible.  You may add other material on the covers in addition.
+Copying with changes limited to the covers, as long as they preserve
+the title of the Document and satisfy these conditions, can be treated
+as verbatim copying in other respects.
+
+If the required texts for either cover are too voluminous to fit
+legibly, you should put the first ones listed (as many as fit
+reasonably) on the actual cover, and continue the rest onto adjacent
+pages.
+
+If you publish or distribute Opaque copies of the Document numbering
+more than 100, you must either include a machine-readable Transparent
+copy along with each Opaque copy, or state in or with each Opaque copy
+a publicly-accessible computer-network location containing a complete
+Transparent copy of the Document, free of added material, which the
+general network-using public has access to download anonymously at no
+charge using public-standard network protocols.  If you use the latter
+option, you must take reasonably prudent steps, when you begin
+distribution of Opaque copies in quantity, to ensure that this
+Transparent copy will remain thus accessible at the stated location
+until at least one year after the last time you distribute an Opaque
+copy (directly or through your agents or retailers) of that edition to
+the public.
+
+It is requested, but not required, that you contact the authors of the
+Document well before redistributing any large number of copies, to give
+them a chance to provide you with an updated version of the Document.
+
+
+4. MODIFICATIONS
+
+You may copy and distribute a Modified Version of the Document under
+the conditions of sections 2 and 3 above, provided that you release
+the Modified Version under precisely this License, with the Modified
+Version filling the role of the Document, thus licensing distribution
+and modification of the Modified Version to whoever possesses a copy
+of it.  In addition, you must do these things in the Modified Version:
+
+A. Use in the Title Page (and on the covers, if any) a title distinct
+   from that of the Document, and from those of previous versions
+   (which should, if there were any, be listed in the History section
+   of the Document).  You may use the same title as a previous version
+   if the original publisher of that version gives permission.
+B. List on the Title Page, as authors, one or more persons or entities
+   responsible for authorship of the modifications in the Modified
+   Version, together with at least five of the principal authors of the
+   Document (all of its principal authors, if it has less than five).
+C. State on the Title page the name of the publisher of the
+   Modified Version, as the publisher.
+D. Preserve all the copyright notices of the Document.
+E. Add an appropriate copyright notice for your modifications
+   adjacent to the other copyright notices.
+F. Include, immediately after the copyright notices, a license notice
+   giving the public permission to use the Modified Version under the
+   terms of this License, in the form shown in the Addendum below.
+G. Preserve in that license notice the full lists of Invariant Sections
+   and required Cover Texts given in the Document's license notice.
+H. Include an unaltered copy of this License.
+I. Preserve the section entitled "History", and its title, and add to
+   it an item stating at least the title, year, new authors, and
+   publisher of the Modified Version as given on the Title Page.  If
+   there is no section entitled "History" in the Document, create one
+   stating the title, year, authors, and publisher of the Document as
+   given on its Title Page, then add an item describing the Modified
+   Version as stated in the previous sentence.
+J. Preserve the network location, if any, given in the Document for
+   public access to a Transparent copy of the Document, and likewise
+   the network locations given in the Document for previous versions
+   it was based on.  These may be placed in the "History" section.
+   You may omit a network location for a work that was published at
+   least four years before the Document itself, or if the original
+   publisher of the version it refers to gives permission.
+K. In any section entitled "Acknowledgements" or "Dedications",
+   preserve the section's title, and preserve in the section all the
+   substance and tone of each of the contributor acknowledgements
+   and/or dedications given therein.
+L. Preserve all the Invariant Sections of the Document,
+   unaltered in their text and in their titles.  Section numbers
+   or the equivalent are not considered part of the section titles.
+M. Delete any section entitled "Endorsements".  Such a section
+   may not be included in the Modified Version.
+N. Do not retitle any existing section as "Endorsements"
+   or to conflict in title with any Invariant Section.
+
+If the Modified Version includes new front-matter sections or
+appendices that qualify as Secondary Sections and contain no material
+copied from the Document, you may at your option designate some or all
+of these sections as invariant.  To do this, add their titles to the
+list of Invariant Sections in the Modified Version's license notice.
+These titles must be distinct from any other section titles.
+
+You may add a section entitled "Endorsements", provided it contains
+nothing but endorsements of your Modified Version by various
+parties--for example, statements of peer review or that the text has
+been approved by an organization as the authoritative definition of a
+standard.
+
+You may add a passage of up to five words as a Front-Cover Text, and a
+passage of up to 25 words as a Back-Cover Text, to the end of the list
+of Cover Texts in the Modified Version.  Only one passage of
+Front-Cover Text and one of Back-Cover Text may be added by (or
+through arrangements made by) any one entity.  If the Document already
+includes a cover text for the same cover, previously added by you or
+by arrangement made by the same entity you are acting on behalf of,
+you may not add another; but you may replace the old one, on explicit
+permission from the previous publisher that added the old one.
+
+The author(s) and publisher(s) of the Document do not by this License
+give permission to use their names for publicity for or to assert or
+imply endorsement of any Modified Version.
+
+
+5. COMBINING DOCUMENTS
+
+You may combine the Document with other documents released under this
+License, under the terms defined in section 4 above for modified
+versions, provided that you include in the combination all of the
+Invariant Sections of all of the original documents, unmodified, and
+list them all as Invariant Sections of your combined work in its
+license notice.
+
+The combined work need only contain one copy of this License, and
+multiple identical Invariant Sections may be replaced with a single
+copy.  If there are multiple Invariant Sections with the same name but
+different contents, make the title of each such section unique by
+adding at the end of it, in parentheses, the name of the original
+author or publisher of that section if known, or else a unique number.
+Make the same adjustment to the section titles in the list of
+Invariant Sections in the license notice of the combined work.
+
+In the combination, you must combine any sections entitled "History"
+in the various original documents, forming one section entitled
+"History"; likewise combine any sections entitled "Acknowledgements",
+and any sections entitled "Dedications".  You must delete all sections
+entitled "Endorsements."
+
+
+6. COLLECTIONS OF DOCUMENTS
+
+You may make a collection consisting of the Document and other documents
+released under this License, and replace the individual copies of this
+License in the various documents with a single copy that is included in
+the collection, provided that you follow the rules of this License for
+verbatim copying of each of the documents in all other respects.
+
+You may extract a single document from such a collection, and distribute
+it individually under this License, provided you insert a copy of this
+License into the extracted document, and follow this License in all
+other respects regarding verbatim copying of that document.
+
+
+7. AGGREGATION WITH INDEPENDENT WORKS
+
+A compilation of the Document or its derivatives with other separate
+and independent documents or works, in or on a volume of a storage or
+distribution medium, does not as a whole count as a Modified Version
+of the Document, provided no compilation copyright is claimed for the
+compilation.  Such a compilation is called an "aggregate", and this
+License does not apply to the other self-contained works thus compiled
+with the Document, on account of their being thus compiled, if they
+are not themselves derivative works of the Document.
+
+If the Cover Text requirement of section 3 is applicable to these
+copies of the Document, then if the Document is less than one quarter
+of the entire aggregate, the Document's Cover Texts may be placed on
+covers that surround only the Document within the aggregate.
+Otherwise they must appear on covers around the whole aggregate.
+
+
+8. TRANSLATION
+
+Translation is considered a kind of modification, so you may
+distribute translations of the Document under the terms of section 4.
+Replacing Invariant Sections with translations requires special
+permission from their copyright holders, but you may include
+translations of some or all Invariant Sections in addition to the
+original versions of these Invariant Sections.  You may include a
+translation of this License provided that you also include the
+original English version of this License.  In case of a disagreement
+between the translation and the original English version of this
+License, the original English version will prevail.
+
+
+9. TERMINATION
+
+You may not copy, modify, sublicense, or distribute the Document except
+as expressly provided for under this License.  Any other attempt to
+copy, modify, sublicense or distribute the Document is void, and will
+automatically terminate your rights under this License.  However,
+parties who have received copies, or rights, from you under this
+License will not have their licenses terminated so long as such
+parties remain in full compliance.
+
+
+10. FUTURE REVISIONS OF THIS LICENSE
+
+The Free Software Foundation may publish new, revised versions
+of the GNU Free Documentation License from time to time.  Such new
+versions will be similar in spirit to the present version, but may
+differ in detail to address new problems or concerns.  See
+https://www.gnu.org/licenses/.
+
+Each version of the License is given a distinguishing version number.
+If the Document specifies that a particular numbered version of this
+License "or any later version" applies to it, you have the option of
+following the terms and conditions either of that specified version or
+of any later version that has been published (not as a draft) by the
+Free Software Foundation.  If the Document does not specify a version
+number of this License, you may choose any version ever published (not
+as a draft) by the Free Software Foundation.
+
+
+ADDENDUM: How to use this License for your documents
+
+To use this License in a document you have written, include a copy of
+the License in the document and put the following copyright and
+license notices just after the title page:
+
+      Copyright (c)  YEAR  YOUR NAME.
       Permission is granted to copy, distribute and/or modify this document
       under the terms of the GNU Free Documentation License, Version 1.1
       or any later version published by the Free Software Foundation;
       with the Invariant Sections being LIST THEIR TITLES, with the
       Front-Cover Texts being LIST, and with the Back-Cover Texts being LIST.
       A copy of the license is included in the section entitled "GNU
-      Free Documentation License".</pre>
+      Free Documentation License".
 
-<p>If you have no Invariant Sections, write "with no Invariant Sections"
-instead of saying which ones are invariant. If you have no Front-Cover Texts,
-write "no Front-Cover Texts" instead of "Front-Cover Texts being LIST";
-likewise for Back-Cover Texts.</p>
+If you have no Invariant Sections, write "with no Invariant Sections"
+instead of saying which ones are invariant.  If you have no
+Front-Cover Texts, write "no Front-Cover Texts" instead of
+"Front-Cover Texts being LIST"; likewise for Back-Cover Texts.
 
-<p>If your document contains nontrivial examples of program code, we recommend
-releasing these examples in parallel under your choice of free software
-license, such as the GNU General Public License, to permit their use in free
-software.</p>
-
-<!-- END OF TERMS AND CONDITIONS -->
-
-</div>
-</div>
-
-</div><!-- for id="content", starts in the include above -->
-
-              <!-- begin server/footer-text.html -->
-
-
-
-
-
-<div style="clear:both"></div>
-
-
-<div id="language-container">
- <div class="backtotop">
-  <hr class="no-display" />
-  <a href="#top"><b>&#9650;</b></a>
- </div>
- <div id="languages" class="rounded-corners">
-  <div class="button">
-   <a href="#top" class="close"><span>BACK TO TOP</span></a>
-  </div>
-  <div id="set-language" class="button">
-   <span class="gnun-split"></span>
-   <a href="/server/select-language.html?callback=/licenses/old-licenses/fdl-1.1" rel="nofollow">
-   Set language
-   <span class="gnun-split"></span>
-   </a>
-  </div>
-  <p>Available for this page:</p>
-  <div id="translations">
-<p>
-<span dir="ltr" class="original">[en]&nbsp;<a lang="en" hreflang="en" href="/licenses/old-licenses/fdl-1.1.en.html">English</a> &nbsp;</span>
-<span dir="ltr">[de]&nbsp;<a lang="de" hreflang="de" href="/licenses/old-licenses/fdl-1.1.de.html">Deutsch</a> &nbsp;</span>
-<span dir="ltr">[fr]&nbsp;<a lang="fr" hreflang="fr" href="/licenses/old-licenses/fdl-1.1.fr.html">français</a> &nbsp;</span>
-<span dir="ltr">[ja]&nbsp;<a lang="ja" hreflang="ja" href="/licenses/old-licenses/fdl-1.1.ja.html">日本語</a> &nbsp;</span>
-<span dir="ltr">[pt-br]&nbsp;<a lang="pt-br" hreflang="pt-br" href="/licenses/old-licenses/fdl-1.1.pt-br.html">português</a> &nbsp;</span>
-<span dir="ltr">[ru]&nbsp;<a lang="ru" hreflang="ru" href="/licenses/old-licenses/fdl-1.1.ru.html">русский</a> &nbsp;</span>
-<span dir="ltr">[uk]&nbsp;<a lang="uk" hreflang="uk" href="/licenses/old-licenses/fdl-1.1.uk.html">українська</a> &nbsp;</span>
-<span dir="ltr">[zh-cn]&nbsp;<a lang="zh-cn" hreflang="zh-cn" href="/licenses/old-licenses/fdl-1.1.zh-cn.html">简体中文</a> &nbsp;</span>
-</p>
-</div>
- </div>
-</div>
-
-<div id="mission-statement" role="complementary">
- <div class="backtotop">
-  <hr class="no-display" />
-  <a href="#header"><span>BACK TO TOP </span>&#9650;</a>
- </div>
-<div style="clear: both"></div>
-<blockquote>
-<p style="direction:ltr; text-align:left"><a href="//www.fsf.org"><img id="fsfbanner"
-src="/graphics/fsf-logo-notext-small.png" alt="&nbsp;[FSF logo]&nbsp;"
-width="75" height="25" /></a><strong>
-&ldquo;The Free Software Foundation (FSF) is a nonprofit with a worldwide
-mission to promote computer user freedom. We defend the rights of all
-software users.&rdquo;</strong></p>
-</blockquote>
-
-<div id="support-the-fsf" class="button">
- <a class="join" href="//www.fsf.org/associate/support_freedom?referrer=4052">JOIN</a>
- <a class="donate" href="//donate.fsf.org/">DONATE</a>
- <a class="shop" href="//shop.fsf.org/">SHOP</a>
-</div>
-</div>
-<!-- end server/footer-text.html -->
-
-
-<div id="footer" role="contentinfo">
-<div class="unprintable">
-
-<p>Please send general FSF &amp; GNU inquiries to
-<a href="mailto:gnu@gnu.org">&lt;gnu@gnu.org&gt;</a>.
-There are also <a href="/contact/">other ways to contact</a>
-the FSF.  Broken links and other corrections or suggestions can be sent
-to <a href="mailto:webmasters@gnu.org">&lt;webmasters@gnu.org&gt;</a>.</p>
-
-<p><!-- TRANSLATORS: Ignore the original text in this paragraph,
-        replace it with the translation of these two:
-
-        We work hard and do our best to provide accurate, good quality
-        translations.  However, we are not exempt from imperfection.
-        Please send your comments and general suggestions in this regard
-        to <a href="mailto:web-translators@gnu.org">
-        &lt;web-translators@gnu.org&gt;</a>.</p>
-
-        <p>For information on coordinating and contributing translations of
-        our web pages, see <a
-        href="/server/standards/README.translations.html">Translations
-        README</a>. -->
-Please see the <a
-href="/server/standards/README.translations.html">Translations
-README</a> for information on coordinating and contributing translations
-of this article.</p>
-</div>
-
-<p>Copyright notice above.</p>
-
-<!-- start of server/bottom-notes.html -->
-<div id="bottom-notes" class="unprintable">
-<p><a href="//www.fsf.org/about/dmca-notice">Copyright Infringement Notification</a></p>
-<div id="generic">
-
-
-</div>
-</div>
-<!-- end of server/bottom-notes.html -->
-
-
-<p class="unprintable">Updated:
-<!-- timestamp start -->
-$Date: 2023/11/30 09:46:01 $
-<!-- timestamp end --></p>
-</div>
-</div><!-- for class="inner", starts in the banner include -->
-</body>
-</html>
+If your document contains nontrivial examples of program code, we
+recommend releasing these examples in parallel under your choice of
+free software license, such as the GNU General Public License,
+to permit their use in free software.

--- a/licenses-generator/src/main/resources/offline-license-mirror/www.gnu.org/licenses/old-licenses/fdl-1.2
+++ b/licenses-generator/src/main/resources/offline-license-mirror/www.gnu.org/licenses/old-licenses/fdl-1.2
@@ -1,821 +1,397 @@
-<!DOCTYPE html>
-<html xmlns="http://www.w3.org/1999/xhtml" xml:lang="en" lang="en">
-<head>
-<meta http-equiv="content-type" content="text/html; charset=utf-8" />
-<link rel="author" href="mailto:webmasters@gnu.org" />
-<link rel="icon" type="image/png" href="/graphics/gnu-head-mini.png" />
-<meta name="ICBM" content="42.355469,-71.058627" />
-<link rel="stylesheet" type="text/css" href="/layout.min.css" media="screen" />
-<link rel="stylesheet" type="text/css" href="/print.min.css" media="print" />
-
-
-
-<!-- Parent-Version: 1.98 -->
-<!-- This page is derived from /server/standards/boilerplate.html -->
-<title>GNU Free Documentation License 1.2
-- GNU Project - Free Software Foundation</title>
-<!-- begin translist file -->
-
-<link rel="alternate" type="text/html" href="/licenses/old-licenses/fdl-1.2.html" hreflang="x-default" />
-<link rel="alternate" type="text/html" lang="en" hreflang="en" href="/licenses/old-licenses/fdl-1.2.en.html" title="English" />
-<link rel="alternate" type="text/html" lang="de" hreflang="de" href="/licenses/old-licenses/fdl-1.2.de.html" title="Deutsch" />
-<link rel="alternate" type="text/html" lang="fr" hreflang="fr" href="/licenses/old-licenses/fdl-1.2.fr.html" title="français" />
-<link rel="alternate" type="text/html" lang="ja" hreflang="ja" href="/licenses/old-licenses/fdl-1.2.ja.html" title="日本語" />
-<link rel="alternate" type="text/html" lang="pt-br" hreflang="pt-br" href="/licenses/old-licenses/fdl-1.2.pt-br.html" title="português" />
-<link rel="alternate" type="text/html" lang="ru" hreflang="ru" href="/licenses/old-licenses/fdl-1.2.ru.html" title="русский" />
-<link rel="alternate" type="text/html" lang="uk" hreflang="uk" href="/licenses/old-licenses/fdl-1.2.uk.html" title="українська" />
-<link rel="alternate" type="text/html" lang="zh-cn" hreflang="zh-cn" href="/licenses/old-licenses/fdl-1.2.zh-cn.html" title="简体中文" />
-<!-- end translist file -->
-
-<!-- start of server/banner.html -->
-<!-- start of head-include-2.html -->
-<meta name="viewport" content="width=device-width, initial-scale=1" />
-<!-- end of head-include-2.html -->
-
-</head>
-<body>
-<div class="inner">
-<!-- start of server/body-include-1.html -->
-<div id="top">
-<a class="skip" href="#content"><b>Skip to main text</b></a>
-</div>
-
-<div id="fsf-frame" role="complementary">
-<form id="fssbox" action="https://my.fsf.org/civicrm/profile/create?reset=1&amp;gid=31"
-      method="post">
- <div>
-  <input name="postURL" type="hidden" value="" />
-  <input type="hidden" name="group[25]" value="1" />
-  <input name="cancelURL" type="hidden" value="https://crm.fsf.org/civicrm/profile?reset=1&amp;gid=31" />
-  <input name="_qf_default" type="hidden" value="Edit:cancel" />
-  <label for="frmEmail">
-   <a href="//www.fsf.org/fss">Free Software Supporter</a>:
-  </label>
-  <input type="text" id="frmEmail" name="email-Primary" size="18" maxlength="80"
-         value="email address" onfocus="this.value=''"/>
-  <input type="submit" name="_qf_Edit_next" value="Sign up" />
- </div>
-</form>
-
-<div id="join-fsf" class="button"><a
-href="https://www.fsf.org/associate/support_freedom?referrer=4052">JOIN&nbsp;THE&nbsp;FSF</a>
-</div>
-</div>
-
-<div id="header" role="banner">
-<p id="gnu-banner">
- <a href="/">
- <img src="/graphics/heckert_gnu.transp.small.png" height="48" width="49"
-      alt="&nbsp;[A GNU head]&nbsp;" /><strong>GNU</strong> <span
- class="hide">Operating System</span></a><br />
- <small id="fsf-support">Supported by the
- <a href="#mission-statement">Free Software Foundation</a></small>
-</p>
-
-<div id="switches">
-<!-- begin search button -->
- <div  id="search-button" class="switch">
-  <a href="//www.gnu.org/cgi-bin/estseek.cgi">
-  <img id="search-icon" height="30" width="30"
-       src="/graphics/icons/search.png"
-       alt="&nbsp;[Search www.gnu.org]&nbsp;" /></a>
- </div>
-<!-- end search button -->
-
- <div id="language-button" class="switch">
-  <a href="#language-container">
-  <img id="language-icon" height="30" width="37"
-       src="/graphics/icons/translations.png"
-       alt="&nbsp;[Other languages]&nbsp;" /></a>
- </div>
-
-</div>
-</div>
-<!-- end of server/body-include-1.html -->
-
-<!-- start of server/body-include-2 -->
-
-
-<div style="clear: both"></div>
-
-<div id="navigation" role="navigation">
- <a id="more-links" href="#navigation" title="More...">
-   <span>Site navigation</span></a>
- <a id="less-links" href="#content"><b>Skip</b></a>
- <ul>
-
-   <li id="tabAboutGNU"><a href="/gnu/gnu.html">ABOUT&nbsp;GNU</a></li>
-
-
-  <li id="tabPhilosophy"><a href="/philosophy/philosophy.html">PHILOSOPHY</a></li>
-
-
-  <li id="tabLicenses" class="active">
-     <span class='no-display'>=</span> 
-    <a href="/licenses/licenses.html">LICENSES</a>
-    <span class="gnun-split"></span>
-     <span class='no-display'>=</span> 
-  </li>
-
-
-  <li id="tabEducation"><a href="/education/education.html">EDUCATION</a></li>
-
-
-  <li id="tabSoftware"><a href="/software/software.html">SOFTWARE</a></li>
-
-
-  <li id="tabDistros"><a href="/distros/distros.html">DISTROS</a></li>
-
-
-  <li id="tabDoc"><a href="/doc/doc.html">DOCS</a></li>
-
-
-  <li id="tabMalware"><a href="/proprietary/proprietary.html">MALWARE</a></li>
-
-
-  <li id="tabHelp"><a href="/help/help.html">HELP&nbsp;GNU</a></li>
-
-
-  <li id="tabAV"><a href="/audio-video/audio-video.html">AUDIO&nbsp;&amp;&nbsp;VIDEO</a></li>
-
-
-  <li id="tabArt"><a href="/graphics/graphics.html">GNU&nbsp;ART</a></li>
-
-
-  <li id="tabFun"><a href="/fun/humor.html">FUN</a></li>
-
-
-  <li id="tabPeople"><a href="/people/people.html">GNU'S&nbsp;WHO?</a></li>
-
-  <li><a href="//directory.fsf.org">SOFTWARE&nbsp;DIRECTORY</a></li>
-  <li><a href="https://h-node.org/">HARDWARE</a></li>
-  <li><a href="/server/sitemap.html">SITEMAP</a></li>
- </ul>
- <div style="clear: both"></div>
-</div><!-- /"navigation -->
-<!-- end of server/body-include-2 -->
-
-<div id="content" role="main">
-<!-- end of server/banner.html -->
-
-<div class="reduced-width">
-<h2>GNU Free Documentation License&nbsp;1.2</h2>
-
-<p class="button" style="margin: 2em 1.5em">
-  <b><a href="#SEC1">Skip to license text</a></b></p>
-
-<h3>Related Pages</h3>
-<ul>
-  <li><a href="/licenses/fdl.html">The latest version of the FDL,
-      version 1.3</a></li>
-  <li><a href="/philosophy/free-doc.html">Free software and free
-      documentation</a></li>
-  <li><a href="/licenses/gpl-violation.html">What to do if you see a
-      possible GFDL violation</a></li>
-  <li><a href="/licenses/why-gfdl.html">Why publishers should use the
-      GNU Free Documentation License</a></li>
-  <li><a href="/licenses/fdl-howto.html">Tips on how to use the FDL</a></li>
-  <li><a href="/licenses/fdl-howto-opt.html">Using the optional features
-      of the GFDL</a></li>
-  <li><a href="/licenses/old-licenses/fdl-1.2-translations.html">Translations
-      of GFDLv1.2</a></li>
-  <li>The GNU Free Documentation License version 1.2 (GFDLv1.2) in other
-      formats:
-      <a href="/licenses/old-licenses/fdl-1.2.txt">plain text</a>,
-      <a href="/licenses/old-licenses/fdl-1.2.texi">Texinfo</a>,
-      <a href="/licenses/old-licenses/fdl-1.2.tex">LaTeX</a>,
-  <a href="/licenses/old-licenses/fdl-1.2-standalone.html">standalone HTML</a>,
-      <a href="/licenses/old-licenses/fdl-1.2.xml">Docbook</a>, 
-      <a href="/licenses/old-licenses/fdl-1.2.md">Markdown</a>, 
-      <a href="/licenses/old-licenses/fdl-1.2.odt">ODF</a>, 
-      <a href="/licenses/old-licenses/fdl-1.2.rtf">RTF</a>
-  </li>
-  <li><a href="/licenses/old-licenses/old-licenses.html#FDL">Old versions
-      of the GFDL</a></li>
-</ul>
-
-<p><i>Differences between versions 1.1 and 1.2 of the
-  GNU Free Documentation License:</i>
-</p>
-<ul>
-  <li><a href="/licenses/fdl-1.2-diff.txt">Plain context diff</a></li>
-  <li><a href="/licenses/fdl-1.2-wdiff.txt">Word diff</a></li>
-  <li><a href="/licenses/fdl-1.2-pdiff.ps">Word diff in
-      PostScript format</a></li>
-</ul>
-
-<hr class="thin" />
-
-<h3>Table of Contents</h3>
-
-<ul>
-  <li><a id="TOC1" href="#SEC1">Current version of the GNU Free Documentation License</a></li>
-  <li><a id="TOC4" href="#SEC4">How to use this License for your documents</a></li>
-</ul>
-
-<hr class="thin" />
-
-<!-- The license text is in English and appears broken in RTL as
-     Arabic, Farsi, etc.  Explicitly set the direction to override the
-     one defined in the translation. -->
-<div dir="ltr">
-<h3 id="SEC1">GNU Free Documentation License</h3>
-<p>
-  Version 1.2, November 2002
-</p>
-
-<pre>
-  Copyright (C) 2000,2001,2002  Free Software Foundation, Inc.
-  &lt;<a href="https://www.fsf.org">https://www.fsf.org/</a>&gt;
-  Everyone is permitted to copy and distribute verbatim copies
-  of this license document, but changing it is not allowed.
-</pre>
-
-<h4 id="section0">0. PREAMBLE</h4>
-
-<p>
-  The purpose of this License is to make a manual, textbook, or other
-  functional and useful document "free" in the sense of freedom: to
-  assure everyone the effective freedom to copy and redistribute it,
-  with or without modifying it, either commercially or noncommercially.
-  Secondarily, this License preserves for the author and publisher a way
-  to get credit for their work, while not being considered responsible
-  for modifications made by others.
-</p>
-
-<p>
-  This License is a kind of "copyleft", which means that derivative
-  works of the document must themselves be free in the same sense.  It
-  complements the GNU General Public License, which is a copyleft
-  license designed for free software.
-</p>
-
-<p>
-  We have designed this License in order to use it for manuals for free
-  software, because free software needs free documentation: a free
-  program should come with manuals providing the same freedoms that the
-  software does.  But this License is not limited to software manuals;
-  it can be used for any textual work, regardless of subject matter or
-  whether it is published as a printed book.  We recommend this License
-  principally for works whose purpose is instruction or reference.
-</p>
-
-<h4 id="section1">1. APPLICABILITY AND DEFINITIONS</h4>
-
-<p>
-  This License applies to any manual or other work, in any medium, that
-  contains a notice placed by the copyright holder saying it can be
-  distributed under the terms of this License.  Such a notice grants a
-  world-wide, royalty-free license, unlimited in duration, to use that
-  work under the conditions stated herein.  The "Document", below,
-  refers to any such manual or work.  Any member of the public is a
-  licensee, and is addressed as "you".  You accept the license if you
-  copy, modify or distribute the work in a way requiring permission
-  under copyright law.
-</p>
-
-<p>
-  A "Modified Version" of the Document means any work containing the
-  Document or a portion of it, either copied verbatim, or with
-  modifications and/or translated into another language.
-</p>
-
-<p>
-  A "Secondary Section" is a named appendix or a front-matter section of
-  the Document that deals exclusively with the relationship of the
-  publishers or authors of the Document to the Document's overall subject
-  (or to related matters) and contains nothing that could fall directly
-  within that overall subject.  (Thus, if the Document is in part a
-  textbook of mathematics, a Secondary Section may not explain any
-  mathematics.)  The relationship could be a matter of historical
-  connection with the subject or with related matters, or of legal,
-  commercial, philosophical, ethical or political position regarding
-  them.
-</p>
-
-<p>
-  The "Invariant Sections" are certain Secondary Sections whose titles
-  are designated, as being those of Invariant Sections, in the notice
-  that says that the Document is released under this License.  If a
-  section does not fit the above definition of Secondary then it is not
-  allowed to be designated as Invariant.  The Document may contain zero
-  Invariant Sections.  If the Document does not identify any Invariant
-  Sections then there are none.
-</p>
-
-<p>
-  The "Cover Texts" are certain short passages of text that are listed,
-  as Front-Cover Texts or Back-Cover Texts, in the notice that says that
-  the Document is released under this License.  A Front-Cover Text may
-  be at most 5 words, and a Back-Cover Text may be at most 25 words.
-</p>
-
-<p>
-  A "Transparent" copy of the Document means a machine-readable copy,
-  represented in a format whose specification is available to the
-  general public, that is suitable for revising the document
-  straightforwardly with generic text editors or (for images composed of
-  pixels) generic paint programs or (for drawings) some widely available
-  drawing editor, and that is suitable for input to text formatters or
-  for automatic translation to a variety of formats suitable for input
-  to text formatters.  A copy made in an otherwise Transparent file
-  format whose markup, or absence of markup, has been arranged to thwart
-  or discourage subsequent modification by readers is not Transparent.
-  An image format is not Transparent if used for any substantial amount
-  of text.  A copy that is not "Transparent" is called "Opaque".
-</p>
-
-<p>
-  Examples of suitable formats for Transparent copies include plain
-  ASCII without markup, Texinfo input format, LaTeX input format, SGML
-  or XML using a publicly available DTD, and standard-conforming simple
-  HTML, PostScript or PDF designed for human modification.  Examples of
-  transparent image formats include PNG, XCF and JPG.  Opaque formats
-  include proprietary formats that can be read and edited only by
-  proprietary word processors, SGML or XML for which the DTD and/or
-  processing tools are not generally available, and the
-  machine-generated HTML, PostScript or PDF produced by some word
-  processors for output purposes only.
-</p>
-
-<p>
-  The "Title Page" means, for a printed book, the title page itself,
-  plus such following pages as are needed to hold, legibly, the material
-  this License requires to appear in the title page.  For works in
-  formats which do not have any title page as such, "Title Page" means
-  the text near the most prominent appearance of the work's title,
-  preceding the beginning of the body of the text.
-</p>
-
-<p>
-  A section "Entitled XYZ" means a named subunit of the Document whose
-  title either is precisely XYZ or contains XYZ in parentheses following
-  text that translates XYZ in another language.  (Here XYZ stands for a
-  specific section name mentioned below, such as "Acknowledgements",
-  "Dedications", "Endorsements", or "History".)  To "Preserve the Title"
-  of such a section when you modify the Document means that it remains a
-  section "Entitled XYZ" according to this definition.
-</p>
-
-<p>
-  The Document may include Warranty Disclaimers next to the notice which
-  states that this License applies to the Document.  These Warranty
-  Disclaimers are considered to be included by reference in this
-  License, but only as regards disclaiming warranties: any other
-  implication that these Warranty Disclaimers may have is void and has
-  no effect on the meaning of this License.
-</p>
-
-<h4 id="section2">2. VERBATIM COPYING</h4>
-
-<p>
-  You may copy and distribute the Document in any medium, either
-  commercially or noncommercially, provided that this License, the
-  copyright notices, and the license notice saying this License applies
-  to the Document are reproduced in all copies, and that you add no other
-  conditions whatsoever to those of this License.  You may not use
-  technical measures to obstruct or control the reading or further
-  copying of the copies you make or distribute.  However, you may accept
-  compensation in exchange for copies.  If you distribute a large enough
-  number of copies you must also follow the conditions in section 3.
-</p>
-
-<p>
-  You may also lend copies, under the same conditions stated above, and
-  you may publicly display copies.
-</p>
-
-<h4 id="section3">3. COPYING IN QUANTITY</h4>
-
-<p>
-  If you publish printed copies (or copies in media that commonly have
-  printed covers) of the Document, numbering more than 100, and the
-  Document's license notice requires Cover Texts, you must enclose the
-  copies in covers that carry, clearly and legibly, all these Cover
-  Texts: Front-Cover Texts on the front cover, and Back-Cover Texts on
-  the back cover.  Both covers must also clearly and legibly identify
-  you as the publisher of these copies.  The front cover must present
-  the full title with all words of the title equally prominent and
-  visible.  You may add other material on the covers in addition.
-  Copying with changes limited to the covers, as long as they preserve
-  the title of the Document and satisfy these conditions, can be treated
-  as verbatim copying in other respects.
-</p>
-
-<p>
-  If the required texts for either cover are too voluminous to fit
-  legibly, you should put the first ones listed (as many as fit
-  reasonably) on the actual cover, and continue the rest onto adjacent
-  pages.
-</p>
-
-<p>
-  If you publish or distribute Opaque copies of the Document numbering
-  more than 100, you must either include a machine-readable Transparent
-  copy along with each Opaque copy, or state in or with each Opaque copy
-  a computer-network location from which the general network-using
-  public has access to download using public-standard network protocols
-  a complete Transparent copy of the Document, free of added material.
-  If you use the latter option, you must take reasonably prudent steps,
-  when you begin distribution of Opaque copies in quantity, to ensure
-  that this Transparent copy will remain thus accessible at the stated
-  location until at least one year after the last time you distribute an
-  Opaque copy (directly or through your agents or retailers) of that
-  edition to the public.
-</p>
-
-<p>
-  It is requested, but not required, that you contact the authors of the
-  Document well before redistributing any large number of copies, to give
-  them a chance to provide you with an updated version of the Document.
-</p>
-
-<h4 id="section4">4. MODIFICATIONS</h4>
-
-<p>
-  You may copy and distribute a Modified Version of the Document under
-  the conditions of sections 2 and 3 above, provided that you release
-  the Modified Version under precisely this License, with the Modified
-  Version filling the role of the Document, thus licensing distribution
-  and modification of the Modified Version to whoever possesses a copy
-  of it.  In addition, you must do these things in the Modified Version:
-</p>
-
-<ul>
-  <li><strong>A.</strong> Use in the Title Page (and on the covers, if any) a title distinct
-  from that of the Document, and from those of previous versions
-  (which should, if there were any, be listed in the History section
-  of the Document).  You may use the same title as a previous version
-  if the original publisher of that version gives permission.</li>
-  <li><strong>B.</strong> List on the Title Page, as authors, one or more persons or entities
-  responsible for authorship of the modifications in the Modified
-  Version, together with at least five of the principal authors of the
-  Document (all of its principal authors, if it has fewer than five),
-  unless they release you from this requirement.</li>
-  <li><strong>C.</strong> State on the Title page the name of the publisher of the
-  Modified Version, as the publisher.</li>
-  <li><strong>D.</strong> Preserve all the copyright notices of the Document.</li>
-  <li><strong>E.</strong> Add an appropriate copyright notice for your modifications
-  adjacent to the other copyright notices.</li>
-  <li><strong>F.</strong> Include, immediately after the copyright notices, a license notice
-  giving the public permission to use the Modified Version under the
-  terms of this License, in the form shown in the Addendum below.</li>
-  <li><strong>G.</strong> Preserve in that license notice the full lists of Invariant Sections
-  and required Cover Texts given in the Document's license notice.</li>
-  <li><strong>H.</strong> Include an unaltered copy of this License.</li>
-  <li><strong>I.</strong> Preserve the section Entitled "History", Preserve its Title, and add
-  to it an item stating at least the title, year, new authors, and
-  publisher of the Modified Version as given on the Title Page.  If
-  there is no section Entitled "History" in the Document, create one
-  stating the title, year, authors, and publisher of the Document as
-  given on its Title Page, then add an item describing the Modified
-  Version as stated in the previous sentence.</li>
-  <li><strong>J.</strong> Preserve the network location, if any, given in the Document for
-  public access to a Transparent copy of the Document, and likewise
-  the network locations given in the Document for previous versions
-  it was based on.  These may be placed in the "History" section.
-  You may omit a network location for a work that was published at
-  least four years before the Document itself, or if the original
-  publisher of the version it refers to gives permission.</li>
-  <li><strong>K.</strong> For any section Entitled "Acknowledgements" or "Dedications",
-  Preserve the Title of the section, and preserve in the section all
-  the substance and tone of each of the contributor acknowledgements
-  and/or dedications given therein.</li>
-  <li><strong>L.</strong> Preserve all the Invariant Sections of the Document,
-  unaltered in their text and in their titles.  Section numbers
-  or the equivalent are not considered part of the section titles.</li>
-  <li><strong>M.</strong> Delete any section Entitled "Endorsements".  Such a section
-  may not be included in the Modified Version.</li>
-  <li><strong>N.</strong> Do not retitle any existing section to be Entitled "Endorsements"
-  or to conflict in title with any Invariant Section.</li>
-  <li><strong>O.</strong> Preserve any Warranty Disclaimers.</li>
-</ul>
-
-<p>
-  If the Modified Version includes new front-matter sections or
-  appendices that qualify as Secondary Sections and contain no material
-  copied from the Document, you may at your option designate some or all
-  of these sections as invariant.  To do this, add their titles to the
-  list of Invariant Sections in the Modified Version's license notice.
-  These titles must be distinct from any other section titles.
-</p>
-
-<p>
-  You may add a section Entitled "Endorsements", provided it contains
-  nothing but endorsements of your Modified Version by various
-  parties--for example, statements of peer review or that the text has
-  been approved by an organization as the authoritative definition of a
-  standard.
-</p>
-
-<p>
-  You may add a passage of up to five words as a Front-Cover Text, and a
-  passage of up to 25 words as a Back-Cover Text, to the end of the list
-  of Cover Texts in the Modified Version.  Only one passage of
-  Front-Cover Text and one of Back-Cover Text may be added by (or
-  through arrangements made by) any one entity.  If the Document already
-  includes a cover text for the same cover, previously added by you or
-  by arrangement made by the same entity you are acting on behalf of,
-  you may not add another; but you may replace the old one, on explicit
-  permission from the previous publisher that added the old one.
-</p>
-
-<p>
-  The author(s) and publisher(s) of the Document do not by this License
-  give permission to use their names for publicity for or to assert or
-  imply endorsement of any Modified Version.
-</p>
-
-<h4 id="section5">5. COMBINING DOCUMENTS</h4>
-
-<p>
-  You may combine the Document with other documents released under this
-  License, under the terms defined in section 4 above for modified
-  versions, provided that you include in the combination all of the
-  Invariant Sections of all of the original documents, unmodified, and
-  list them all as Invariant Sections of your combined work in its
-  license notice, and that you preserve all their Warranty Disclaimers.
-</p>
-
-<p>
-  The combined work need only contain one copy of this License, and
-  multiple identical Invariant Sections may be replaced with a single
-  copy.  If there are multiple Invariant Sections with the same name but
-  different contents, make the title of each such section unique by
-  adding at the end of it, in parentheses, the name of the original
-  author or publisher of that section if known, or else a unique number.
-  Make the same adjustment to the section titles in the list of
-  Invariant Sections in the license notice of the combined work.
-</p>
-
-<p>
-  In the combination, you must combine any sections Entitled "History"
-  in the various original documents, forming one section Entitled
-  "History"; likewise combine any sections Entitled "Acknowledgements",
-  and any sections Entitled "Dedications".  You must delete all sections
-  Entitled "Endorsements."
-</p>
-
-<h4 id="section6">6. COLLECTIONS OF DOCUMENTS</h4>
-
-<p>
-  You may make a collection consisting of the Document and other documents
-  released under this License, and replace the individual copies of this
-  License in the various documents with a single copy that is included in
-  the collection, provided that you follow the rules of this License for
-  verbatim copying of each of the documents in all other respects.
-</p>
-
-<p>
-  You may extract a single document from such a collection, and distribute
-  it individually under this License, provided you insert a copy of this
-  License into the extracted document, and follow this License in all
-  other respects regarding verbatim copying of that document.
-</p>
-
-<h4 id="section7">7. AGGREGATION WITH INDEPENDENT WORKS</h4>
-
-<p>
-  A compilation of the Document or its derivatives with other separate
-  and independent documents or works, in or on a volume of a storage or
-  distribution medium, is called an "aggregate" if the copyright
-  resulting from the compilation is not used to limit the legal rights
-  of the compilation's users beyond what the individual works permit.
-  When the Document is included in an aggregate, this License does not
-  apply to the other works in the aggregate which are not themselves
-  derivative works of the Document.
-</p>
-
-<p>
-  If the Cover Text requirement of section 3 is applicable to these
-  copies of the Document, then if the Document is less than one half of
-  the entire aggregate, the Document's Cover Texts may be placed on
-  covers that bracket the Document within the aggregate, or the
-  electronic equivalent of covers if the Document is in electronic form.
-  Otherwise they must appear on printed covers that bracket the whole
-  aggregate.
-</p>
-
-<h4 id="section8">8. TRANSLATION</h4>
-
-<p>
-  Translation is considered a kind of modification, so you may
-  distribute translations of the Document under the terms of section 4.
-  Replacing Invariant Sections with translations requires special
-  permission from their copyright holders, but you may include
-  translations of some or all Invariant Sections in addition to the
-  original versions of these Invariant Sections.  You may include a
-  translation of this License, and all the license notices in the
-  Document, and any Warranty Disclaimers, provided that you also include
-  the original English version of this License and the original versions
-  of those notices and disclaimers.  In case of a disagreement between
-  the translation and the original version of this License or a notice
-  or disclaimer, the original version will prevail.
-</p>
-
-<p>
-  If a section in the Document is Entitled "Acknowledgements",
-  "Dedications", or "History", the requirement (section 4) to Preserve
-  its Title (section 1) will typically require changing the actual
-  title.
-</p>
-
-<h4 id="section9">9. TERMINATION</h4>
-
-<p>
-  You may not copy, modify, sublicense, or distribute the Document except
-  as expressly provided for under this License.  Any other attempt to
-  copy, modify, sublicense or distribute the Document is void, and will
-  automatically terminate your rights under this License.  However,
-  parties who have received copies, or rights, from you under this
-  License will not have their licenses terminated so long as such
-  parties remain in full compliance.
-</p>
-
-<h4 id="section10">10. FUTURE REVISIONS OF THIS LICENSE</h4>
-
-<p>
-  The Free Software Foundation may publish new, revised versions
-  of the GNU Free Documentation License from time to time.  Such new
-  versions will be similar in spirit to the present version, but may
-  differ in detail to address new problems or concerns.  See
-  https://www.gnu.org/licenses/.
-</p>
-
-<p>
-  Each version of the License is given a distinguishing version number.
-  If the Document specifies that a particular numbered version of this
-  License "or any later version" applies to it, you have the option of
-  following the terms and conditions either of that specified version or
-  of any later version that has been published (not as a draft) by the
-  Free Software Foundation.  If the Document does not specify a version
-  number of this License, you may choose any version ever published (not
-  as a draft) by the Free Software Foundation.
-</p>
-
-<h4 id="SEC4">How to use this License for your documents</h4>
-
-<p>
-  To use this License in a document you have written, include a copy of
-  the License in the document and put the following copyright and
-  license notices just after the title page:
-</p>
-
-<pre>
-  Copyright (c)  YEAR  YOUR NAME.
-  Permission is granted to copy, distribute and/or modify this document
-  under the terms of the GNU Free Documentation License, Version 1.2
-  or any later version published by the Free Software Foundation;
-  with no Invariant Sections, no Front-Cover Texts, and no Back-Cover
-  Texts.  A copy of the license is included in the section entitled "GNU
-  Free Documentation License".
-</pre>
-
-<p>
-  If you have Invariant Sections, Front-Cover Texts and Back-Cover Texts,
-  replace the "with...Texts." line with this:
-</p>
-
-<pre>
-  with the Invariant Sections being LIST THEIR TITLES, with the
-  Front-Cover Texts being LIST, and with the Back-Cover Texts being LIST.
-</pre>
-
-<p>
-  If you have Invariant Sections without Cover Texts, or some other
-  combination of the three, merge those two alternatives to suit the
-  situation.
-</p>
-
-<p>
-  If your document contains nontrivial examples of program code, we
-  recommend releasing these examples in parallel under your choice of
-  free software license, such as the GNU General Public License,
-  to permit their use in free software.
-</p>
-
-</div>
-</div>
-
-</div><!-- for id="content", starts in the include above -->
-
-              <!-- begin server/footer-text.html -->
-
-
-
-
-
-<div style="clear:both"></div>
-
-
-<div id="language-container">
- <div class="backtotop">
-  <hr class="no-display" />
-  <a href="#top"><b>&#9650;</b></a>
- </div>
- <div id="languages" class="rounded-corners">
-  <div class="button">
-   <a href="#top" class="close"><span>BACK TO TOP</span></a>
-  </div>
-  <div id="set-language" class="button">
-   <span class="gnun-split"></span>
-   <a href="/server/select-language.html?callback=/licenses/old-licenses/fdl-1.2" rel="nofollow">
-   Set language
-   <span class="gnun-split"></span>
-   </a>
-  </div>
-  <p>Available for this page:</p>
-  <div id="translations">
-<p>
-<span dir="ltr" class="original">[en]&nbsp;<a lang="en" hreflang="en" href="/licenses/old-licenses/fdl-1.2.en.html">English</a> &nbsp;</span>
-<span dir="ltr">[de]&nbsp;<a lang="de" hreflang="de" href="/licenses/old-licenses/fdl-1.2.de.html">Deutsch</a> &nbsp;</span>
-<span dir="ltr">[fr]&nbsp;<a lang="fr" hreflang="fr" href="/licenses/old-licenses/fdl-1.2.fr.html">français</a> &nbsp;</span>
-<span dir="ltr">[ja]&nbsp;<a lang="ja" hreflang="ja" href="/licenses/old-licenses/fdl-1.2.ja.html">日本語</a> &nbsp;</span>
-<span dir="ltr">[pt-br]&nbsp;<a lang="pt-br" hreflang="pt-br" href="/licenses/old-licenses/fdl-1.2.pt-br.html">português</a> &nbsp;</span>
-<span dir="ltr">[ru]&nbsp;<a lang="ru" hreflang="ru" href="/licenses/old-licenses/fdl-1.2.ru.html">русский</a> &nbsp;</span>
-<span dir="ltr">[uk]&nbsp;<a lang="uk" hreflang="uk" href="/licenses/old-licenses/fdl-1.2.uk.html">українська</a> &nbsp;</span>
-<span dir="ltr">[zh-cn]&nbsp;<a lang="zh-cn" hreflang="zh-cn" href="/licenses/old-licenses/fdl-1.2.zh-cn.html">简体中文</a> &nbsp;</span>
-</p>
-</div>
- </div>
-</div>
-
-<div id="mission-statement" role="complementary">
- <div class="backtotop">
-  <hr class="no-display" />
-  <a href="#header"><span>BACK TO TOP </span>&#9650;</a>
- </div>
-<div style="clear: both"></div>
-<blockquote>
-<p style="direction:ltr; text-align:left"><a href="//www.fsf.org"><img id="fsfbanner"
-src="/graphics/fsf-logo-notext-small.png" alt="&nbsp;[FSF logo]&nbsp;"
-width="75" height="25" /></a><strong>
-&ldquo;The Free Software Foundation (FSF) is a nonprofit with a worldwide
-mission to promote computer user freedom. We defend the rights of all
-software users.&rdquo;</strong></p>
-</blockquote>
-
-<div id="support-the-fsf" class="button">
- <a class="join" href="//www.fsf.org/associate/support_freedom?referrer=4052">JOIN</a>
- <a class="donate" href="//donate.fsf.org/">DONATE</a>
- <a class="shop" href="//shop.fsf.org/">SHOP</a>
-</div>
-</div>
-<!-- end server/footer-text.html -->
-
-
-<div id="footer" role="contentinfo">
-<div class="unprintable">
-
-<p>Please send general FSF &amp; GNU inquiries to
-<a href="mailto:gnu@gnu.org">&lt;gnu@gnu.org&gt;</a>.
-There are also <a href="/contact/">other ways to contact</a>
-the FSF.  Broken links and other corrections or suggestions can be sent
-to <a href="mailto:webmasters@gnu.org">&lt;webmasters@gnu.org&gt;</a>.</p>
-
-<p><!-- TRANSLATORS: Ignore the original text in this paragraph,
-        replace it with the translation of these two:
-
-        We work hard and do our best to provide accurate, good quality
-        translations.  However, we are not exempt from imperfection.
-        Please send your comments and general suggestions in this regard
-        to <a href="mailto:web-translators@gnu.org">
-        &lt;web-translators@gnu.org&gt;</a>.</p>
-
-        <p>For information on coordinating and contributing translations of
-        our web pages, see <a
-        href="/server/standards/README.translations.html">Translations
-        README</a>. -->
-Please see the <a
-href="/server/standards/README.translations.html">Translations README</a> for
-information on coordinating and contributing translations of this article.</p>
-</div>
-
-<p>Copyright notice above.</p>
-
-<p>
-Verbatim copying and distribution of this entire article is
-permitted in any medium without royalty provided this notice is 
-preserved.
-</p>
-
-<!-- start of server/bottom-notes.html -->
-<div id="bottom-notes" class="unprintable">
-<p><a href="//www.fsf.org/about/dmca-notice">Copyright Infringement Notification</a></p>
-<div id="generic">
-
-
-</div>
-</div>
-<!-- end of server/bottom-notes.html -->
-
-
-<p class="unprintable">Updated:
-<!-- timestamp start -->
-$Date: 2023/11/30 09:46:01 $
-<!-- timestamp end -->
-</p>
-</div>
-</div><!-- for class="inner", starts in the banner include -->
-</body>
-</html>
+                GNU Free Documentation License
+                  Version 1.2, November 2002
+
+
+ Copyright (C) 2000,2001,2002  Free Software Foundation, Inc.
+     <https://fsf.org/>
+ Everyone is permitted to copy and distribute verbatim copies
+ of this license document, but changing it is not allowed.
+
+
+0. PREAMBLE
+
+The purpose of this License is to make a manual, textbook, or other
+functional and useful document "free" in the sense of freedom: to
+assure everyone the effective freedom to copy and redistribute it,
+with or without modifying it, either commercially or noncommercially.
+Secondarily, this License preserves for the author and publisher a way
+to get credit for their work, while not being considered responsible
+for modifications made by others.
+
+This License is a kind of "copyleft", which means that derivative
+works of the document must themselves be free in the same sense.  It
+complements the GNU General Public License, which is a copyleft
+license designed for free software.
+
+We have designed this License in order to use it for manuals for free
+software, because free software needs free documentation: a free
+program should come with manuals providing the same freedoms that the
+software does.  But this License is not limited to software manuals;
+it can be used for any textual work, regardless of subject matter or
+whether it is published as a printed book.  We recommend this License
+principally for works whose purpose is instruction or reference.
+
+
+1. APPLICABILITY AND DEFINITIONS
+
+This License applies to any manual or other work, in any medium, that
+contains a notice placed by the copyright holder saying it can be
+distributed under the terms of this License.  Such a notice grants a
+world-wide, royalty-free license, unlimited in duration, to use that
+work under the conditions stated herein.  The "Document", below,
+refers to any such manual or work.  Any member of the public is a
+licensee, and is addressed as "you".  You accept the license if you
+copy, modify or distribute the work in a way requiring permission
+under copyright law.
+
+A "Modified Version" of the Document means any work containing the
+Document or a portion of it, either copied verbatim, or with
+modifications and/or translated into another language.
+
+A "Secondary Section" is a named appendix or a front-matter section of
+the Document that deals exclusively with the relationship of the
+publishers or authors of the Document to the Document's overall subject
+(or to related matters) and contains nothing that could fall directly
+within that overall subject.  (Thus, if the Document is in part a
+textbook of mathematics, a Secondary Section may not explain any
+mathematics.)  The relationship could be a matter of historical
+connection with the subject or with related matters, or of legal,
+commercial, philosophical, ethical or political position regarding
+them.
+
+The "Invariant Sections" are certain Secondary Sections whose titles
+are designated, as being those of Invariant Sections, in the notice
+that says that the Document is released under this License.  If a
+section does not fit the above definition of Secondary then it is not
+allowed to be designated as Invariant.  The Document may contain zero
+Invariant Sections.  If the Document does not identify any Invariant
+Sections then there are none.
+
+The "Cover Texts" are certain short passages of text that are listed,
+as Front-Cover Texts or Back-Cover Texts, in the notice that says that
+the Document is released under this License.  A Front-Cover Text may
+be at most 5 words, and a Back-Cover Text may be at most 25 words.
+
+A "Transparent" copy of the Document means a machine-readable copy,
+represented in a format whose specification is available to the
+general public, that is suitable for revising the document
+straightforwardly with generic text editors or (for images composed of
+pixels) generic paint programs or (for drawings) some widely available
+drawing editor, and that is suitable for input to text formatters or
+for automatic translation to a variety of formats suitable for input
+to text formatters.  A copy made in an otherwise Transparent file
+format whose markup, or absence of markup, has been arranged to thwart
+or discourage subsequent modification by readers is not Transparent.
+An image format is not Transparent if used for any substantial amount
+of text.  A copy that is not "Transparent" is called "Opaque".
+
+Examples of suitable formats for Transparent copies include plain
+ASCII without markup, Texinfo input format, LaTeX input format, SGML
+or XML using a publicly available DTD, and standard-conforming simple
+HTML, PostScript or PDF designed for human modification.  Examples of
+transparent image formats include PNG, XCF and JPG.  Opaque formats
+include proprietary formats that can be read and edited only by
+proprietary word processors, SGML or XML for which the DTD and/or
+processing tools are not generally available, and the
+machine-generated HTML, PostScript or PDF produced by some word
+processors for output purposes only.
+
+The "Title Page" means, for a printed book, the title page itself,
+plus such following pages as are needed to hold, legibly, the material
+this License requires to appear in the title page.  For works in
+formats which do not have any title page as such, "Title Page" means
+the text near the most prominent appearance of the work's title,
+preceding the beginning of the body of the text.
+
+A section "Entitled XYZ" means a named subunit of the Document whose
+title either is precisely XYZ or contains XYZ in parentheses following
+text that translates XYZ in another language.  (Here XYZ stands for a
+specific section name mentioned below, such as "Acknowledgements",
+"Dedications", "Endorsements", or "History".)  To "Preserve the Title"
+of such a section when you modify the Document means that it remains a
+section "Entitled XYZ" according to this definition.
+
+The Document may include Warranty Disclaimers next to the notice which
+states that this License applies to the Document.  These Warranty
+Disclaimers are considered to be included by reference in this
+License, but only as regards disclaiming warranties: any other
+implication that these Warranty Disclaimers may have is void and has
+no effect on the meaning of this License.
+
+
+2. VERBATIM COPYING
+
+You may copy and distribute the Document in any medium, either
+commercially or noncommercially, provided that this License, the
+copyright notices, and the license notice saying this License applies
+to the Document are reproduced in all copies, and that you add no other
+conditions whatsoever to those of this License.  You may not use
+technical measures to obstruct or control the reading or further
+copying of the copies you make or distribute.  However, you may accept
+compensation in exchange for copies.  If you distribute a large enough
+number of copies you must also follow the conditions in section 3.
+
+You may also lend copies, under the same conditions stated above, and
+you may publicly display copies.
+
+
+3. COPYING IN QUANTITY
+
+If you publish printed copies (or copies in media that commonly have
+printed covers) of the Document, numbering more than 100, and the
+Document's license notice requires Cover Texts, you must enclose the
+copies in covers that carry, clearly and legibly, all these Cover
+Texts: Front-Cover Texts on the front cover, and Back-Cover Texts on
+the back cover.  Both covers must also clearly and legibly identify
+you as the publisher of these copies.  The front cover must present
+the full title with all words of the title equally prominent and
+visible.  You may add other material on the covers in addition.
+Copying with changes limited to the covers, as long as they preserve
+the title of the Document and satisfy these conditions, can be treated
+as verbatim copying in other respects.
+
+If the required texts for either cover are too voluminous to fit
+legibly, you should put the first ones listed (as many as fit
+reasonably) on the actual cover, and continue the rest onto adjacent
+pages.
+
+If you publish or distribute Opaque copies of the Document numbering
+more than 100, you must either include a machine-readable Transparent
+copy along with each Opaque copy, or state in or with each Opaque copy
+a computer-network location from which the general network-using
+public has access to download using public-standard network protocols
+a complete Transparent copy of the Document, free of added material.
+If you use the latter option, you must take reasonably prudent steps,
+when you begin distribution of Opaque copies in quantity, to ensure
+that this Transparent copy will remain thus accessible at the stated
+location until at least one year after the last time you distribute an
+Opaque copy (directly or through your agents or retailers) of that
+edition to the public.
+
+It is requested, but not required, that you contact the authors of the
+Document well before redistributing any large number of copies, to give
+them a chance to provide you with an updated version of the Document.
+
+
+4. MODIFICATIONS
+
+You may copy and distribute a Modified Version of the Document under
+the conditions of sections 2 and 3 above, provided that you release
+the Modified Version under precisely this License, with the Modified
+Version filling the role of the Document, thus licensing distribution
+and modification of the Modified Version to whoever possesses a copy
+of it.  In addition, you must do these things in the Modified Version:
+
+A. Use in the Title Page (and on the covers, if any) a title distinct
+   from that of the Document, and from those of previous versions
+   (which should, if there were any, be listed in the History section
+   of the Document).  You may use the same title as a previous version
+   if the original publisher of that version gives permission.
+B. List on the Title Page, as authors, one or more persons or entities
+   responsible for authorship of the modifications in the Modified
+   Version, together with at least five of the principal authors of the
+   Document (all of its principal authors, if it has fewer than five),
+   unless they release you from this requirement.
+C. State on the Title page the name of the publisher of the
+   Modified Version, as the publisher.
+D. Preserve all the copyright notices of the Document.
+E. Add an appropriate copyright notice for your modifications
+   adjacent to the other copyright notices.
+F. Include, immediately after the copyright notices, a license notice
+   giving the public permission to use the Modified Version under the
+   terms of this License, in the form shown in the Addendum below.
+G. Preserve in that license notice the full lists of Invariant Sections
+   and required Cover Texts given in the Document's license notice.
+H. Include an unaltered copy of this License.
+I. Preserve the section Entitled "History", Preserve its Title, and add
+   to it an item stating at least the title, year, new authors, and
+   publisher of the Modified Version as given on the Title Page.  If
+   there is no section Entitled "History" in the Document, create one
+   stating the title, year, authors, and publisher of the Document as
+   given on its Title Page, then add an item describing the Modified
+   Version as stated in the previous sentence.
+J. Preserve the network location, if any, given in the Document for
+   public access to a Transparent copy of the Document, and likewise
+   the network locations given in the Document for previous versions
+   it was based on.  These may be placed in the "History" section.
+   You may omit a network location for a work that was published at
+   least four years before the Document itself, or if the original
+   publisher of the version it refers to gives permission.
+K. For any section Entitled "Acknowledgements" or "Dedications",
+   Preserve the Title of the section, and preserve in the section all
+   the substance and tone of each of the contributor acknowledgements
+   and/or dedications given therein.
+L. Preserve all the Invariant Sections of the Document,
+   unaltered in their text and in their titles.  Section numbers
+   or the equivalent are not considered part of the section titles.
+M. Delete any section Entitled "Endorsements".  Such a section
+   may not be included in the Modified Version.
+N. Do not retitle any existing section to be Entitled "Endorsements"
+   or to conflict in title with any Invariant Section.
+O. Preserve any Warranty Disclaimers.
+
+If the Modified Version includes new front-matter sections or
+appendices that qualify as Secondary Sections and contain no material
+copied from the Document, you may at your option designate some or all
+of these sections as invariant.  To do this, add their titles to the
+list of Invariant Sections in the Modified Version's license notice.
+These titles must be distinct from any other section titles.
+
+You may add a section Entitled "Endorsements", provided it contains
+nothing but endorsements of your Modified Version by various
+parties--for example, statements of peer review or that the text has
+been approved by an organization as the authoritative definition of a
+standard.
+
+You may add a passage of up to five words as a Front-Cover Text, and a
+passage of up to 25 words as a Back-Cover Text, to the end of the list
+of Cover Texts in the Modified Version.  Only one passage of
+Front-Cover Text and one of Back-Cover Text may be added by (or
+through arrangements made by) any one entity.  If the Document already
+includes a cover text for the same cover, previously added by you or
+by arrangement made by the same entity you are acting on behalf of,
+you may not add another; but you may replace the old one, on explicit
+permission from the previous publisher that added the old one.
+
+The author(s) and publisher(s) of the Document do not by this License
+give permission to use their names for publicity for or to assert or
+imply endorsement of any Modified Version.
+
+
+5. COMBINING DOCUMENTS
+
+You may combine the Document with other documents released under this
+License, under the terms defined in section 4 above for modified
+versions, provided that you include in the combination all of the
+Invariant Sections of all of the original documents, unmodified, and
+list them all as Invariant Sections of your combined work in its
+license notice, and that you preserve all their Warranty Disclaimers.
+
+The combined work need only contain one copy of this License, and
+multiple identical Invariant Sections may be replaced with a single
+copy.  If there are multiple Invariant Sections with the same name but
+different contents, make the title of each such section unique by
+adding at the end of it, in parentheses, the name of the original
+author or publisher of that section if known, or else a unique number.
+Make the same adjustment to the section titles in the list of
+Invariant Sections in the license notice of the combined work.
+
+In the combination, you must combine any sections Entitled "History"
+in the various original documents, forming one section Entitled
+"History"; likewise combine any sections Entitled "Acknowledgements",
+and any sections Entitled "Dedications".  You must delete all sections
+Entitled "Endorsements".
+
+
+6. COLLECTIONS OF DOCUMENTS
+
+You may make a collection consisting of the Document and other documents
+released under this License, and replace the individual copies of this
+License in the various documents with a single copy that is included in
+the collection, provided that you follow the rules of this License for
+verbatim copying of each of the documents in all other respects.
+
+You may extract a single document from such a collection, and distribute
+it individually under this License, provided you insert a copy of this
+License into the extracted document, and follow this License in all
+other respects regarding verbatim copying of that document.
+
+
+7. AGGREGATION WITH INDEPENDENT WORKS
+
+A compilation of the Document or its derivatives with other separate
+and independent documents or works, in or on a volume of a storage or
+distribution medium, is called an "aggregate" if the copyright
+resulting from the compilation is not used to limit the legal rights
+of the compilation's users beyond what the individual works permit.
+When the Document is included in an aggregate, this License does not
+apply to the other works in the aggregate which are not themselves
+derivative works of the Document.
+
+If the Cover Text requirement of section 3 is applicable to these
+copies of the Document, then if the Document is less than one half of
+the entire aggregate, the Document's Cover Texts may be placed on
+covers that bracket the Document within the aggregate, or the
+electronic equivalent of covers if the Document is in electronic form.
+Otherwise they must appear on printed covers that bracket the whole
+aggregate.
+
+
+8. TRANSLATION
+
+Translation is considered a kind of modification, so you may
+distribute translations of the Document under the terms of section 4.
+Replacing Invariant Sections with translations requires special
+permission from their copyright holders, but you may include
+translations of some or all Invariant Sections in addition to the
+original versions of these Invariant Sections.  You may include a
+translation of this License, and all the license notices in the
+Document, and any Warranty Disclaimers, provided that you also include
+the original English version of this License and the original versions
+of those notices and disclaimers.  In case of a disagreement between
+the translation and the original version of this License or a notice
+or disclaimer, the original version will prevail.
+
+If a section in the Document is Entitled "Acknowledgements",
+"Dedications", or "History", the requirement (section 4) to Preserve
+its Title (section 1) will typically require changing the actual
+title.
+
+
+9. TERMINATION
+
+You may not copy, modify, sublicense, or distribute the Document except
+as expressly provided for under this License.  Any other attempt to
+copy, modify, sublicense or distribute the Document is void, and will
+automatically terminate your rights under this License.  However,
+parties who have received copies, or rights, from you under this
+License will not have their licenses terminated so long as such
+parties remain in full compliance.
+
+
+10. FUTURE REVISIONS OF THIS LICENSE
+
+The Free Software Foundation may publish new, revised versions
+of the GNU Free Documentation License from time to time.  Such new
+versions will be similar in spirit to the present version, but may
+differ in detail to address new problems or concerns.  See
+https://www.gnu.org/licenses/.
+
+Each version of the License is given a distinguishing version number.
+If the Document specifies that a particular numbered version of this
+License "or any later version" applies to it, you have the option of
+following the terms and conditions either of that specified version or
+of any later version that has been published (not as a draft) by the
+Free Software Foundation.  If the Document does not specify a version
+number of this License, you may choose any version ever published (not
+as a draft) by the Free Software Foundation.
+
+
+ADDENDUM: How to use this License for your documents
+
+To use this License in a document you have written, include a copy of
+the License in the document and put the following copyright and
+license notices just after the title page:
+
+    Copyright (c)  YEAR  YOUR NAME.
+    Permission is granted to copy, distribute and/or modify this document
+    under the terms of the GNU Free Documentation License, Version 1.2
+    or any later version published by the Free Software Foundation;
+    with no Invariant Sections, no Front-Cover Texts, and no Back-Cover Texts.
+    A copy of the license is included in the section entitled "GNU
+    Free Documentation License".
+
+If you have Invariant Sections, Front-Cover Texts and Back-Cover Texts,
+replace the "with...Texts." line with this:
+
+    with the Invariant Sections being LIST THEIR TITLES, with the
+    Front-Cover Texts being LIST, and with the Back-Cover Texts being LIST.
+
+If you have Invariant Sections without Cover Texts, or some other
+combination of the three, merge those two alternatives to suit the
+situation.
+
+If your document contains nontrivial examples of program code, we
+recommend releasing these examples in parallel under your choice of
+free software license, such as the GNU General Public License,
+to permit their use in free software.

--- a/licenses-generator/src/main/resources/offline-license-mirror/www.gnu.org/licenses/old-licenses/gpl-1.0
+++ b/licenses-generator/src/main/resources/offline-license-mirror/www.gnu.org/licenses/old-licenses/gpl-1.0
@@ -1,199 +1,10 @@
-<!DOCTYPE html>
-<html xmlns="http://www.w3.org/1999/xhtml" xml:lang="en" lang="en">
-<head>
-<meta http-equiv="content-type" content="text/html; charset=utf-8" />
-<link rel="author" href="mailto:webmasters@gnu.org" />
-<link rel="icon" type="image/png" href="/graphics/gnu-head-mini.png" />
-<meta name="ICBM" content="42.355469,-71.058627" />
-<link rel="stylesheet" type="text/css" href="/layout.min.css" media="screen" />
-<link rel="stylesheet" type="text/css" href="/print.min.css" media="print" />
 
-
-
-<!-- Parent-Version: 1.98 -->
-<!-- This page is derived from /server/standards/boilerplate.html -->
-<title>GNU General Public License v1.0 - GNU Project - Free Software Foundation</title>
-<!-- begin translist file -->
-
-<link rel="alternate" type="text/html" href="/licenses/old-licenses/gpl-1.0.html" hreflang="x-default" />
-<link rel="alternate" type="text/html" lang="en" hreflang="en" href="/licenses/old-licenses/gpl-1.0.en.html" title="English" />
-<link rel="alternate" type="text/html" lang="de" hreflang="de" href="/licenses/old-licenses/gpl-1.0.de.html" title="Deutsch" />
-<link rel="alternate" type="text/html" lang="fr" hreflang="fr" href="/licenses/old-licenses/gpl-1.0.fr.html" title="français" />
-<link rel="alternate" type="text/html" lang="ja" hreflang="ja" href="/licenses/old-licenses/gpl-1.0.ja.html" title="日本語" />
-<link rel="alternate" type="text/html" lang="pt-br" hreflang="pt-br" href="/licenses/old-licenses/gpl-1.0.pt-br.html" title="português" />
-<link rel="alternate" type="text/html" lang="ru" hreflang="ru" href="/licenses/old-licenses/gpl-1.0.ru.html" title="русский" />
-<link rel="alternate" type="text/html" lang="uk" hreflang="uk" href="/licenses/old-licenses/gpl-1.0.uk.html" title="українська" />
-<link rel="alternate" type="text/html" lang="zh-cn" hreflang="zh-cn" href="/licenses/old-licenses/gpl-1.0.zh-cn.html" title="简体中文" />
-<!-- end translist file -->
-
-<!-- start of server/banner.html -->
-<!-- start of head-include-2.html -->
-<meta name="viewport" content="width=device-width, initial-scale=1" />
-<!-- end of head-include-2.html -->
-
-</head>
-<body>
-<div class="inner">
-<!-- start of server/body-include-1.html -->
-<div id="top">
-<a class="skip" href="#content"><b>Skip to main text</b></a>
-</div>
-
-<div id="fsf-frame" role="complementary">
-<form id="fssbox" action="https://my.fsf.org/civicrm/profile/create?reset=1&amp;gid=31"
-      method="post">
- <div>
-  <input name="postURL" type="hidden" value="" />
-  <input type="hidden" name="group[25]" value="1" />
-  <input name="cancelURL" type="hidden" value="https://crm.fsf.org/civicrm/profile?reset=1&amp;gid=31" />
-  <input name="_qf_default" type="hidden" value="Edit:cancel" />
-  <label for="frmEmail">
-   <a href="//www.fsf.org/fss">Free Software Supporter</a>:
-  </label>
-  <input type="text" id="frmEmail" name="email-Primary" size="18" maxlength="80"
-         value="email address" onfocus="this.value=''"/>
-  <input type="submit" name="_qf_Edit_next" value="Sign up" />
- </div>
-</form>
-
-<div id="join-fsf" class="button"><a
-href="https://www.fsf.org/associate/support_freedom?referrer=4052">JOIN&nbsp;THE&nbsp;FSF</a>
-</div>
-</div>
-
-<div id="header" role="banner">
-<p id="gnu-banner">
- <a href="/">
- <img src="/graphics/heckert_gnu.transp.small.png" height="48" width="49"
-      alt="&nbsp;[A GNU head]&nbsp;" /><strong>GNU</strong> <span
- class="hide">Operating System</span></a><br />
- <small id="fsf-support">Supported by the
- <a href="#mission-statement">Free Software Foundation</a></small>
-</p>
-
-<div id="switches">
-<!-- begin search button -->
- <div  id="search-button" class="switch">
-  <a href="//www.gnu.org/cgi-bin/estseek.cgi">
-  <img id="search-icon" height="30" width="30"
-       src="/graphics/icons/search.png"
-       alt="&nbsp;[Search www.gnu.org]&nbsp;" /></a>
- </div>
-<!-- end search button -->
-
- <div id="language-button" class="switch">
-  <a href="#language-container">
-  <img id="language-icon" height="30" width="37"
-       src="/graphics/icons/translations.png"
-       alt="&nbsp;[Other languages]&nbsp;" /></a>
- </div>
-
-</div>
-</div>
-<!-- end of server/body-include-1.html -->
-
-<!-- start of server/body-include-2 -->
-
-
-<div style="clear: both"></div>
-
-<div id="navigation" role="navigation">
- <a id="more-links" href="#navigation" title="More...">
-   <span>Site navigation</span></a>
- <a id="less-links" href="#content"><b>Skip</b></a>
- <ul>
-
-   <li id="tabAboutGNU"><a href="/gnu/gnu.html">ABOUT&nbsp;GNU</a></li>
-
-
-  <li id="tabPhilosophy"><a href="/philosophy/philosophy.html">PHILOSOPHY</a></li>
-
-
-  <li id="tabLicenses" class="active">
-     <span class='no-display'>=</span> 
-    <a href="/licenses/licenses.html">LICENSES</a>
-    <span class="gnun-split"></span>
-     <span class='no-display'>=</span> 
-  </li>
-
-
-  <li id="tabEducation"><a href="/education/education.html">EDUCATION</a></li>
-
-
-  <li id="tabSoftware"><a href="/software/software.html">SOFTWARE</a></li>
-
-
-  <li id="tabDistros"><a href="/distros/distros.html">DISTROS</a></li>
-
-
-  <li id="tabDoc"><a href="/doc/doc.html">DOCS</a></li>
-
-
-  <li id="tabMalware"><a href="/proprietary/proprietary.html">MALWARE</a></li>
-
-
-  <li id="tabHelp"><a href="/help/help.html">HELP&nbsp;GNU</a></li>
-
-
-  <li id="tabAV"><a href="/audio-video/audio-video.html">AUDIO&nbsp;&amp;&nbsp;VIDEO</a></li>
-
-
-  <li id="tabArt"><a href="/graphics/graphics.html">GNU&nbsp;ART</a></li>
-
-
-  <li id="tabFun"><a href="/fun/humor.html">FUN</a></li>
-
-
-  <li id="tabPeople"><a href="/people/people.html">GNU'S&nbsp;WHO?</a></li>
-
-  <li><a href="//directory.fsf.org">SOFTWARE&nbsp;DIRECTORY</a></li>
-  <li><a href="https://h-node.org/">HARDWARE</a></li>
-  <li><a href="/server/sitemap.html">SITEMAP</a></li>
- </ul>
- <div style="clear: both"></div>
-</div><!-- /"navigation -->
-<!-- end of server/body-include-2 -->
-
-<div id="content" role="main">
-<!-- end of server/banner.html -->
-
-<div class="reduced-width">
-<h2>GNU General Public License, version&nbsp;1</h2>
-
-<p class="button" style="margin: 2em 1.5em">
-  <b><a href="#license-text">Skip to license text</a></b></p>
-
-<ul>
-  <li><a href="/licenses/gpl.html">The latest version of the GPL,
-      version 3</a></li>
-  <li><a href="/licenses/gpl-violation.html">What to do if you see a
-       possible GPL violation</a></li>
-  <li>The GNU General Public License version 1 (GPLv1) in other formats:
-       <a href="/licenses/old-licenses/gpl-1.0.txt">plain text format</a>,
-       <a href="/licenses/old-licenses/gpl-1.0-standalone.html">standalone HTML</a>,
-       <a href="/licenses/old-licenses/gpl-1.0.md">Markdown</a>, 
-       <a href="/licenses/old-licenses/gpl-1.0.odt">ODF</a>, 
-       <a href="/licenses/old-licenses/gpl-1.0.rtf">RTF</a>, 
-       <a href="/licenses/old-licenses/gpl-1.0.dbk">Docbook</a>, 
-       <a href="/licenses/old-licenses/gpl-1.0.tex">LaTeX</a>, 
-       <a href="/licenses/old-licenses/gpl-1.0.texi">Texinfo</a>
-  </li>
-  <li><a href="/licenses/old-licenses/old-licenses.html#GPL">Old versions
-      of the GPL</a></li>
-</ul>
-
-<hr class="thin" />
-
-<!-- The license text is in English and appears broken in RTL as
-     Arabic, Farsi, etc.  Explicitly set the direction to override the
-     one defined in the translation. -->
-<div id="license-text" dir="ltr">
-<pre>
                     GNU GENERAL PUBLIC LICENSE
                      Version 1, February 1989
 
  Copyright (C) 1989 Free Software Foundation, Inc.
- &lt;<a href="https://fsf.org/">https://fsf.org/</a>&gt;
+                    <https://fsf.org/>
+
  Everyone is permitted to copy and distribute verbatim copies
  of this license document, but changing it is not allowed.
 
@@ -237,7 +48,7 @@ authors' reputations.
 
   The precise terms and conditions for copying, distribution and
 modification follow.
-
+
                     GNU GENERAL PUBLIC LICENSE
    TERMS AND CONDITIONS FOR COPYING, DISTRIBUTION AND MODIFICATION
 
@@ -288,7 +99,7 @@ it, and copy and distribute such modifications under the terms of Paragraph
 Mere aggregation of another independent work with the Program (or its
 derivative) on a volume of a storage or distribution medium does not bring
 the other work under the scope of these terms.
-
+
   3. You may copy and distribute the Program (or a portion or derivative of
 it, under Paragraph 2) in object code or executable form under the terms of
 Paragraphs 1 and 2 above provided that you also do one of the following:
@@ -334,7 +145,7 @@ Program), the recipient automatically receives a license from the original
 licensor to copy, distribute or modify the Program subject to these
 terms and conditions.  You may not impose any further restrictions on the
 recipients' exercise of the rights granted herein.
-
+
   7. The Free Software Foundation may publish revised and/or new versions
 of the General Public License from time to time.  Such new versions will
 be similar in spirit to the present version, but may differ in detail to
@@ -379,7 +190,7 @@ PROGRAMS), EVEN IF SUCH HOLDER OR OTHER PARTY HAS BEEN ADVISED OF THE
 POSSIBILITY OF SUCH DAMAGES.
 
                      END OF TERMS AND CONDITIONS
-
+
         Appendix: How to Apply These Terms to Your New Programs
 
   If you develop a new program, and you want it to be of the greatest
@@ -392,8 +203,8 @@ attach them to the start of each source file to most effectively convey
 the exclusion of warranty; and each file should have at least the
 "copyright" line and a pointer to where the full notice is found.
 
-    &lt;one line to give the program's name and a brief idea of what it does.&gt;
-    Copyright (C) 19yy  &lt;name of author&gt;
+    <one line to give the program's name and a brief idea of what it does.>
+    Copyright (C) 19yy  <name of author>
 
     This program is free software; you can redistribute it and/or modify
     it under the terms of the GNU General Public License as published by
@@ -406,8 +217,8 @@ the exclusion of warranty; and each file should have at least the
     GNU General Public License for more details.
 
     You should have received a copy of the GNU General Public License
-    along with this program; if not, see
-    &lt;<a href="https://www.gnu.org/licenses/">https://www.gnu.org/licenses/</a>&gt;.
+    along with this program; if not, see <https://www.gnu.org/licenses/>.
+
 
 Also add information on how to contact you by electronic and paper mail.
 
@@ -433,129 +244,7 @@ necessary.  Here a sample; alter the names:
   program `Gnomovision' (a program to direct compilers to make passes
   at assemblers) written by James Hacker.
 
-  &lt;signature of Moe Ghoul&gt;, 1 April 1989
+  <signature of Moe Ghoul>, 1 April 1989
   Moe Ghoul, President of Vice
 
 That's all there is to it!
-</pre>
-
-</div>
-</div>
-
-</div><!-- for id="content", starts in the include above -->
-
-              <!-- begin server/footer-text.html -->
-
-
-
-
-
-<div style="clear:both"></div>
-
-
-<div id="language-container">
- <div class="backtotop">
-  <hr class="no-display" />
-  <a href="#top"><b>&#9650;</b></a>
- </div>
- <div id="languages" class="rounded-corners">
-  <div class="button">
-   <a href="#top" class="close"><span>BACK TO TOP</span></a>
-  </div>
-  <div id="set-language" class="button">
-   <span class="gnun-split"></span>
-   <a href="/server/select-language.html?callback=/licenses/old-licenses/gpl-1.0" rel="nofollow">
-   Set language
-   <span class="gnun-split"></span>
-   </a>
-  </div>
-  <p>Available for this page:</p>
-  <div id="translations">
-<p>
-<span dir="ltr" class="original">[en]&nbsp;<a lang="en" hreflang="en" href="/licenses/old-licenses/gpl-1.0.en.html">English</a> &nbsp;</span>
-<span dir="ltr">[de]&nbsp;<a lang="de" hreflang="de" href="/licenses/old-licenses/gpl-1.0.de.html">Deutsch</a> &nbsp;</span>
-<span dir="ltr">[fr]&nbsp;<a lang="fr" hreflang="fr" href="/licenses/old-licenses/gpl-1.0.fr.html">français</a> &nbsp;</span>
-<span dir="ltr">[ja]&nbsp;<a lang="ja" hreflang="ja" href="/licenses/old-licenses/gpl-1.0.ja.html">日本語</a> &nbsp;</span>
-<span dir="ltr">[pt-br]&nbsp;<a lang="pt-br" hreflang="pt-br" href="/licenses/old-licenses/gpl-1.0.pt-br.html">português</a> &nbsp;</span>
-<span dir="ltr">[ru]&nbsp;<a lang="ru" hreflang="ru" href="/licenses/old-licenses/gpl-1.0.ru.html">русский</a> &nbsp;</span>
-<span dir="ltr">[uk]&nbsp;<a lang="uk" hreflang="uk" href="/licenses/old-licenses/gpl-1.0.uk.html">українська</a> &nbsp;</span>
-<span dir="ltr">[zh-cn]&nbsp;<a lang="zh-cn" hreflang="zh-cn" href="/licenses/old-licenses/gpl-1.0.zh-cn.html">简体中文</a> &nbsp;</span>
-</p>
-</div>
- </div>
-</div>
-
-<div id="mission-statement" role="complementary">
- <div class="backtotop">
-  <hr class="no-display" />
-  <a href="#header"><span>BACK TO TOP </span>&#9650;</a>
- </div>
-<div style="clear: both"></div>
-<blockquote>
-<p style="direction:ltr; text-align:left"><a href="//www.fsf.org"><img id="fsfbanner"
-src="/graphics/fsf-logo-notext-small.png" alt="&nbsp;[FSF logo]&nbsp;"
-width="75" height="25" /></a><strong>
-&ldquo;The Free Software Foundation (FSF) is a nonprofit with a worldwide
-mission to promote computer user freedom. We defend the rights of all
-software users.&rdquo;</strong></p>
-</blockquote>
-
-<div id="support-the-fsf" class="button">
- <a class="join" href="//www.fsf.org/associate/support_freedom?referrer=4052">JOIN</a>
- <a class="donate" href="//donate.fsf.org/">DONATE</a>
- <a class="shop" href="//shop.fsf.org/">SHOP</a>
-</div>
-</div>
-<!-- end server/footer-text.html -->
-
-
-<div id="footer" role="contentinfo">
-<div class="unprintable">
-
-<p>Please send general FSF &amp; GNU inquiries to
-<a href="mailto:gnu@gnu.org">&lt;gnu@gnu.org&gt;</a>.
-There are also <a href="/contact/">other ways to contact</a>
-the FSF.  Broken links and other corrections or suggestions can be sent
-to <a href="mailto:webmasters@gnu.org">&lt;webmasters@gnu.org&gt;</a>.</p>
-
-<p><!-- TRANSLATORS: Ignore the original text in this paragraph,
-        replace it with the translation of these two:
-
-        We work hard and do our best to provide accurate, good quality
-        translations.  However, we are not exempt from imperfection.
-        Please send your comments and general suggestions in this regard
-        to <a href="mailto:web-translators@gnu.org">
-        &lt;web-translators@gnu.org&gt;</a>.</p>
-
-        <p>For information on coordinating and contributing translations of
-        our web pages, see <a
-        href="/server/standards/README.translations.html">Translations
-        README</a>. -->
-Please see the <a
-href="/server/standards/README.translations.html">Translations
-README</a> for information on coordinating and contributing translations
-of this article.</p>
-</div>
-
-<p>Copyright notice above.</p>
-
-<!-- start of server/bottom-notes.html -->
-<div id="bottom-notes" class="unprintable">
-<p><a href="//www.fsf.org/about/dmca-notice">Copyright Infringement Notification</a></p>
-<div id="generic">
-
-
-</div>
-</div>
-<!-- end of server/bottom-notes.html -->
-
-
-<p class="unprintable">Updated:
-<!-- timestamp start -->
-$Date: 2023/11/30 09:46:01 $
-<!-- timestamp end -->
-</p>
-</div>
-</div><!-- for class="inner", starts in the banner include -->
-</body>
-</html>

--- a/licenses-generator/src/main/resources/offline-license-mirror/www.gnu.org/licenses/old-licenses/gpl-2.0
+++ b/licenses-generator/src/main/resources/offline-license-mirror/www.gnu.org/licenses/old-licenses/gpl-2.0
@@ -1,227 +1,13 @@
-<!DOCTYPE html>
-<html xmlns="http://www.w3.org/1999/xhtml" xml:lang="en" lang="en">
-<head>
-<meta http-equiv="content-type" content="text/html; charset=utf-8" />
-<link rel="author" href="mailto:webmasters@gnu.org" />
-<link rel="icon" type="image/png" href="/graphics/gnu-head-mini.png" />
-<meta name="ICBM" content="42.355469,-71.058627" />
-<link rel="stylesheet" type="text/css" href="/layout.min.css" media="screen" />
-<link rel="stylesheet" type="text/css" href="/print.min.css" media="print" />
+                    GNU GENERAL PUBLIC LICENSE
+                       Version 2, June 1991
 
+ Copyright (C) 1989, 1991 Free Software Foundation, Inc.,
+ <https://fsf.org/>
+ Everyone is permitted to copy and distribute verbatim copies
+ of this license document, but changing it is not allowed.
 
+                            Preamble
 
-<!-- Parent-Version: 1.98 -->
-<!-- This page is derived from /server/standards/boilerplate.html -->
-<title>GNU General Public License v2.0 - GNU Project - Free Software Foundation</title>
-<link rel="alternate" type="application/rdf+xml" href="gpl-2.0.rdf" /> 
-<!-- begin translist file -->
-
-<link rel="alternate" type="text/html" href="/licenses/old-licenses/gpl-2.0.html" hreflang="x-default" />
-<link rel="alternate" type="text/html" lang="en" hreflang="en" href="/licenses/old-licenses/gpl-2.0.en.html" title="English" />
-<link rel="alternate" type="text/html" lang="cs" hreflang="cs" href="/licenses/old-licenses/gpl-2.0.cs.html" title="čeština" />
-<link rel="alternate" type="text/html" lang="de" hreflang="de" href="/licenses/old-licenses/gpl-2.0.de.html" title="Deutsch" />
-<link rel="alternate" type="text/html" lang="fr" hreflang="fr" href="/licenses/old-licenses/gpl-2.0.fr.html" title="français" />
-<link rel="alternate" type="text/html" lang="ja" hreflang="ja" href="/licenses/old-licenses/gpl-2.0.ja.html" title="日本語" />
-<link rel="alternate" type="text/html" lang="pt-br" hreflang="pt-br" href="/licenses/old-licenses/gpl-2.0.pt-br.html" title="português" />
-<link rel="alternate" type="text/html" lang="ru" hreflang="ru" href="/licenses/old-licenses/gpl-2.0.ru.html" title="русский" />
-<link rel="alternate" type="text/html" lang="uk" hreflang="uk" href="/licenses/old-licenses/gpl-2.0.uk.html" title="українська" />
-<link rel="alternate" type="text/html" lang="zh-cn" hreflang="zh-cn" href="/licenses/old-licenses/gpl-2.0.zh-cn.html" title="简体中文" />
-<!-- end translist file -->
-
-<!-- start of server/banner.html -->
-<!-- start of head-include-2.html -->
-<meta name="viewport" content="width=device-width, initial-scale=1" />
-<!-- end of head-include-2.html -->
-
-</head>
-<body>
-<div class="inner">
-<!-- start of server/body-include-1.html -->
-<div id="top">
-<a class="skip" href="#content"><b>Skip to main text</b></a>
-</div>
-
-<div id="fsf-frame" role="complementary">
-<form id="fssbox" action="https://my.fsf.org/civicrm/profile/create?reset=1&amp;gid=31"
-      method="post">
- <div>
-  <input name="postURL" type="hidden" value="" />
-  <input type="hidden" name="group[25]" value="1" />
-  <input name="cancelURL" type="hidden" value="https://crm.fsf.org/civicrm/profile?reset=1&amp;gid=31" />
-  <input name="_qf_default" type="hidden" value="Edit:cancel" />
-  <label for="frmEmail">
-   <a href="//www.fsf.org/fss">Free Software Supporter</a>:
-  </label>
-  <input type="text" id="frmEmail" name="email-Primary" size="18" maxlength="80"
-         value="email address" onfocus="this.value=''"/>
-  <input type="submit" name="_qf_Edit_next" value="Sign up" />
- </div>
-</form>
-
-<div id="join-fsf" class="button"><a
-href="https://www.fsf.org/associate/support_freedom?referrer=4052">JOIN&nbsp;THE&nbsp;FSF</a>
-</div>
-</div>
-
-<div id="header" role="banner">
-<p id="gnu-banner">
- <a href="/">
- <img src="/graphics/heckert_gnu.transp.small.png" height="48" width="49"
-      alt="&nbsp;[A GNU head]&nbsp;" /><strong>GNU</strong> <span
- class="hide">Operating System</span></a><br />
- <small id="fsf-support">Supported by the
- <a href="#mission-statement">Free Software Foundation</a></small>
-</p>
-
-<div id="switches">
-<!-- begin search button -->
- <div  id="search-button" class="switch">
-  <a href="//www.gnu.org/cgi-bin/estseek.cgi">
-  <img id="search-icon" height="30" width="30"
-       src="/graphics/icons/search.png"
-       alt="&nbsp;[Search www.gnu.org]&nbsp;" /></a>
- </div>
-<!-- end search button -->
-
- <div id="language-button" class="switch">
-  <a href="#language-container">
-  <img id="language-icon" height="30" width="37"
-       src="/graphics/icons/translations.png"
-       alt="&nbsp;[Other languages]&nbsp;" /></a>
- </div>
-
-</div>
-</div>
-<!-- end of server/body-include-1.html -->
-
-<!-- start of server/body-include-2 -->
-
-
-<div style="clear: both"></div>
-
-<div id="navigation" role="navigation">
- <a id="more-links" href="#navigation" title="More...">
-   <span>Site navigation</span></a>
- <a id="less-links" href="#content"><b>Skip</b></a>
- <ul>
-
-   <li id="tabAboutGNU"><a href="/gnu/gnu.html">ABOUT&nbsp;GNU</a></li>
-
-
-  <li id="tabPhilosophy"><a href="/philosophy/philosophy.html">PHILOSOPHY</a></li>
-
-
-  <li id="tabLicenses" class="active">
-     <span class='no-display'>=</span> 
-    <a href="/licenses/licenses.html">LICENSES</a>
-    <span class="gnun-split"></span>
-     <span class='no-display'>=</span> 
-  </li>
-
-
-  <li id="tabEducation"><a href="/education/education.html">EDUCATION</a></li>
-
-
-  <li id="tabSoftware"><a href="/software/software.html">SOFTWARE</a></li>
-
-
-  <li id="tabDistros"><a href="/distros/distros.html">DISTROS</a></li>
-
-
-  <li id="tabDoc"><a href="/doc/doc.html">DOCS</a></li>
-
-
-  <li id="tabMalware"><a href="/proprietary/proprietary.html">MALWARE</a></li>
-
-
-  <li id="tabHelp"><a href="/help/help.html">HELP&nbsp;GNU</a></li>
-
-
-  <li id="tabAV"><a href="/audio-video/audio-video.html">AUDIO&nbsp;&amp;&nbsp;VIDEO</a></li>
-
-
-  <li id="tabArt"><a href="/graphics/graphics.html">GNU&nbsp;ART</a></li>
-
-
-  <li id="tabFun"><a href="/fun/humor.html">FUN</a></li>
-
-
-  <li id="tabPeople"><a href="/people/people.html">GNU'S&nbsp;WHO?</a></li>
-
-  <li><a href="//directory.fsf.org">SOFTWARE&nbsp;DIRECTORY</a></li>
-  <li><a href="https://h-node.org/">HARDWARE</a></li>
-  <li><a href="/server/sitemap.html">SITEMAP</a></li>
- </ul>
- <div style="clear: both"></div>
-</div><!-- /"navigation -->
-<!-- end of server/body-include-2 -->
-
-<div id="content" role="main">
-<!-- end of server/banner.html -->
-
-<div class="reduced-width">
-<h2>GNU General Public License, version&nbsp;2</h2>
-
-<p class="button" style="margin: 2em 1.5em">
-  <b><a href="#SEC1">Skip to license text</a></b></p>
-
-<ul>
-  <li><a href="/licenses/gpl.html">The latest version of the GPL, version 3</a></li>
-  <li><a href="/licenses/gpl-violation.html">What to do if you see a possible
-    GPL violation</a></li>
-  <li><a href="/licenses/old-licenses/gpl-2.0-translations.html">Translations
-    of GPLv2</a></li>
-  <li><a href="/licenses/old-licenses/gpl-2.0-faq.html">GPLv2 Frequently Asked
-    Questions</a></li>
-  <li>The GNU General Public License version 2 (GPLv2) in other formats: <a
-    href="/licenses/old-licenses/gpl-2.0.txt">plain text</a>, <a
-    href="/licenses/old-licenses/gpl-2.0.texi">Texinfo</a>, <a
-    href="/licenses/old-licenses/gpl-2.0.tex">LaTeX</a>, <a 
-    href="/licenses/old-licenses/gpl-2.0-standalone.html">standalone HTML</a>,  <a 
-    href="/licenses/old-licenses/gpl-2.0.dbk">Docbook</a>, <a 
-    href="/licenses/old-licenses/gpl-2.0.md">Markdown</a>,  <a 
-    href="/licenses/old-licenses/gpl-2.0.odt">ODF</a>, <a 
-    href="/licenses/old-licenses/gpl-2.0.rtf">RTF</a></li>
-</ul>
-
-<hr class="thin" />
-
-<h3>Table of Contents</h3>
-<ul>
-  <li><a id="TOC1" href="#SEC1">GNU GENERAL PUBLIC LICENSE
-    <!--TRANSLATORS: Don't translate the license; copy msgid's verbatim!--></a> 
-    <ul>
-      <li><a id="TOC2" href="#SEC2">Preamble</a></li>
-      <li><a id="TOC3" href="#SEC3">TERMS AND CONDITIONS FOR COPYING,
-        DISTRIBUTION AND MODIFICATION</a></li>
-      <li><a id="TOC4" href="#SEC4">How to Apply These Terms to Your New
-        Programs</a></li>
-    </ul>
-  </li>
-</ul>
-
-<hr class="thin" />
-
-<!-- The license text is in English and appears broken in RTL as
-Arabic, Farsi, etc. Explicitly set the direction to override the
-one defined in the translation. -->
-<div dir="ltr">
-<h3 id="SEC1">GNU GENERAL PUBLIC LICENSE</h3>
-<p>
-Version 2, June 1991
-</p>
-
-<pre>
-Copyright (C) 1989, 1991 Free Software Foundation, Inc.  
-&lt;<a href="https://fsf.org/">https://fsf.org/</a>&gt;
-Everyone is permitted to copy and distribute verbatim copies
-of this license document, but changing it is not allowed.
-</pre>
-
-<span id="SEC2"></span>
-<h4 id="preamble">Preamble</h4>
-
-<p>
   The licenses for most software are designed to take away your
 freedom to share and change it.  By contrast, the GNU General Public
 License is intended to guarantee your freedom to share and change free
@@ -231,66 +17,49 @@ Foundation's software and to any other program whose authors commit to
 using it.  (Some other Free Software Foundation software is covered by
 the GNU Lesser General Public License instead.)  You can apply it to
 your programs, too.
-</p>
 
-<p>
   When we speak of free software, we are referring to freedom, not
 price.  Our General Public Licenses are designed to make sure that you
 have the freedom to distribute copies of free software (and charge for
 this service if you wish), that you receive source code or can get it
 if you want it, that you can change the software or use pieces of it
 in new free programs; and that you know you can do these things.
-</p>
 
-<p>
   To protect your rights, we need to make restrictions that forbid
 anyone to deny you these rights or to ask you to surrender the rights.
 These restrictions translate to certain responsibilities for you if you
 distribute copies of the software, or if you modify it.
-</p>
 
-<p>
   For example, if you distribute copies of such a program, whether
 gratis or for a fee, you must give the recipients all the rights that
 you have.  You must make sure that they, too, receive or can get the
 source code.  And you must show them these terms so they know their
 rights.
-</p>
 
-<p>
   We protect your rights with two steps: (1) copyright the software, and
 (2) offer you this license which gives you legal permission to copy,
 distribute and/or modify the software.
-</p>
 
-<p>
   Also, for each author's protection and ours, we want to make certain
 that everyone understands that there is no warranty for this free
 software.  If the software is modified by someone else and passed on, we
 want its recipients to know that what they have is not the original, so
 that any problems introduced by others will not reflect on the original
 authors' reputations.
-</p>
 
-<p>
   Finally, any free program is threatened constantly by software
 patents.  We wish to avoid the danger that redistributors of a free
 program will individually obtain patent licenses, in effect making the
 program proprietary.  To prevent this, we have made it clear that any
 patent must be licensed for everyone's free use or not licensed at all.
-</p>
 
-<p>
   The precise terms and conditions for copying, distribution and
 modification follow.
-</p>
 
-<span id="SEC3"></span>
-<h4 id="terms">TERMS AND CONDITIONS FOR COPYING, DISTRIBUTION AND MODIFICATION</h4>
+                    GNU GENERAL PUBLIC LICENSE
+   TERMS AND CONDITIONS FOR COPYING, DISTRIBUTION AND MODIFICATION
 
-<p id="section0">
-<strong>0.</strong>
- This License applies to any program or other work which contains
+  0. This License applies to any program or other work which contains
 a notice placed by the copyright holder saying it may be distributed
 under the terms of this General Public License.  The "Program", below,
 refers to any such program or work, and a "work based on the Program"
@@ -299,73 +68,49 @@ that is to say, a work containing the Program or a portion of it,
 either verbatim or with modifications and/or translated into another
 language.  (Hereinafter, translation is included without limitation in
 the term "modification".)  Each licensee is addressed as "you".
-</p>
 
-<p>
 Activities other than copying, distribution and modification are not
 covered by this License; they are outside its scope.  The act of
 running the Program is not restricted, and the output from the Program
 is covered only if its contents constitute a work based on the
 Program (independent of having been made by running the Program).
 Whether that is true depends on what the Program does.
-</p>
 
-<p id="section1">
-<strong>1.</strong>
- You may copy and distribute verbatim copies of the Program's
+  1. You may copy and distribute verbatim copies of the Program's
 source code as you receive it, in any medium, provided that you
 conspicuously and appropriately publish on each copy an appropriate
 copyright notice and disclaimer of warranty; keep intact all the
 notices that refer to this License and to the absence of any warranty;
 and give any other recipients of the Program a copy of this License
 along with the Program.
-</p>
 
-<p>
 You may charge a fee for the physical act of transferring a copy, and
 you may at your option offer warranty protection in exchange for a fee.
-</p>
 
-<p id="section2">
-<strong>2.</strong>
- You may modify your copy or copies of the Program or any portion
+  2. You may modify your copy or copies of the Program or any portion
 of it, thus forming a work based on the Program, and copy and
 distribute such modifications or work under the terms of Section 1
 above, provided that you also meet all of these conditions:
-</p>
 
-<dl>
-  <dt></dt>
-    <dd>
-      <strong>a)</strong>
-      You must cause the modified files to carry prominent notices
-      stating that you changed the files and the date of any change.
-    </dd>
-  <dt></dt>
-    <dd>
-      <strong>b)</strong>
-      You must cause any work that you distribute or publish, that in
-      whole or in part contains or is derived from the Program or any
-      part thereof, to be licensed as a whole at no charge to all third
-      parties under the terms of this License.
-    </dd>
-  <dt></dt>
-    <dd>
-      <strong>c)</strong>
-      If the modified program normally reads commands interactively
-      when run, you must cause it, when started running for such
-      interactive use in the most ordinary way, to print or display an
-      announcement including an appropriate copyright notice and a
-      notice that there is no warranty (or else, saying that you provide
-      a warranty) and that users may redistribute the program under
-      these conditions, and telling the user how to view a copy of this
-      License.  (Exception: if the Program itself is interactive but
-      does not normally print such an announcement, your work based on
-      the Program is not required to print an announcement.)
-    </dd>
-</dl>
+    a) You must cause the modified files to carry prominent notices
+    stating that you changed the files and the date of any change.
 
-<p>
+    b) You must cause any work that you distribute or publish, that in
+    whole or in part contains or is derived from the Program or any
+    part thereof, to be licensed as a whole at no charge to all third
+    parties under the terms of this License.
+
+    c) If the modified program normally reads commands interactively
+    when run, you must cause it, when started running for such
+    interactive use in the most ordinary way, to print or display an
+    announcement including an appropriate copyright notice and a
+    notice that there is no warranty (or else, saying that you provide
+    a warranty) and that users may redistribute the program under
+    these conditions, and telling the user how to view a copy of this
+    License.  (Exception: if the Program itself is interactive but
+    does not normally print such an announcement, your work based on
+    the Program is not required to print an announcement.)
+
 These requirements apply to the modified work as a whole.  If
 identifiable sections of that work are not derived from the Program,
 and can be reasonably considered independent and separate works in
@@ -375,62 +120,38 @@ distribute the same sections as part of a whole which is a work based
 on the Program, the distribution of the whole must be on the terms of
 this License, whose permissions for other licensees extend to the
 entire whole, and thus to each and every part regardless of who wrote it.
-</p>
 
-<p>
 Thus, it is not the intent of this section to claim rights or contest
 your rights to work written entirely by you; rather, the intent is to
 exercise the right to control the distribution of derivative or
 collective works based on the Program.
-</p>
 
-<p>
 In addition, mere aggregation of another work not based on the Program
 with the Program (or with a work based on the Program) on a volume of
 a storage or distribution medium does not bring the other work under
 the scope of this License.
-</p>
 
-<p id="section3">
-<strong>3.</strong>
- You may copy and distribute the Program (or a work based on it,
+  3. You may copy and distribute the Program (or a work based on it,
 under Section 2) in object code or executable form under the terms of
 Sections 1 and 2 above provided that you also do one of the following:
-</p>
 
-<!-- we use this doubled UL to get the sub-sections indented, -->
-<!-- while making the bullets as unobvious as possible. -->
+    a) Accompany it with the complete corresponding machine-readable
+    source code, which must be distributed under the terms of Sections
+    1 and 2 above on a medium customarily used for software interchange; or,
 
-<dl>
-  <dt></dt>
-    <dd>
-      <strong>a)</strong>
-      Accompany it with the complete corresponding machine-readable
-      source code, which must be distributed under the terms of Sections
-      1 and 2 above on a medium customarily used for software interchange; or,
-    </dd>
-  <dt></dt>
-    <dd>
-      <strong>b)</strong>
-      Accompany it with a written offer, valid for at least three
-      years, to give any third party, for a charge no more than your
-      cost of physically performing source distribution, a complete
-      machine-readable copy of the corresponding source code, to be
-      distributed under the terms of Sections 1 and 2 above on a medium
-      customarily used for software interchange; or,
-    </dd>
-  <dt></dt>
-    <dd>
-      <strong>c)</strong>
-      Accompany it with the information you received as to the offer
-      to distribute corresponding source code.  (This alternative is
-      allowed only for noncommercial distribution and only if you
-      received the program in object code or executable form with such
-      an offer, in accord with Subsection b above.)
-    </dd>
-</dl>
+    b) Accompany it with a written offer, valid for at least three
+    years, to give any third party, for a charge no more than your
+    cost of physically performing source distribution, a complete
+    machine-readable copy of the corresponding source code, to be
+    distributed under the terms of Sections 1 and 2 above on a medium
+    customarily used for software interchange; or,
 
-<p>
+    c) Accompany it with the information you received as to the offer
+    to distribute corresponding source code.  (This alternative is
+    allowed only for noncommercial distribution and only if you
+    received the program in object code or executable form with such
+    an offer, in accord with Subsection b above.)
+
 The source code for a work means the preferred form of the work for
 making modifications to it.  For an executable work, complete source
 code means all the source code for all modules it contains, plus any
@@ -441,30 +162,22 @@ anything that is normally distributed (in either source or binary
 form) with the major components (compiler, kernel, and so on) of the
 operating system on which the executable runs, unless that component
 itself accompanies the executable.
-</p>
 
-<p>
 If distribution of executable or object code is made by offering
 access to copy from a designated place, then offering equivalent
 access to copy the source code from the same place counts as
 distribution of the source code, even though third parties are not
 compelled to copy the source along with the object code.
-</p>
 
-<p id="section4">
-<strong>4.</strong>
- You may not copy, modify, sublicense, or distribute the Program
+  4. You may not copy, modify, sublicense, or distribute the Program
 except as expressly provided under this License.  Any attempt
 otherwise to copy, modify, sublicense or distribute the Program is
 void, and will automatically terminate your rights under this License.
 However, parties who have received copies, or rights, from you under
 this License will not have their licenses terminated so long as such
 parties remain in full compliance.
-</p>
 
-<p id="section5">
-<strong>5.</strong>
- You are not required to accept this License, since you have not
+  5. You are not required to accept this License, since you have not
 signed it.  However, nothing else grants you permission to modify or
 distribute the Program or its derivative works.  These actions are
 prohibited by law if you do not accept this License.  Therefore, by
@@ -472,22 +185,16 @@ modifying or distributing the Program (or any work based on the
 Program), you indicate your acceptance of this License to do so, and
 all its terms and conditions for copying, distributing or modifying
 the Program or works based on it.
-</p>
 
-<p id="section6">
-<strong>6.</strong>
- Each time you redistribute the Program (or any work based on the
+  6. Each time you redistribute the Program (or any work based on the
 Program), the recipient automatically receives a license from the
 original licensor to copy, distribute or modify the Program subject to
 these terms and conditions.  You may not impose any further
 restrictions on the recipients' exercise of the rights granted herein.
 You are not responsible for enforcing compliance by third parties to
 this License.
-</p>
 
-<p id="section7">
-<strong>7.</strong>
- If, as a consequence of a court judgment or allegation of patent
+  7. If, as a consequence of a court judgment or allegation of patent
 infringement or for any other reason (not limited to patent issues),
 conditions are imposed on you (whether by court order, agreement or
 otherwise) that contradict the conditions of this License, they do not
@@ -499,16 +206,12 @@ license would not permit royalty-free redistribution of the Program by
 all those who receive copies directly or indirectly through you, then
 the only way you could satisfy both it and this License would be to
 refrain entirely from distribution of the Program.
-</p>
 
-<p>
 If any portion of this section is held invalid or unenforceable under
 any particular circumstance, the balance of the section is intended to
 apply and the section as a whole is intended to apply in other
 circumstances.
-</p>
 
-<p>
 It is not the purpose of this section to induce you to infringe any
 patents or other property right claims or to contest validity of any
 such claims; this section has the sole purpose of protecting the
@@ -519,33 +222,23 @@ through that system in reliance on consistent application of that
 system; it is up to the author/donor to decide if he or she is willing
 to distribute software through any other system and a licensee cannot
 impose that choice.
-</p>
 
-<p>
 This section is intended to make thoroughly clear what is believed to
 be a consequence of the rest of this License.
-</p>
 
-<p id="section8">
-<strong>8.</strong>
- If the distribution and/or use of the Program is restricted in
+  8. If the distribution and/or use of the Program is restricted in
 certain countries either by patents or by copyrighted interfaces, the
 original copyright holder who places the Program under this License
 may add an explicit geographical distribution limitation excluding
 those countries, so that distribution is permitted only in or among
 countries not thus excluded.  In such case, this License incorporates
 the limitation as if written in the body of this License.
-</p>
 
-<p id="section9">
-<strong>9.</strong>
- The Free Software Foundation may publish revised and/or new versions
+  9. The Free Software Foundation may publish revised and/or new versions
 of the General Public License from time to time.  Such new versions will
 be similar in spirit to the present version, but may differ in detail to
 address new problems or concerns.
-</p>
 
-<p>
 Each version is given a distinguishing version number.  If the Program
 specifies a version number of this License which applies to it and "any
 later version", you have the option of following the terms and conditions
@@ -553,24 +246,18 @@ either of that version or of any later version published by the Free
 Software Foundation.  If the Program does not specify a version number of
 this License, you may choose any version ever published by the Free Software
 Foundation.
-</p>
 
-<p id="section10">
-<strong>10.</strong>
- If you wish to incorporate parts of the Program into other free
+  10. If you wish to incorporate parts of the Program into other free
 programs whose distribution conditions are different, write to the author
 to ask for permission.  For software which is copyrighted by the Free
 Software Foundation, write to the Free Software Foundation; we sometimes
 make exceptions for this.  Our decision will be guided by the two goals
 of preserving the free status of all derivatives of our free software and
 of promoting the sharing and reuse of software generally.
-</p>
 
-<p id="section11"><strong>NO WARRANTY</strong></p>
+                            NO WARRANTY
 
-<p>
-<strong>11.</strong>
- BECAUSE THE PROGRAM IS LICENSED FREE OF CHARGE, THERE IS NO WARRANTY
+  11. BECAUSE THE PROGRAM IS LICENSED FREE OF CHARGE, THERE IS NO WARRANTY
 FOR THE PROGRAM, TO THE EXTENT PERMITTED BY APPLICABLE LAW.  EXCEPT WHEN
 OTHERWISE STATED IN WRITING THE COPYRIGHT HOLDERS AND/OR OTHER PARTIES
 PROVIDE THE PROGRAM "AS IS" WITHOUT WARRANTY OF ANY KIND, EITHER EXPRESSED
@@ -579,11 +266,8 @@ MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE.  THE ENTIRE RISK AS
 TO THE QUALITY AND PERFORMANCE OF THE PROGRAM IS WITH YOU.  SHOULD THE
 PROGRAM PROVE DEFECTIVE, YOU ASSUME THE COST OF ALL NECESSARY SERVICING,
 REPAIR OR CORRECTION.
-</p>
 
-<p id="section12">
-<strong>12.</strong>
- IN NO EVENT UNLESS REQUIRED BY APPLICABLE LAW OR AGREED TO IN WRITING
+  12. IN NO EVENT UNLESS REQUIRED BY APPLICABLE LAW OR AGREED TO IN WRITING
 WILL ANY COPYRIGHT HOLDER, OR ANY OTHER PARTY WHO MAY MODIFY AND/OR
 REDISTRIBUTE THE PROGRAM AS PERMITTED ABOVE, BE LIABLE TO YOU FOR DAMAGES,
 INCLUDING ANY GENERAL, SPECIAL, INCIDENTAL OR CONSEQUENTIAL DAMAGES ARISING
@@ -592,213 +276,63 @@ TO LOSS OF DATA OR DATA BEING RENDERED INACCURATE OR LOSSES SUSTAINED BY
 YOU OR THIRD PARTIES OR A FAILURE OF THE PROGRAM TO OPERATE WITH ANY OTHER
 PROGRAMS), EVEN IF SUCH HOLDER OR OTHER PARTY HAS BEEN ADVISED OF THE
 POSSIBILITY OF SUCH DAMAGES.
-</p>
 
-<h4>END OF TERMS AND CONDITIONS</h4>
+                     END OF TERMS AND CONDITIONS
 
-<span id="SEC4"></span>
-<h4 id="howto">How to Apply These Terms to Your New Programs</h4>
+            How to Apply These Terms to Your New Programs
 
-<p>
   If you develop a new program, and you want it to be of the greatest
 possible use to the public, the best way to achieve this is to make it
 free software which everyone can redistribute and change under these terms.
-</p>
 
-<p>
   To do so, attach the following notices to the program.  It is safest
 to attach them to the start of each source file to most effectively
 convey the exclusion of warranty; and each file should have at least
 the "copyright" line and a pointer to where the full notice is found.
-</p>
 
-<pre>
-<var>one line to give the program's name and an idea of what it does.</var>
-Copyright (C) <var>yyyy</var>  <var>name of author</var>
+    <one line to give the program's name and a brief idea of what it does.>
+    Copyright (C) <year>  <name of author>
 
-This program is free software; you can redistribute it and/or
-modify it under the terms of the GNU General Public License
-as published by the Free Software Foundation; either version 2
-of the License, or (at your option) any later version.
+    This program is free software; you can redistribute it and/or modify
+    it under the terms of the GNU General Public License as published by
+    the Free Software Foundation; either version 2 of the License, or
+    (at your option) any later version.
 
-This program is distributed in the hope that it will be useful,
-but WITHOUT ANY WARRANTY; without even the implied warranty of
-MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
-GNU General Public License for more details.
+    This program is distributed in the hope that it will be useful,
+    but WITHOUT ANY WARRANTY; without even the implied warranty of
+    MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+    GNU General Public License for more details.
 
-You should have received a copy of the GNU General Public License
-along with this program; if not, see
-&lt;<a href="https://www.gnu.org/licenses/">https://www.gnu.org/licenses/</a>&gt;.
-</pre>
+    You should have received a copy of the GNU General Public License along
+    with this program; if not, see <https://www.gnu.org/licenses/>.
 
-<p>
 Also add information on how to contact you by electronic and paper mail.
-</p>
 
-<p>
 If the program is interactive, make it output a short notice like this
 when it starts in an interactive mode:
-</p>
 
-<pre>
-Gnomovision version 69, Copyright (C) <var>year</var> <var>name of author</var>
-Gnomovision comes with ABSOLUTELY NO WARRANTY; for details
-type `show w'.  This is free software, and you are welcome
-to redistribute it under certain conditions; type `show c' 
-for details.
-</pre>
+    Gnomovision version 69, Copyright (C) year name of author
+    Gnomovision comes with ABSOLUTELY NO WARRANTY; for details type `show w'.
+    This is free software, and you are welcome to redistribute it
+    under certain conditions; type `show c' for details.
 
-<p>
-The hypothetical commands <samp>`show w'</samp> and <samp>`show c'</samp> should show
-the appropriate parts of the General Public License.  Of course, the
-commands you use may be called something other than <samp>`show w'</samp> and
-<samp>`show c'</samp>; they could even be mouse-clicks or menu items--whatever
-suits your program.
-</p>
+The hypothetical commands `show w' and `show c' should show the appropriate
+parts of the General Public License.  Of course, the commands you use may
+be called something other than `show w' and `show c'; they could even be
+mouse-clicks or menu items--whatever suits your program.
 
-<p>
 You should also get your employer (if you work as a programmer) or your
 school, if any, to sign a "copyright disclaimer" for the program, if
 necessary.  Here is a sample; alter the names:
-</p>
 
+  Yoyodyne, Inc., hereby disclaims all copyright interest in the program
+  `Gnomovision' (which makes passes at compilers) written by James Hacker.
 
-<pre>
-Yoyodyne, Inc., hereby disclaims all copyright
-interest in the program `Gnomovision'
-(which makes passes at compilers) written 
-by James Hacker.
+  <signature of Moe Ghoul>, 1 April 1989
+  Moe Ghoul, President of Vice
 
-<var>signature of Moe Ghoul</var>, 1 April 1989
-Moe Ghoul, President of Vice
-</pre>
-
-<p>
 This General Public License does not permit incorporating your program into
 proprietary programs.  If your program is a subroutine library, you may
 consider it more useful to permit linking proprietary applications with the
-library.  If this is what you want to do, use the 
-<a href="https://www.gnu.org/licenses/lgpl.html">GNU Lesser General Public License</a>
-instead of this License.
-</p>
-
-</div>
-</div>
-
-</div><!-- for id="content", starts in the include above -->
-
-              <!-- begin server/footer-text.html -->
-
-
-
-
-
-<div style="clear:both"></div>
-
-
-<div id="language-container">
- <div class="backtotop">
-  <hr class="no-display" />
-  <a href="#top"><b>&#9650;</b></a>
- </div>
- <div id="languages" class="rounded-corners">
-  <div class="button">
-   <a href="#top" class="close"><span>BACK TO TOP</span></a>
-  </div>
-  <div id="set-language" class="button">
-   <span class="gnun-split"></span>
-   <a href="/server/select-language.html?callback=/licenses/old-licenses/gpl-2.0" rel="nofollow">
-   Set language
-   <span class="gnun-split"></span>
-   </a>
-  </div>
-  <p>Available for this page:</p>
-  <div id="translations">
-<p>
-<span dir="ltr" class="original">[en]&nbsp;<a lang="en" hreflang="en" href="/licenses/old-licenses/gpl-2.0.en.html">English</a> &nbsp;</span>
-<span dir="ltr">[cs]&nbsp;<a lang="cs" hreflang="cs" href="/licenses/old-licenses/gpl-2.0.cs.html">čeština</a> &nbsp;</span>
-<span dir="ltr">[de]&nbsp;<a lang="de" hreflang="de" href="/licenses/old-licenses/gpl-2.0.de.html">Deutsch</a> &nbsp;</span>
-<span dir="ltr">[fr]&nbsp;<a lang="fr" hreflang="fr" href="/licenses/old-licenses/gpl-2.0.fr.html">français</a> &nbsp;</span>
-<span dir="ltr">[ja]&nbsp;<a lang="ja" hreflang="ja" href="/licenses/old-licenses/gpl-2.0.ja.html">日本語</a> &nbsp;</span>
-<span dir="ltr">[pt-br]&nbsp;<a lang="pt-br" hreflang="pt-br" href="/licenses/old-licenses/gpl-2.0.pt-br.html">português</a> &nbsp;</span>
-<span dir="ltr">[ru]&nbsp;<a lang="ru" hreflang="ru" href="/licenses/old-licenses/gpl-2.0.ru.html">русский</a> &nbsp;</span>
-<span dir="ltr">[uk]&nbsp;<a lang="uk" hreflang="uk" href="/licenses/old-licenses/gpl-2.0.uk.html">українська</a> &nbsp;</span>
-<span dir="ltr">[zh-cn]&nbsp;<a lang="zh-cn" hreflang="zh-cn" href="/licenses/old-licenses/gpl-2.0.zh-cn.html">简体中文</a> &nbsp;</span>
-</p>
-</div>
- </div>
-</div>
-
-<div id="mission-statement" role="complementary">
- <div class="backtotop">
-  <hr class="no-display" />
-  <a href="#header"><span>BACK TO TOP </span>&#9650;</a>
- </div>
-<div style="clear: both"></div>
-<blockquote>
-<p style="direction:ltr; text-align:left"><a href="//www.fsf.org"><img id="fsfbanner"
-src="/graphics/fsf-logo-notext-small.png" alt="&nbsp;[FSF logo]&nbsp;"
-width="75" height="25" /></a><strong>
-&ldquo;The Free Software Foundation (FSF) is a nonprofit with a worldwide
-mission to promote computer user freedom. We defend the rights of all
-software users.&rdquo;</strong></p>
-</blockquote>
-
-<div id="support-the-fsf" class="button">
- <a class="join" href="//www.fsf.org/associate/support_freedom?referrer=4052">JOIN</a>
- <a class="donate" href="//donate.fsf.org/">DONATE</a>
- <a class="shop" href="//shop.fsf.org/">SHOP</a>
-</div>
-</div>
-<!-- end server/footer-text.html -->
-
-
-<div id="footer" role="contentinfo">
-<div class="unprintable">
-
-<p>Please send general FSF &amp; GNU inquiries to
-<a href="mailto:gnu@gnu.org">&lt;gnu@gnu.org&gt;</a>.
-There are also <a href="/contact/">other ways to contact</a>
-the FSF.  Broken links and other corrections or suggestions can be sent
-to <a href="mailto:webmasters@gnu.org">&lt;webmasters@gnu.org&gt;</a>.</p>
-
-<p><!-- TRANSLATORS: Ignore the original text in this paragraph,
-        replace it with the translation of these two:
-
-        We work hard and do our best to provide accurate, good quality
-        translations.  However, we are not exempt from imperfection.
-        Please send your comments and general suggestions in this regard
-        to <a href="mailto:web-translators@gnu.org">
-        &lt;web-translators@gnu.org&gt;</a>.</p>
-
-        <p>For information on coordinating and contributing translations of
-        our web pages, see <a
-        href="/server/standards/README.translations.html">Translations
-        README</a>. -->
-Please see the <a
-href="/server/standards/README.translations.html">Translations
-README</a> for information on coordinating and contributing translations
-of this article.</p>
-</div>
-
-<p>Copyright notice above.</p>
-
-<!-- start of server/bottom-notes.html -->
-<div id="bottom-notes" class="unprintable">
-<p><a href="//www.fsf.org/about/dmca-notice">Copyright Infringement Notification</a></p>
-<div id="generic">
-
-
-</div>
-</div>
-<!-- end of server/bottom-notes.html -->
-
-
-<p class="unprintable">Updated:
-<!-- timestamp start -->
-$Date: 2023/11/30 09:46:01 $
-<!-- timestamp end --></p>
-</div>
-</div><!-- for class="inner", starts in the banner include -->
-</body>
-</html>
+library.  If this is what you want to do, use the GNU Lesser General
+Public License instead of this License.

--- a/licenses-generator/src/main/resources/offline-license-mirror/www.gnu.org/licenses/old-licenses/lgpl-2.0
+++ b/licenses-generator/src/main/resources/offline-license-mirror/www.gnu.org/licenses/old-licenses/lgpl-2.0
@@ -1,271 +1,38 @@
-<!DOCTYPE html>
-<html xmlns="http://www.w3.org/1999/xhtml" xml:lang="en" lang="en">
-<head>
-<meta http-equiv="content-type" content="text/html; charset=utf-8" />
-<link rel="author" href="mailto:webmasters@gnu.org" />
-<link rel="icon" type="image/png" href="/graphics/gnu-head-mini.png" />
-<meta name="ICBM" content="42.355469,-71.058627" />
-<link rel="stylesheet" type="text/css" href="/layout.min.css" media="screen" />
-<link rel="stylesheet" type="text/css" href="/print.min.css" media="print" />
+                  GNU LIBRARY GENERAL PUBLIC LICENSE
+                       Version 2, June 1991
 
-
-
-<!-- Parent-Version: 1.98 -->
-<!-- This page is derived from /server/standards/boilerplate.html -->
-<title>GNU Library General Public License v2.0 - GNU Project - Free Software Foundation</title>
-<!-- begin translist file -->
-
-<link rel="alternate" type="text/html" href="/licenses/old-licenses/lgpl-2.0.html" hreflang="x-default" />
-<link rel="alternate" type="text/html" lang="en" hreflang="en" href="/licenses/old-licenses/lgpl-2.0.en.html" title="English" />
-<link rel="alternate" type="text/html" lang="de" hreflang="de" href="/licenses/old-licenses/lgpl-2.0.de.html" title="Deutsch" />
-<link rel="alternate" type="text/html" lang="fr" hreflang="fr" href="/licenses/old-licenses/lgpl-2.0.fr.html" title="français" />
-<link rel="alternate" type="text/html" lang="ja" hreflang="ja" href="/licenses/old-licenses/lgpl-2.0.ja.html" title="日本語" />
-<link rel="alternate" type="text/html" lang="pt-br" hreflang="pt-br" href="/licenses/old-licenses/lgpl-2.0.pt-br.html" title="português" />
-<link rel="alternate" type="text/html" lang="ru" hreflang="ru" href="/licenses/old-licenses/lgpl-2.0.ru.html" title="русский" />
-<link rel="alternate" type="text/html" lang="uk" hreflang="uk" href="/licenses/old-licenses/lgpl-2.0.uk.html" title="українська" />
-<link rel="alternate" type="text/html" lang="zh-cn" hreflang="zh-cn" href="/licenses/old-licenses/lgpl-2.0.zh-cn.html" title="简体中文" />
-<!-- end translist file -->
-
-<!-- start of server/banner.html -->
-<!-- start of head-include-2.html -->
-<meta name="viewport" content="width=device-width, initial-scale=1" />
-<!-- end of head-include-2.html -->
-
-</head>
-<body>
-<div class="inner">
-<!-- start of server/body-include-1.html -->
-<div id="top">
-<a class="skip" href="#content"><b>Skip to main text</b></a>
-</div>
-
-<div id="fsf-frame" role="complementary">
-<form id="fssbox" action="https://my.fsf.org/civicrm/profile/create?reset=1&amp;gid=31"
-      method="post">
- <div>
-  <input name="postURL" type="hidden" value="" />
-  <input type="hidden" name="group[25]" value="1" />
-  <input name="cancelURL" type="hidden" value="https://crm.fsf.org/civicrm/profile?reset=1&amp;gid=31" />
-  <input name="_qf_default" type="hidden" value="Edit:cancel" />
-  <label for="frmEmail">
-   <a href="//www.fsf.org/fss">Free Software Supporter</a>:
-  </label>
-  <input type="text" id="frmEmail" name="email-Primary" size="18" maxlength="80"
-         value="email address" onfocus="this.value=''"/>
-  <input type="submit" name="_qf_Edit_next" value="Sign up" />
- </div>
-</form>
-
-<div id="join-fsf" class="button"><a
-href="https://www.fsf.org/associate/support_freedom?referrer=4052">JOIN&nbsp;THE&nbsp;FSF</a>
-</div>
-</div>
-
-<div id="header" role="banner">
-<p id="gnu-banner">
- <a href="/">
- <img src="/graphics/heckert_gnu.transp.small.png" height="48" width="49"
-      alt="&nbsp;[A GNU head]&nbsp;" /><strong>GNU</strong> <span
- class="hide">Operating System</span></a><br />
- <small id="fsf-support">Supported by the
- <a href="#mission-statement">Free Software Foundation</a></small>
-</p>
-
-<div id="switches">
-<!-- begin search button -->
- <div  id="search-button" class="switch">
-  <a href="//www.gnu.org/cgi-bin/estseek.cgi">
-  <img id="search-icon" height="30" width="30"
-       src="/graphics/icons/search.png"
-       alt="&nbsp;[Search www.gnu.org]&nbsp;" /></a>
- </div>
-<!-- end search button -->
-
- <div id="language-button" class="switch">
-  <a href="#language-container">
-  <img id="language-icon" height="30" width="37"
-       src="/graphics/icons/translations.png"
-       alt="&nbsp;[Other languages]&nbsp;" /></a>
- </div>
-
-</div>
-</div>
-<!-- end of server/body-include-1.html -->
-
-<!-- start of server/body-include-2 -->
-
-
-<div style="clear: both"></div>
-
-<div id="navigation" role="navigation">
- <a id="more-links" href="#navigation" title="More...">
-   <span>Site navigation</span></a>
- <a id="less-links" href="#content"><b>Skip</b></a>
- <ul>
-
-   <li id="tabAboutGNU"><a href="/gnu/gnu.html">ABOUT&nbsp;GNU</a></li>
-
-
-  <li id="tabPhilosophy"><a href="/philosophy/philosophy.html">PHILOSOPHY</a></li>
-
-
-  <li id="tabLicenses" class="active">
-     <span class='no-display'>=</span> 
-    <a href="/licenses/licenses.html">LICENSES</a>
-    <span class="gnun-split"></span>
-     <span class='no-display'>=</span> 
-  </li>
-
-
-  <li id="tabEducation"><a href="/education/education.html">EDUCATION</a></li>
-
-
-  <li id="tabSoftware"><a href="/software/software.html">SOFTWARE</a></li>
-
-
-  <li id="tabDistros"><a href="/distros/distros.html">DISTROS</a></li>
-
-
-  <li id="tabDoc"><a href="/doc/doc.html">DOCS</a></li>
-
-
-  <li id="tabMalware"><a href="/proprietary/proprietary.html">MALWARE</a></li>
-
-
-  <li id="tabHelp"><a href="/help/help.html">HELP&nbsp;GNU</a></li>
-
-
-  <li id="tabAV"><a href="/audio-video/audio-video.html">AUDIO&nbsp;&amp;&nbsp;VIDEO</a></li>
-
-
-  <li id="tabArt"><a href="/graphics/graphics.html">GNU&nbsp;ART</a></li>
-
-
-  <li id="tabFun"><a href="/fun/humor.html">FUN</a></li>
-
-
-  <li id="tabPeople"><a href="/people/people.html">GNU'S&nbsp;WHO?</a></li>
-
-  <li><a href="//directory.fsf.org">SOFTWARE&nbsp;DIRECTORY</a></li>
-  <li><a href="https://h-node.org/">HARDWARE</a></li>
-  <li><a href="/server/sitemap.html">SITEMAP</a></li>
- </ul>
- <div style="clear: both"></div>
-</div><!-- /"navigation -->
-<!-- end of server/body-include-2 -->
-
-<div id="content" role="main">
-<!-- end of server/banner.html -->
-
-<div class="reduced-width">
-<h2>GNU Library General Public License, version&nbsp;2.0</h2>
-
-<p class="button" style="margin: 2em 1.5em">
-  <b><a href="#SEC1">Skip to license text</a></b></p>
-
-<div class="announcement">
-<blockquote>
-  <p><strong>Please note that the GNU Library General Public License has been
-  superseded by the <a href="/licenses/lgpl.html">GNU Lesser General Public
-  License</a>.</strong></p>
-</blockquote>
-</div>
-
-<p>We urge everyone to use the <a href="/licenses/lgpl.html">GNU Lesser General
-Public License</a> instead of this GNU Library GPL. We leave the Library GPL
-available here for historical reference.</p>
-<ul>
-  <li><a href="/licenses/lgpl.html">The latest version of the LGPL, version 3</a></li>
-  <li><a href="/licenses/why-not-lgpl.html">Why you shouldn't use the Library
-    GPL for your next library</a></li>
-  <li><a href="/licenses/gpl-violation.html">What to do if you see a possible
-    LGPL violation</a></li>
-  <li><a href="/licenses/old-licenses/lgpl-2.0-translations.html">Translations
-    of LGPLv2.0</a></li>
-  <li>The GNU Library General Public License version 2.0 (LGPLv2.0) in other
-    formats: <a href="/licenses/old-licenses/lgpl-2.0.txt">plain text</a>, <a
-    href="/licenses/old-licenses/lgpl-2.0-standalone.html">standalone 
-    HTML</a>, <a href="/licenses/old-licenses/lgpl-2.0.dbk">Docbook</a>, 
-    <a href="/licenses/old-licenses/lgpl-2.0.md">Markdown</a>, 
-    <a href="/licenses/old-licenses/lgpl-2.0.odt">ODF</a>, 
-    <a href="/licenses/old-licenses/lgpl-2.0.rtf">RTF</a>, 
-    <a href="/licenses/old-licenses/lgpl-2.0.tex">LaTeX</a>, 
-    <a href="/licenses/old-licenses/lgpl-2.0.texi">Texinfo</a>
-  </li>
-  <li><a href="/licenses/old-licenses/old-licenses.html#LGPL">Old versions of
-    the LGPL</a></li>
-</ul>
-
-<hr class="thin" />
-
-<h3>Table of Contents</h3>
-
-<ul>
-  <li><a id="TOC1" href="#SEC1">GNU LIBRARY GENERAL PUBLIC LICENSE</a> 
-    <ul>
-      <li><a id="TOC2" href="#SEC2">Preamble</a></li>
-      <li><a id="TOC3" href="#SEC3">TERMS AND CONDITIONS FOR COPYING,
-        DISTRIBUTION AND MODIFICATION</a></li>
-      <li><a id="TOC4" href="#SEC4">How to Apply These Terms to Your New
-        Libraries</a></li>
-    </ul>
-  </li>
-</ul>
-
-<hr class="thin" />
-
-<!-- The license text is in English and appears broken in RTL as
-Arabic, Farsi, etc. Explicitly set the direction to override the
-one defined in the translation. -->
-<div dir="ltr">
-<h3 id="SEC1">GNU LIBRARY GENERAL PUBLIC LICENSE</h3>
-<p>
-Version 2, June 1991
-</p>
-
-<pre>
-Copyright (C) 1991 Free Software Foundation, Inc.
-&lt;<a href="https://fsf.org/">https://fsf.org/</a>&gt;
-Everyone is permitted to copy and distribute verbatim copies
-of this license document, but changing it is not allowed.
+ Copyright (C) 1991 Free Software Foundation, Inc.
+ <https://fsf.org/>
+ Everyone is permitted to copy and distribute verbatim copies
+ of this license document, but changing it is not allowed.
 
 [This is the first released version of the library GPL.  It is
  numbered 2 because it goes with version 2 of the ordinary GPL.]
-</pre>
 
-<h4 id="SEC2">Preamble</h4>
+                            Preamble
 
-<p>
   The licenses for most software are designed to take away your
 freedom to share and change it.  By contrast, the GNU General Public
 Licenses are intended to guarantee your freedom to share and change
 free software--to make sure the software is free for all its users.
-</p>
 
-<p>
   This license, the Library General Public License, applies to some
 specially designated Free Software Foundation software, and to any
 other libraries whose authors decide to use it.  You can use it for
 your libraries, too.
-</p>
 
-<p>
   When we speak of free software, we are referring to freedom, not
 price.  Our General Public Licenses are designed to make sure that you
 have the freedom to distribute copies of free software (and charge for
 this service if you wish), that you receive source code or can get it
 if you want it, that you can change the software or use pieces of it
 in new free programs; and that you know you can do these things.
-</p>
 
-<p>
   To protect your rights, we need to make restrictions that forbid
 anyone to deny you these rights or to ask you to surrender the rights.
 These restrictions translate to certain responsibilities for you if
 you distribute copies of the library, or if you modify it.
-</p>
 
-<p>
   For example, if you distribute copies of the library, whether gratis
 or for a fee, you must give the recipients all the rights that we gave
 you.  You must make sure that they, too, receive or can get the source
@@ -273,42 +40,32 @@ code.  If you link a program with the library, you must provide
 complete object files to the recipients so that they can relink them
 with the library, after making changes to the library and recompiling
 it.  And you must show them these terms so they know their rights.
-</p>
 
-<p>
   Our method of protecting your rights has two steps: (1) copyright
 the library, and (2) offer you this license which gives you legal
 permission to copy, distribute and/or modify the library.
-</p>
 
-<p>
   Also, for each distributor's protection, we want to make certain
 that everyone understands that there is no warranty for this free
 library.  If the library is modified by someone else and passed on, we
 want its recipients to know that what they have is not the original
 version, so that any problems introduced by others will not reflect on
 the original authors' reputations.
-</p>
-
-<p>
+
   Finally, any free program is threatened constantly by software
 patents.  We wish to avoid the danger that companies distributing free
 software will individually obtain patent licenses, thus in effect
 transforming the program into proprietary software.  To prevent this,
 we have made it clear that any patent must be licensed for everyone's
 free use or not licensed at all.
-</p>
 
-<p>
   Most GNU software, including some libraries, is covered by the ordinary
 GNU General Public License, which was designed for utility programs.  This
 license, the GNU Library General Public License, applies to certain
 designated libraries.  This license is quite different from the ordinary
 one; be sure to read it in full, and don't assume that anything in it is
 the same as in the ordinary license.
-</p>
 
-<p>
   The reason we have a separate public license for some libraries is that
 they blur the distinction we usually make between modifying or adding to a
 program and simply using it.  Linking a program with a library, without
@@ -317,16 +74,12 @@ analogous to running a utility program or application program.  However, in
 a textual and legal sense, the linked executable is a combined work, a
 derivative of the original library, and the ordinary General Public License
 treats it as such.
-</p>
 
-<p>
   Because of this blurred distinction, using the ordinary General
 Public License for libraries did not effectively promote software
 sharing, because most developers did not use the libraries.  We
 concluded that weaker conditions might promote sharing better.
-</p>
 
-<p>
   However, unrestricted linking of non-free programs would deprive the
 users of those programs of all benefit from the free status of the
 libraries themselves.  This Library General Public License is intended to
@@ -336,38 +89,29 @@ libraries that are incorporated in them.  (We have not seen how to achieve
 this as regards changes in header files, but we have achieved it as regards
 changes in the actual functions of the Library.)  The hope is that this
 will lead to faster development of free libraries.
-</p>
 
-<p>
   The precise terms and conditions for copying, distribution and
 modification follow.  Pay close attention to the difference between a
 "work based on the library" and a "work that uses the library".  The
 former contains code derived from the library, while the latter only
 works together with the library.
-</p>
 
-<p>
   Note that it is possible for a library to be covered by the ordinary
 General Public License rather than by this special one.
-</p>
+
+                  GNU LIBRARY GENERAL PUBLIC LICENSE
+   TERMS AND CONDITIONS FOR COPYING, DISTRIBUTION AND MODIFICATION
 
-<h4 id="SEC3">TERMS AND CONDITIONS FOR
-COPYING, DISTRIBUTION AND MODIFICATION</h4>
-
-<p>
-<strong>0.</strong>
- This License Agreement applies to any software library which
+  0. This License Agreement applies to any software library which
 contains a notice placed by the copyright holder or other authorized
 party saying it may be distributed under the terms of this Library
 General Public License (also called "this License").  Each licensee is
 addressed as "you".
-</p>
-<p>
+
   A "library" means a collection of software functions and/or data
 prepared so as to be conveniently linked with application programs
 (which use some of those functions and data) to form executables.
-</p>
-<p>
+
   The "Library", below, refers to any such software library or work
 which has been distributed under these terms.  A "work based on the
 Library" means either the Library or any derivative work under
@@ -375,15 +119,13 @@ copyright law: that is to say, a work containing the Library or a
 portion of it, either verbatim or with modifications and/or translated
 straightforwardly into another language.  (Hereinafter, translation is
 included without limitation in the term "modification".)
-</p>
-<p>
+
   "Source code" for a work means the preferred form of the work for
 making modifications to it.  For a library, complete source code means
 all the source code for all modules it contains, plus any associated
 interface definition files, plus the scripts used to control compilation
 and installation of the library.
-</p>
-<p>
+
   Activities other than copying, distribution and modification are not
 covered by this License; they are outside its scope.  The act of
 running a program using the Library is not restricted, and output from
@@ -391,67 +133,47 @@ such a program is covered only if its contents constitute a work based
 on the Library (independent of the use of the Library in a tool for
 writing it).  Whether that is true depends on what the Library does
 and what the program that uses the Library does.
-</p>
-<p>
-<strong>1.</strong>
- You may copy and distribute verbatim copies of the Library's
+
+  1. You may copy and distribute verbatim copies of the Library's
 complete source code as you receive it, in any medium, provided that
 you conspicuously and appropriately publish on each copy an
 appropriate copyright notice and disclaimer of warranty; keep intact
 all the notices that refer to this License and to the absence of any
 warranty; and distribute a copy of this License along with the
 Library.
-</p>
-<p>
+
   You may charge a fee for the physical act of transferring a copy,
 and you may at your option offer warranty protection in exchange for a
 fee.
-</p>
-<p>
-<strong>2.</strong>
- You may modify your copy or copies of the Library or any portion
+
+  2. You may modify your copy or copies of the Library or any portion
 of it, thus forming a work based on the Library, and copy and
 distribute such modifications or work under the terms of Section 1
 above, provided that you also meet all of these conditions:
-</p>
 
-<!-- we use this doubled UL to get the sub-sections indented, -->
-<!-- while making the bullets as unobvious as possible. -->
-<ul>
+    a) The modified work must itself be a software library.
 
-<li><strong>a)</strong>
-     The modified work must itself be a software library.
-</li>
+    b) You must cause the files modified to carry prominent notices
+    stating that you changed the files and the date of any change.
 
-<li><strong>b)</strong>
-     You must cause the files modified to carry prominent notices
-     stating that you changed the files and the date of any change.
-</li>
+    c) You must cause the whole of the work to be licensed at no
+    charge to all third parties under the terms of this License.
 
-<li><strong>c)</strong>
-     You must cause the whole of the work to be licensed at no
-     charge to all third parties under the terms of this License.
-</li>
+    d) If a facility in the modified Library refers to a function or a
+    table of data to be supplied by an application program that uses
+    the facility, other than as an argument passed when the facility
+    is invoked, then you must make a good faith effort to ensure that,
+    in the event an application does not supply such function or
+    table, the facility still operates, and performs whatever part of
+    its purpose remains meaningful.
 
-<li><strong>d)</strong>
-     If a facility in the modified Library refers to a function or a
-     table of data to be supplied by an application program that uses
-     the facility, other than as an argument passed when the facility
-     is invoked, then you must make a good faith effort to ensure that,
-     in the event an application does not supply such function or
-     table, the facility still operates, and performs whatever part of
-     its purpose remains meaningful.
-     <p>
-     (For example, a function in a library to compute square roots has
-     a purpose that is entirely well-defined independent of the
-     application.  Therefore, Subsection 2d requires that any
-     application-supplied function or table used by this function must
-     be optional: if the application does not supply it, the square
-     root function must still compute square roots.)</p>
-</li>
-</ul>
+    (For example, a function in a library to compute square roots has
+    a purpose that is entirely well-defined independent of the
+    application.  Therefore, Subsection 2d requires that any
+    application-supplied function or table used by this function must
+    be optional: if the application does not supply it, the square
+    root function must still compute square roots.)
 
-<p>
 These requirements apply to the modified work as a whole.  If
 identifiable sections of that work are not derived from the Library,
 and can be reasonably considered independent and separate works in
@@ -462,22 +184,18 @@ on the Library, the distribution of the whole must be on the terms of
 this License, whose permissions for other licensees extend to the
 entire whole, and thus to each and every part regardless of who wrote
 it.
-</p>
-<p>
+
 Thus, it is not the intent of this section to claim rights or contest
 your rights to work written entirely by you; rather, the intent is to
 exercise the right to control the distribution of derivative or
 collective works based on the Library.
-</p>
-<p>
+
 In addition, mere aggregation of another work not based on the Library
 with the Library (or with a work based on the Library) on a volume of
 a storage or distribution medium does not bring the other work under
 the scope of this License.
-</p>
-<p>
-<strong>3.</strong>
- You may opt to apply the terms of the ordinary GNU General Public
+
+  3. You may opt to apply the terms of the ordinary GNU General Public
 License instead of this License to a given copy of the Library.  To do
 this, you must alter all the notices that refer to this License, so
 that they refer to the ordinary GNU General Public License, version 2,
@@ -485,79 +203,65 @@ instead of to this License.  (If a newer version than version 2 of the
 ordinary GNU General Public License has appeared, then you can specify
 that version instead if you wish.)  Do not make any other change in
 these notices.
-</p>
-<p>
+
   Once this change is made in a given copy, it is irreversible for
 that copy, so the ordinary GNU General Public License applies to all
 subsequent copies and derivative works made from that copy.
-</p>
-<p>
+
   This option is useful when you wish to copy part of the code of
 the Library into a program that is not a library.
-</p>
-<p>
-<strong>4.</strong>
- You may copy and distribute the Library (or a portion or
+
+  4. You may copy and distribute the Library (or a portion or
 derivative of it, under Section 2) in object code or executable form
 under the terms of Sections 1 and 2 above provided that you accompany
 it with the complete corresponding machine-readable source code, which
 must be distributed under the terms of Sections 1 and 2 above on a
 medium customarily used for software interchange.
-</p>
-<p>
+
   If distribution of object code is made by offering access to copy
 from a designated place, then offering equivalent access to copy the
 source code from the same place satisfies the requirement to
 distribute the source code, even though third parties are not
 compelled to copy the source along with the object code.
-</p>
-<p>
-<strong>5.</strong>
- A program that contains no derivative of any portion of the
+
+  5. A program that contains no derivative of any portion of the
 Library, but is designed to work with the Library by being compiled or
 linked with it, is called a "work that uses the Library".  Such a
 work, in isolation, is not a derivative work of the Library, and
 therefore falls outside the scope of this License.
-</p>
-<p>
+
   However, linking a "work that uses the Library" with the Library
 creates an executable that is a derivative of the Library (because it
 contains portions of the Library), rather than a "work that uses the
 library".  The executable is therefore covered by this License.
 Section 6 states terms for distribution of such executables.
-</p>
-<p>
+
   When a "work that uses the Library" uses material from a header file
 that is part of the Library, the object code for the work may be a
 derivative work of the Library even though the source code is not.
 Whether this is true is especially significant if the work can be
 linked without the Library, or if the work is itself a library.  The
 threshold for this to be true is not precisely defined by law.
-</p>
-<p>
+
   If such an object file uses only numerical parameters, data
 structure layouts and accessors, and small macros and small inline
 functions (ten lines or less in length), then the use of the object
 file is unrestricted, regardless of whether it is legally a derivative
 work.  (Executables containing this object code plus portions of the
 Library will still fall under Section 6.)
-</p>
-<p>
+
   Otherwise, if the work is a derivative of the Library, you may
 distribute the object code for the work under the terms of Section 6.
 Any executables containing that work also fall under Section 6,
 whether or not they are linked directly with the Library itself.
-</p>
-<p>
-<strong>6.</strong>
- As an exception to the Sections above, you may also compile or
+
+  6. As an exception to the Sections above, you may also compile or
 link a "work that uses the Library" with the Library to produce a
 work containing portions of the Library, and distribute that work
 under terms of your choice, provided that the terms permit
 modification of the work for the customer's own use and reverse
 engineering for debugging such modifications.
-</p>
-<p>
+
   You must give prominent notice with each copy of the work that the
 Library is used in it and that the Library and its use are covered by
 this License.  You must supply a copy of this License.  If the work
@@ -565,43 +269,31 @@ during execution displays copyright notices, you must include the
 copyright notice for the Library among them, as well as a reference
 directing the user to the copy of this License.  Also, you must do one
 of these things:
-</p>
 
-<ul>
-<li><strong>a)</strong>
-     Accompany the work with the complete corresponding
-     machine-readable source code for the Library including whatever
-     changes were used in the work (which must be distributed under
-     Sections 1 and 2 above); and, if the work is an executable linked
-     with the Library, with the complete machine-readable "work that
-     uses the Library", as object code and/or source code, so that the
-     user can modify the Library and then relink to produce a modified
-     executable containing the modified Library.  (It is understood
-     that the user who changes the contents of definitions files in the
-     Library will not necessarily be able to recompile the application
-     to use the modified definitions.)
-</li>
+    a) Accompany the work with the complete corresponding
+    machine-readable source code for the Library including whatever
+    changes were used in the work (which must be distributed under
+    Sections 1 and 2 above); and, if the work is an executable linked
+    with the Library, with the complete machine-readable "work that
+    uses the Library", as object code and/or source code, so that the
+    user can modify the Library and then relink to produce a modified
+    executable containing the modified Library.  (It is understood
+    that the user who changes the contents of definitions files in the
+    Library will not necessarily be able to recompile the application
+    to use the modified definitions.)
 
-<li><strong>b)</strong>
-     Accompany the work with a written offer, valid for at
-     least three years, to give the same user the materials
-     specified in Subsection 6a, above, for a charge no more
-     than the cost of performing this distribution.
-</li>
+    b) Accompany the work with a written offer, valid for at
+    least three years, to give the same user the materials
+    specified in Subsection 6a, above, for a charge no more
+    than the cost of performing this distribution.
 
-<li><strong>c)</strong>
-     If distribution of the work is made by offering access to copy
-     from a designated place, offer equivalent access to copy the above
-     specified materials from the same place.
-</li>
+    c) If distribution of the work is made by offering access to copy
+    from a designated place, offer equivalent access to copy the above
+    specified materials from the same place.
 
-<li><strong>d)</strong>
-     Verify that the user has already received a copy of these
-     materials or that you have already sent this user a copy.
-</li>
-</ul>
+    d) Verify that the user has already received a copy of these
+    materials or that you have already sent this user a copy.
 
-<p>
   For an executable, the required form of the "work that uses the
 Library" must include any data and utility programs needed for
 reproducing the executable from it.  However, as a special exception,
@@ -610,52 +302,38 @@ distributed (in either source or binary form) with the major
 components (compiler, kernel, and so on) of the operating system on
 which the executable runs, unless that component itself accompanies
 the executable.
-</p>
-<p>
+
   It may happen that this requirement contradicts the license
 restrictions of other proprietary libraries that do not normally
 accompany the operating system.  Such a contradiction means you cannot
 use both them and the Library together in an executable that you
 distribute.
-</p>
-<p>
-<strong>7.</strong>
- You may place library facilities that are a work based on the
+
+  7. You may place library facilities that are a work based on the
 Library side-by-side in a single library together with other library
 facilities not covered by this License, and distribute such a combined
 library, provided that the separate distribution of the work based on
 the Library and of the other library facilities is otherwise
 permitted, and provided that you do these two things:
-</p>
 
-<ul>
-<li><strong>a)</strong>
-     Accompany the combined library with a copy of the same work
-     based on the Library, uncombined with any other library
-     facilities.  This must be distributed under the terms of the
-     Sections above.
-</li>
+    a) Accompany the combined library with a copy of the same work
+    based on the Library, uncombined with any other library
+    facilities.  This must be distributed under the terms of the
+    Sections above.
 
-<li><strong>b)</strong>
-     Give prominent notice with the combined library of the fact
-     that part of it is a work based on the Library, and explaining
-     where to find the accompanying uncombined form of the same work.
-</li>
-</ul>
+    b) Give prominent notice with the combined library of the fact
+    that part of it is a work based on the Library, and explaining
+    where to find the accompanying uncombined form of the same work.
 
-<p>
-<strong>8.</strong>
- You may not copy, modify, sublicense, link with, or distribute
+  8. You may not copy, modify, sublicense, link with, or distribute
 the Library except as expressly provided under this License.  Any
 attempt otherwise to copy, modify, sublicense, link with, or
 distribute the Library is void, and will automatically terminate your
 rights under this License.  However, parties who have received copies,
 or rights, from you under this License will not have their licenses
 terminated so long as such parties remain in full compliance.
-</p>
-<p>
-<strong>9.</strong>
- You are not required to accept this License, since you have not
+
+  9. You are not required to accept this License, since you have not
 signed it.  However, nothing else grants you permission to modify or
 distribute the Library or its derivative works.  These actions are
 prohibited by law if you do not accept this License.  Therefore, by
@@ -663,20 +341,16 @@ modifying or distributing the Library (or any work based on the
 Library), you indicate your acceptance of this License to do so, and
 all its terms and conditions for copying, distributing or modifying
 the Library or works based on it.
-</p>
-<p>
-<strong>10.</strong>
- Each time you redistribute the Library (or any work based on the
+
+  10. Each time you redistribute the Library (or any work based on the
 Library), the recipient automatically receives a license from the
 original licensor to copy, distribute, link with or modify the Library
 subject to these terms and conditions.  You may not impose any further
 restrictions on the recipients' exercise of the rights granted herein.
 You are not responsible for enforcing compliance by third parties to
 this License.
-</p>
-<p>
-<strong>11.</strong>
- If, as a consequence of a court judgment or allegation of patent
+
+  11. If, as a consequence of a court judgment or allegation of patent
 infringement or for any other reason (not limited to patent issues),
 conditions are imposed on you (whether by court order, agreement or
 otherwise) that contradict the conditions of this License, they do not
@@ -688,13 +362,11 @@ license would not permit royalty-free redistribution of the Library by
 all those who receive copies directly or indirectly through you, then
 the only way you could satisfy both it and this License would be to
 refrain entirely from distribution of the Library.
-</p>
-<p>
+
 If any portion of this section is held invalid or unenforceable under any
 particular circumstance, the balance of the section is intended to apply,
 and the section as a whole is intended to apply in other circumstances.
-</p>
-<p>
+
 It is not the purpose of this section to induce you to infringe any
 patents or other property right claims or to contest validity of any
 such claims; this section has the sole purpose of protecting the
@@ -705,29 +377,23 @@ through that system in reliance on consistent application of that
 system; it is up to the author/donor to decide if he or she is willing
 to distribute software through any other system and a licensee cannot
 impose that choice.
-</p>
-<p>
+
 This section is intended to make thoroughly clear what is believed to
 be a consequence of the rest of this License.
-</p>
-<p>
-<strong>12.</strong>
- If the distribution and/or use of the Library is restricted in
+
+  12. If the distribution and/or use of the Library is restricted in
 certain countries either by patents or by copyrighted interfaces, the
 original copyright holder who places the Library under this License may add
 an explicit geographical distribution limitation excluding those countries,
 so that distribution is permitted only in or among countries not thus
 excluded.  In such case, this License incorporates the limitation as if
 written in the body of this License.
-</p>
-<p>
-<strong>13.</strong>
- The Free Software Foundation may publish revised and/or new
+
+  13. The Free Software Foundation may publish revised and/or new
 versions of the Library General Public License from time to time.
 Such new versions will be similar in spirit to the present version,
 but may differ in detail to address new problems or concerns.
-</p>
-<p>
+
 Each version is given a distinguishing version number.  If the Library
 specifies a version number of this License which applies to it and
 "any later version", you have the option of following the terms and
@@ -735,10 +401,8 @@ conditions either of that version or of any later version published by
 the Free Software Foundation.  If the Library does not specify a
 license version number, you may choose any version ever published by
 the Free Software Foundation.
-</p>
-<p>
-<strong>14.</strong>
- If you wish to incorporate parts of the Library into other free
+
+  14. If you wish to incorporate parts of the Library into other free
 programs whose distribution conditions are incompatible with these,
 write to the author to ask for permission.  For software which is
 copyrighted by the Free Software Foundation, write to the Free
@@ -746,13 +410,10 @@ Software Foundation; we sometimes make exceptions for this.  Our
 decision will be guided by the two goals of preserving the free status
 of all derivatives of our free software and of promoting the sharing
 and reuse of software generally.
-</p>
 
-<p><strong>NO WARRANTY</strong></p>
+                            NO WARRANTY
 
-<p>
-<strong>15.</strong>
- BECAUSE THE LIBRARY IS LICENSED FREE OF CHARGE, THERE IS NO
+  15. BECAUSE THE LIBRARY IS LICENSED FREE OF CHARGE, THERE IS NO
 WARRANTY FOR THE LIBRARY, TO THE EXTENT PERMITTED BY APPLICABLE LAW.
 EXCEPT WHEN OTHERWISE STATED IN WRITING THE COPYRIGHT HOLDERS AND/OR
 OTHER PARTIES PROVIDE THE LIBRARY "AS IS" WITHOUT WARRANTY OF ANY
@@ -761,10 +422,8 @@ IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR
 PURPOSE.  THE ENTIRE RISK AS TO THE QUALITY AND PERFORMANCE OF THE
 LIBRARY IS WITH YOU.  SHOULD THE LIBRARY PROVE DEFECTIVE, YOU ASSUME
 THE COST OF ALL NECESSARY SERVICING, REPAIR OR CORRECTION.
-</p>
-<p>
-<strong>16.</strong>
- IN NO EVENT UNLESS REQUIRED BY APPLICABLE LAW OR AGREED TO IN
+
+  16. IN NO EVENT UNLESS REQUIRED BY APPLICABLE LAW OR AGREED TO IN
 WRITING WILL ANY COPYRIGHT HOLDER, OR ANY OTHER PARTY WHO MAY MODIFY
 AND/OR REDISTRIBUTE THE LIBRARY AS PERMITTED ABOVE, BE LIABLE TO YOU
 FOR DAMAGES, INCLUDING ANY GENERAL, SPECIAL, INCIDENTAL OR
@@ -774,182 +433,48 @@ RENDERED INACCURATE OR LOSSES SUSTAINED BY YOU OR THIRD PARTIES OR A
 FAILURE OF THE LIBRARY TO OPERATE WITH ANY OTHER SOFTWARE), EVEN IF
 SUCH HOLDER OR OTHER PARTY HAS BEEN ADVISED OF THE POSSIBILITY OF SUCH
 DAMAGES.
-</p>
 
-<h4>END OF TERMS AND CONDITIONS</h4>
+                     END OF TERMS AND CONDITIONS
+
+           How to Apply These Terms to Your New Libraries
 
-<h4 id="SEC4">How to Apply These Terms to Your New Libraries</h4>
-
-<p>
   If you develop a new library, and you want it to be of the greatest
 possible use to the public, we recommend making it free software that
 everyone can redistribute and change.  You can do so by permitting
 redistribution under these terms (or, alternatively, under the terms of the
 ordinary General Public License).
-</p>
-<p>
+
   To apply these terms, attach the following notices to the library.  It is
 safest to attach them to the start of each source file to most effectively
 convey the exclusion of warranty; and each file should have at least the
 "copyright" line and a pointer to where the full notice is found.
-</p>
 
-<pre>
-<var>one line to give the library's name and an idea of what it does.</var>
-Copyright (C) <var>year</var>  <var>name of author</var>
+    <one line to give the library's name and a brief idea of what it does.>
+    Copyright (C) <year>  <name of author>
 
-This library is free software; you can redistribute it and/or
-modify it under the terms of the GNU Library General Public
-License as published by the Free Software Foundation; either
-version 2 of the License, or (at your option) any later version.
+    This library is free software; you can redistribute it and/or
+    modify it under the terms of the GNU Library General Public
+    License as published by the Free Software Foundation; either
+    version 2 of the License, or (at your option) any later version.
 
-This library is distributed in the hope that it will be useful,
-but WITHOUT ANY WARRANTY; without even the implied warranty of
-MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
-Library General Public License for more details.
+    This library is distributed in the hope that it will be useful,
+    but WITHOUT ANY WARRANTY; without even the implied warranty of
+    MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+    Library General Public License for more details.
 
-You should have received a copy of the GNU Library General Public
-License along with this library; if not, see
-&lt;<a href="https://www.gnu.org/licenses/">https://www.gnu.org/licenses/</a>&gt;.
-</pre>
+    You should have received a copy of the GNU Library General Public
+    License along with this library; if not, see <https://www.gnu.org/licenses/>.
 
-<p>
 Also add information on how to contact you by electronic and paper mail.
-</p>
-<p>
+
 You should also get your employer (if you work as a programmer) or your
 school, if any, to sign a "copyright disclaimer" for the library, if
 necessary.  Here is a sample; alter the names:
-</p>
 
-<pre>
-Yoyodyne, Inc., hereby disclaims all copyright interest in
-the library `Frob' (a library for tweaking knobs) written
-by James Random Hacker.
+  Yoyodyne, Inc., hereby disclaims all copyright interest in the
+  library `Frob' (a library for tweaking knobs) written by James Random Hacker.
 
-<var>signature of Moe Ghoul</var>, 1 April 1990
-Moe Ghoul, President of Vice
-</pre>
+  <signature of Moe Ghoul>, 1 April 1990
+  Moe Ghoul, President of Vice
 
-<p>
-That's all there is to it!</p>
-
-</div>
-</div>
-
-</div><!-- for id="content", starts in the include above -->
-
-              <!-- begin server/footer-text.html -->
-
-
-
-
-
-<div style="clear:both"></div>
-
-
-<div id="language-container">
- <div class="backtotop">
-  <hr class="no-display" />
-  <a href="#top"><b>&#9650;</b></a>
- </div>
- <div id="languages" class="rounded-corners">
-  <div class="button">
-   <a href="#top" class="close"><span>BACK TO TOP</span></a>
-  </div>
-  <div id="set-language" class="button">
-   <span class="gnun-split"></span>
-   <a href="/server/select-language.html?callback=/licenses/old-licenses/lgpl-2.0" rel="nofollow">
-   Set language
-   <span class="gnun-split"></span>
-   </a>
-  </div>
-  <p>Available for this page:</p>
-  <div id="translations">
-<p>
-<span dir="ltr" class="original">[en]&nbsp;<a lang="en" hreflang="en" href="/licenses/old-licenses/lgpl-2.0.en.html">English</a> &nbsp;</span>
-<span dir="ltr">[de]&nbsp;<a lang="de" hreflang="de" href="/licenses/old-licenses/lgpl-2.0.de.html">Deutsch</a> &nbsp;</span>
-<span dir="ltr">[fr]&nbsp;<a lang="fr" hreflang="fr" href="/licenses/old-licenses/lgpl-2.0.fr.html">français</a> &nbsp;</span>
-<span dir="ltr">[ja]&nbsp;<a lang="ja" hreflang="ja" href="/licenses/old-licenses/lgpl-2.0.ja.html">日本語</a> &nbsp;</span>
-<span dir="ltr">[pt-br]&nbsp;<a lang="pt-br" hreflang="pt-br" href="/licenses/old-licenses/lgpl-2.0.pt-br.html">português</a> &nbsp;</span>
-<span dir="ltr">[ru]&nbsp;<a lang="ru" hreflang="ru" href="/licenses/old-licenses/lgpl-2.0.ru.html">русский</a> &nbsp;</span>
-<span dir="ltr">[uk]&nbsp;<a lang="uk" hreflang="uk" href="/licenses/old-licenses/lgpl-2.0.uk.html">українська</a> &nbsp;</span>
-<span dir="ltr">[zh-cn]&nbsp;<a lang="zh-cn" hreflang="zh-cn" href="/licenses/old-licenses/lgpl-2.0.zh-cn.html">简体中文</a> &nbsp;</span>
-</p>
-</div>
- </div>
-</div>
-
-<div id="mission-statement" role="complementary">
- <div class="backtotop">
-  <hr class="no-display" />
-  <a href="#header"><span>BACK TO TOP </span>&#9650;</a>
- </div>
-<div style="clear: both"></div>
-<blockquote>
-<p style="direction:ltr; text-align:left"><a href="//www.fsf.org"><img id="fsfbanner"
-src="/graphics/fsf-logo-notext-small.png" alt="&nbsp;[FSF logo]&nbsp;"
-width="75" height="25" /></a><strong>
-&ldquo;The Free Software Foundation (FSF) is a nonprofit with a worldwide
-mission to promote computer user freedom. We defend the rights of all
-software users.&rdquo;</strong></p>
-</blockquote>
-
-<div id="support-the-fsf" class="button">
- <a class="join" href="//www.fsf.org/associate/support_freedom?referrer=4052">JOIN</a>
- <a class="donate" href="//donate.fsf.org/">DONATE</a>
- <a class="shop" href="//shop.fsf.org/">SHOP</a>
-</div>
-</div>
-<!-- end server/footer-text.html -->
-
-
-<div id="footer" role="contentinfo">
-<div class="unprintable">
-
-<p>Please send general FSF &amp; GNU inquiries to
-<a href="mailto:gnu@gnu.org">&lt;gnu@gnu.org&gt;</a>.
-There are also <a href="/contact/">other ways to contact</a>
-the FSF.  Broken links and other corrections or suggestions can be sent
-to <a href="mailto:webmasters@gnu.org">&lt;webmasters@gnu.org&gt;</a>.</p>
-
-<p><!-- TRANSLATORS: Ignore the original text in this paragraph,
-        replace it with the translation of these two:
-
-        We work hard and do our best to provide accurate, good quality
-        translations.  However, we are not exempt from imperfection.
-        Please send your comments and general suggestions in this regard
-        to <a href="mailto:web-translators@gnu.org">
-        &lt;web-translators@gnu.org&gt;</a>.</p>
-
-        <p>For information on coordinating and contributing translations of
-        our web pages, see <a
-        href="/server/standards/README.translations.html">Translations
-        README</a>. -->
-Please see the <a
-href="/server/standards/README.translations.html">Translations
-README</a> for information on coordinating and contributing translations
-of this article.</p>
-</div>
-
-<p>Copyright notice above.</p>
-
-<!-- start of server/bottom-notes.html -->
-<div id="bottom-notes" class="unprintable">
-<p><a href="//www.fsf.org/about/dmca-notice">Copyright Infringement Notification</a></p>
-<div id="generic">
-
-
-</div>
-</div>
-<!-- end of server/bottom-notes.html -->
-
-
-<p class="unprintable">Updated:
-<!-- timestamp start -->
-$Date: 2023/11/30 09:46:01 $
-<!-- timestamp end --></p>
-</div>
-</div><!-- for class="inner", starts in the banner include -->
-</body>
-</html>
+That's all there is to it!

--- a/licenses-generator/src/main/resources/offline-license-mirror/www.gnu.org/licenses/old-licenses/lgpl-2.1
+++ b/licenses-generator/src/main/resources/offline-license-mirror/www.gnu.org/licenses/old-licenses/lgpl-2.1
@@ -1,252 +1,29 @@
-<!DOCTYPE html>
-<html xmlns="http://www.w3.org/1999/xhtml" xml:lang="en" lang="en">
-<head>
-<meta http-equiv="content-type" content="text/html; charset=utf-8" />
-<link rel="author" href="mailto:webmasters@gnu.org" />
-<link rel="icon" type="image/png" href="/graphics/gnu-head-mini.png" />
-<meta name="ICBM" content="42.355469,-71.058627" />
-<link rel="stylesheet" type="text/css" href="/layout.min.css" media="screen" />
-<link rel="stylesheet" type="text/css" href="/print.min.css" media="print" />
+                  GNU LESSER GENERAL PUBLIC LICENSE
+                       Version 2.1, February 1999
 
-
-
-<!-- Parent-Version: 1.98 -->
-<!-- This page is derived from /server/standards/boilerplate.html -->
-<title>GNU Lesser General Public License v2.1 - GNU Project - Free Software Foundation</title>
-<link rel="alternate" type="application/rdf+xml" href="lgpl-2.1.rdf" /> 
-<!-- begin translist file -->
-
-<link rel="alternate" type="text/html" href="/licenses/old-licenses/lgpl-2.1.html" hreflang="x-default" />
-<link rel="alternate" type="text/html" lang="en" hreflang="en" href="/licenses/old-licenses/lgpl-2.1.en.html" title="English" />
-<link rel="alternate" type="text/html" lang="de" hreflang="de" href="/licenses/old-licenses/lgpl-2.1.de.html" title="Deutsch" />
-<link rel="alternate" type="text/html" lang="fr" hreflang="fr" href="/licenses/old-licenses/lgpl-2.1.fr.html" title="français" />
-<link rel="alternate" type="text/html" lang="ja" hreflang="ja" href="/licenses/old-licenses/lgpl-2.1.ja.html" title="日本語" />
-<link rel="alternate" type="text/html" lang="pt-br" hreflang="pt-br" href="/licenses/old-licenses/lgpl-2.1.pt-br.html" title="português" />
-<link rel="alternate" type="text/html" lang="ru" hreflang="ru" href="/licenses/old-licenses/lgpl-2.1.ru.html" title="русский" />
-<link rel="alternate" type="text/html" lang="uk" hreflang="uk" href="/licenses/old-licenses/lgpl-2.1.uk.html" title="українська" />
-<link rel="alternate" type="text/html" lang="zh-cn" hreflang="zh-cn" href="/licenses/old-licenses/lgpl-2.1.zh-cn.html" title="简体中文" />
-<!-- end translist file -->
-
-<!-- start of server/banner.html -->
-<!-- start of head-include-2.html -->
-<meta name="viewport" content="width=device-width, initial-scale=1" />
-<!-- end of head-include-2.html -->
-
-</head>
-<body>
-<div class="inner">
-<!-- start of server/body-include-1.html -->
-<div id="top">
-<a class="skip" href="#content"><b>Skip to main text</b></a>
-</div>
-
-<div id="fsf-frame" role="complementary">
-<form id="fssbox" action="https://my.fsf.org/civicrm/profile/create?reset=1&amp;gid=31"
-      method="post">
- <div>
-  <input name="postURL" type="hidden" value="" />
-  <input type="hidden" name="group[25]" value="1" />
-  <input name="cancelURL" type="hidden" value="https://crm.fsf.org/civicrm/profile?reset=1&amp;gid=31" />
-  <input name="_qf_default" type="hidden" value="Edit:cancel" />
-  <label for="frmEmail">
-   <a href="//www.fsf.org/fss">Free Software Supporter</a>:
-  </label>
-  <input type="text" id="frmEmail" name="email-Primary" size="18" maxlength="80"
-         value="email address" onfocus="this.value=''"/>
-  <input type="submit" name="_qf_Edit_next" value="Sign up" />
- </div>
-</form>
-
-<div id="join-fsf" class="button"><a
-href="https://www.fsf.org/associate/support_freedom?referrer=4052">JOIN&nbsp;THE&nbsp;FSF</a>
-</div>
-</div>
-
-<div id="header" role="banner">
-<p id="gnu-banner">
- <a href="/">
- <img src="/graphics/heckert_gnu.transp.small.png" height="48" width="49"
-      alt="&nbsp;[A GNU head]&nbsp;" /><strong>GNU</strong> <span
- class="hide">Operating System</span></a><br />
- <small id="fsf-support">Supported by the
- <a href="#mission-statement">Free Software Foundation</a></small>
-</p>
-
-<div id="switches">
-<!-- begin search button -->
- <div  id="search-button" class="switch">
-  <a href="//www.gnu.org/cgi-bin/estseek.cgi">
-  <img id="search-icon" height="30" width="30"
-       src="/graphics/icons/search.png"
-       alt="&nbsp;[Search www.gnu.org]&nbsp;" /></a>
- </div>
-<!-- end search button -->
-
- <div id="language-button" class="switch">
-  <a href="#language-container">
-  <img id="language-icon" height="30" width="37"
-       src="/graphics/icons/translations.png"
-       alt="&nbsp;[Other languages]&nbsp;" /></a>
- </div>
-
-</div>
-</div>
-<!-- end of server/body-include-1.html -->
-
-<!-- start of server/body-include-2 -->
-
-
-<div style="clear: both"></div>
-
-<div id="navigation" role="navigation">
- <a id="more-links" href="#navigation" title="More...">
-   <span>Site navigation</span></a>
- <a id="less-links" href="#content"><b>Skip</b></a>
- <ul>
-
-   <li id="tabAboutGNU"><a href="/gnu/gnu.html">ABOUT&nbsp;GNU</a></li>
-
-
-  <li id="tabPhilosophy"><a href="/philosophy/philosophy.html">PHILOSOPHY</a></li>
-
-
-  <li id="tabLicenses" class="active">
-     <span class='no-display'>=</span> 
-    <a href="/licenses/licenses.html">LICENSES</a>
-    <span class="gnun-split"></span>
-     <span class='no-display'>=</span> 
-  </li>
-
-
-  <li id="tabEducation"><a href="/education/education.html">EDUCATION</a></li>
-
-
-  <li id="tabSoftware"><a href="/software/software.html">SOFTWARE</a></li>
-
-
-  <li id="tabDistros"><a href="/distros/distros.html">DISTROS</a></li>
-
-
-  <li id="tabDoc"><a href="/doc/doc.html">DOCS</a></li>
-
-
-  <li id="tabMalware"><a href="/proprietary/proprietary.html">MALWARE</a></li>
-
-
-  <li id="tabHelp"><a href="/help/help.html">HELP&nbsp;GNU</a></li>
-
-
-  <li id="tabAV"><a href="/audio-video/audio-video.html">AUDIO&nbsp;&amp;&nbsp;VIDEO</a></li>
-
-
-  <li id="tabArt"><a href="/graphics/graphics.html">GNU&nbsp;ART</a></li>
-
-
-  <li id="tabFun"><a href="/fun/humor.html">FUN</a></li>
-
-
-  <li id="tabPeople"><a href="/people/people.html">GNU'S&nbsp;WHO?</a></li>
-
-  <li><a href="//directory.fsf.org">SOFTWARE&nbsp;DIRECTORY</a></li>
-  <li><a href="https://h-node.org/">HARDWARE</a></li>
-  <li><a href="/server/sitemap.html">SITEMAP</a></li>
- </ul>
- <div style="clear: both"></div>
-</div><!-- /"navigation -->
-<!-- end of server/body-include-2 -->
-
-<div id="content" role="main">
-<!-- end of server/banner.html -->
-
-<div class="reduced-width">
-<h2>GNU Lesser General Public License, version&nbsp;2.1</h2>
-
-<p class="button" style="margin: 2em 1.5em">
-  <b><a href="#SEC1">Skip to license text</a></b></p>
-
-<ul>
-  <li><a href="/licenses/lgpl.html">The latest version of the LGPL, version
-    3</a></li>
-  <li><a href="/licenses/why-not-lgpl.html">Why you shouldn't use the Lesser
-    GPL for your next library</a></li>
-  <li><a href="/licenses/gpl-violation.html">What to do if you see a possible
-    LGPL violation</a></li>
-  <li><a href="/licenses/old-licenses/lgpl-2.1-translations.html">Translations
-    of LGPLv2.1</a></li>
-  <li>The GNU Lesser General Public License version 2.1 (LGPLv2.1) in other
-    formats: <a href="/licenses/old-licenses/lgpl-2.1.txt">plain text</a>, <a
-    href="/licenses/old-licenses/lgpl-2.1.texi">Texinfo</a>, <a
-    href="/licenses/old-licenses/lgpl-2.1-standalone.html">standalone HTML</a>, <a
-    href="/licenses/old-licenses/lgpl-2.1.dbk">Docbook</a>, 
-    <a href="/licenses/old-licenses/lgpl-2.1.md">Markdown</a>, 
-    <a href="/licenses/old-licenses/lgpl-2.1.odt">ODF</a>, 
-    <a href="/licenses/old-licenses/lgpl-2.1.rtf">RTF</a>, and
-    <a href="/licenses/old-licenses/lgpl-2.1.tex">LaTeX</a>
-</li>
-  <li><a href="/licenses/old-licenses/old-licenses.html#LGPL">Old versions of
-    the LGPL</a></li>
-</ul>
-
-<div class="thin"></div>
-
-<p>This GNU Lesser General Public License counts as the successor of the GNU
-Library General Public License. For an explanation of why this change was
-necessary, read the <a href="/licenses/why-not-lgpl.html">Why you shouldn't use
-the Lesser GPL for your next library</a> article.</p>
-
-<h3>Table of Contents</h3>
-<ul>
-  <li><a id="TOC1" href="#SEC1">GNU LESSER GENERAL PUBLIC LICENSE</a> 
-    <ul>
-      <li><a id="TOC2" href="#SEC2">Preamble</a></li>
-      <li><a id="TOC3" href="#SEC3">TERMS AND CONDITIONS FOR COPYING,
-        DISTRIBUTION AND MODIFICATION</a></li>
-      <li><a id="TOC4" href="#SEC4">How to Apply These Terms to Your New
-        Libraries</a></li>
-    </ul>
-  </li>
-</ul>
-
-<hr class="thin" />
-
-<!-- The license text is in English and appears broken in RTL as
-Arabic, Farsi, etc. Explicitly set the direction to override the
-one defined in the translation. -->
-<div dir="ltr">
-<h3 id="SEC1">GNU LESSER GENERAL PUBLIC LICENSE</h3>
-<p>
-Version 2.1, February 1999
-</p>
-
-<pre>
-Copyright (C) 1991, 1999 Free Software Foundation, Inc.
-&lt;<a href="https://fsf.org/">https://fsf.org/</a>&gt;
-Everyone is permitted to copy and distribute verbatim copies
-of this license document, but changing it is not allowed.
+ Copyright (C) 1991, 1999 Free Software Foundation, Inc.
+ <https://fsf.org/>
+ Everyone is permitted to copy and distribute verbatim copies
+ of this license document, but changing it is not allowed.
 
 [This is the first released version of the Lesser GPL.  It also counts
  as the successor of the GNU Library Public License, version 2, hence
  the version number 2.1.]
-</pre>
 
+                            Preamble
 
-<h4 id="SEC2">Preamble</h4>
-
-<p>
   The licenses for most software are designed to take away your
 freedom to share and change it.  By contrast, the GNU General Public
 Licenses are intended to guarantee your freedom to share and change
 free software--to make sure the software is free for all its users.
-</p>
-<p>
+
   This license, the Lesser General Public License, applies to some
 specially designated software packages--typically libraries--of the
 Free Software Foundation and other authors who decide to use it.  You
 can use it too, but we suggest you first think carefully about whether
 this license or the ordinary General Public License is the better
 strategy to use in any particular case, based on the explanations below.
-</p>
-<p>
+
   When we speak of free software, we are referring to freedom of use,
 not price.  Our General Public Licenses are designed to make sure that
 you have the freedom to distribute copies of free software (and charge
@@ -254,14 +31,12 @@ for this service if you wish); that you receive source code or can get
 it if you want it; that you can change the software and use pieces of
 it in new free programs; and that you are informed that you can do
 these things.
-</p>
-<p>
+
   To protect your rights, we need to make restrictions that forbid
 distributors to deny you these rights or to ask you to surrender these
 rights.  These restrictions translate to certain responsibilities for
 you if you distribute copies of the library or if you modify it.
-</p>
-<p>
+
   For example, if you distribute copies of the library, whether gratis
 or for a fee, you must give the recipients all the rights that we gave
 you.  You must make sure that they, too, receive or can get the source
@@ -269,37 +44,32 @@ code.  If you link other code with the library, you must provide
 complete object files to the recipients, so that they can relink them
 with the library after making changes to the library and recompiling
 it.  And you must show them these terms so they know their rights.
-</p>
-<p>
+
   We protect your rights with a two-step method: (1) we copyright the
 library, and (2) we offer you this license, which gives you legal
 permission to copy, distribute and/or modify the library.
-</p>
-<p>
+
   To protect each distributor, we want to make it very clear that
 there is no warranty for the free library.  Also, if the library is
 modified by someone else and passed on, the recipients should know
 that what they have is not the original version, so that the original
 author's reputation will not be affected by problems that might be
 introduced by others.
-</p>
-<p>
+
   Finally, software patents pose a constant threat to the existence of
 any free program.  We wish to make sure that a company cannot
 effectively restrict the users of a free program by obtaining a
 restrictive license from a patent holder.  Therefore, we insist that
 any patent license obtained for a version of the library must be
 consistent with the full freedom of use specified in this license.
-</p>
-<p>
+
   Most GNU software, including some libraries, is covered by the
 ordinary GNU General Public License.  This license, the GNU Lesser
 General Public License, applies to certain designated libraries, and
 is quite different from the ordinary General Public License.  We use
 this license for certain libraries in order to permit linking those
 libraries into non-free programs.
-</p>
-<p>
+
   When a program is linked with a library, whether statically or using
 a shared library, the combination of the two is legally speaking a
 combined work, a derivative of the original library.  The ordinary
@@ -307,8 +77,7 @@ General Public License therefore permits such linking only if the
 entire combination fits its criteria of freedom.  The Lesser General
 Public License permits more lax criteria for linking other code with
 the library.
-</p>
-<p>
+
   We call this license the "Lesser" General Public License because it
 does Less to protect the user's freedom than the ordinary General
 Public License.  It also provides other free software developers Less
@@ -316,8 +85,7 @@ of an advantage over competing non-free programs.  These disadvantages
 are the reason we use the ordinary General Public License for many
 libraries.  However, the Lesser license provides advantages in certain
 special circumstances.
-</p>
-<p>
+
   For example, on rare occasions, there may be a special need to
 encourage the widest possible use of a certain library, so that it becomes
 a de-facto standard.  To achieve this, non-free programs must be
@@ -325,46 +93,38 @@ allowed to use the library.  A more frequent case is that a free
 library does the same job as widely used non-free libraries.  In this
 case, there is little to gain by limiting the free library to free
 software only, so we use the Lesser General Public License.
-</p>
-<p>
+
   In other cases, permission to use a particular library in non-free
 programs enables a greater number of people to use a large body of
 free software.  For example, permission to use the GNU C Library in
 non-free programs enables many more people to use the whole GNU
 operating system, as well as its variant, the GNU/Linux operating
 system.
-</p>
-<p>
+
   Although the Lesser General Public License is Less protective of the
 users' freedom, it does ensure that the user of a program that is
 linked with the Library has the freedom and the wherewithal to run
 that program using a modified version of the Library.
-</p>
-<p>
+
   The precise terms and conditions for copying, distribution and
 modification follow.  Pay close attention to the difference between a
 "work based on the library" and a "work that uses the library".  The
 former contains code derived from the library, whereas the latter must
 be combined with the library in order to run.
-</p>
+
+                  GNU LESSER GENERAL PUBLIC LICENSE
+   TERMS AND CONDITIONS FOR COPYING, DISTRIBUTION AND MODIFICATION
 
-<h4 id="SEC3">TERMS AND CONDITIONS FOR COPYING, DISTRIBUTION AND MODIFICATION</h4>
-
-
-<p>
-<strong>0.</strong>
-This License Agreement applies to any software library or other
+  0. This License Agreement applies to any software library or other
 program which contains a notice placed by the copyright holder or
 other authorized party saying it may be distributed under the terms of
 this Lesser General Public License (also called "this License").
 Each licensee is addressed as "you".
-</p>
-<p>
+
   A "library" means a collection of software functions and/or data
 prepared so as to be conveniently linked with application programs
 (which use some of those functions and data) to form executables.
-</p>
-<p>
+
   The "Library", below, refers to any such software library or work
 which has been distributed under these terms.  A "work based on the
 Library" means either the Library or any derivative work under
@@ -372,15 +132,13 @@ copyright law: that is to say, a work containing the Library or a
 portion of it, either verbatim or with modifications and/or translated
 straightforwardly into another language.  (Hereinafter, translation is
 included without limitation in the term "modification".)
-</p>
-<p>
+
   "Source code" for a work means the preferred form of the work for
 making modifications to it.  For a library, complete source code means
 all the source code for all modules it contains, plus any associated
 interface definition files, plus the scripts used to control compilation
 and installation of the library.
-</p>
-<p>
+
   Activities other than copying, distribution and modification are not
 covered by this License; they are outside its scope.  The act of
 running a program using the Library is not restricted, and output from
@@ -388,84 +146,69 @@ such a program is covered only if its contents constitute a work based
 on the Library (independent of the use of the Library in a tool for
 writing it).  Whether that is true depends on what the Library does
 and what the program that uses the Library does.
-</p>
-<p>
-<strong>1.</strong>
-You may copy and distribute verbatim copies of the Library's
+
+  1. You may copy and distribute verbatim copies of the Library's
 complete source code as you receive it, in any medium, provided that
 you conspicuously and appropriately publish on each copy an
 appropriate copyright notice and disclaimer of warranty; keep intact
 all the notices that refer to this License and to the absence of any
 warranty; and distribute a copy of this License along with the
 Library.
-</p>
-<p>
+
   You may charge a fee for the physical act of transferring a copy,
 and you may at your option offer warranty protection in exchange for a
 fee.
-</p>
-<p>
-<strong>2.</strong>
-You may modify your copy or copies of the Library or any portion
+
+  2. You may modify your copy or copies of the Library or any portion
 of it, thus forming a work based on the Library, and copy and
 distribute such modifications or work under the terms of Section 1
 above, provided that you also meet all of these conditions:
-</p>
 
-<ul>
-  <li><strong>a)</strong>
-       The modified work must itself be a software library.</li>
-  <li><strong>b)</strong>
-       You must cause the files modified to carry prominent notices
-       stating that you changed the files and the date of any change.</li>
+    a) The modified work must itself be a software library.
 
-  <li><strong>c)</strong>
-       You must cause the whole of the work to be licensed at no
-       charge to all third parties under the terms of this License.</li>
+    b) You must cause the files modified to carry prominent notices
+    stating that you changed the files and the date of any change.
 
-  <li><strong>d)</strong>
-       If a facility in the modified Library refers to a function or a
-       table of data to be supplied by an application program that uses
-       the facility, other than as an argument passed when the facility
-       is invoked, then you must make a good faith effort to ensure that,
-       in the event an application does not supply such function or
-       table, the facility still operates, and performs whatever part of
-       its purpose remains meaningful.
-       <p>
-       (For example, a function in a library to compute square roots has
-       a purpose that is entirely well-defined independent of the
-       application.  Therefore, Subsection 2d requires that any
-       application-supplied function or table used by this function must
-       be optional: if the application does not supply it, the square
-       root function must still compute square roots.)</p></li>
-</ul>
+    c) You must cause the whole of the work to be licensed at no
+    charge to all third parties under the terms of this License.
 
-<p>
-These requirements apply to the modified work as a whole.  If identifiable
-sections of that work are not derived from the Library, and can be
-reasonably considered independent and separate works in themselves, then
-this License, and its terms, do not apply to those sections when you
-distribute them as separate works.  But when you distribute the same
-sections as part of a whole which is a work based on the Library, the
-distribution of the whole must be on the terms of this License, whose
-permissions for other licensees extend to the entire whole, and thus to
-each and every part regardless of who wrote it.
-</p>
-<p>
-Thus, it is not the intent of this section to claim rights or contest your
-rights to work written entirely by you; rather, the intent is to exercise
-the right to control the distribution of derivative or collective works
-based on the Library.
-</p>
-<p>
-In addition, mere aggregation of another work not based on the Library with
-the Library (or with a work based on the Library) on a volume of a storage
-or distribution medium does not bring the other work under the scope of
-this License.
-</p>
-<p>
-<strong>3.</strong>
-You may opt to apply the terms of the ordinary GNU General Public
+    d) If a facility in the modified Library refers to a function or a
+    table of data to be supplied by an application program that uses
+    the facility, other than as an argument passed when the facility
+    is invoked, then you must make a good faith effort to ensure that,
+    in the event an application does not supply such function or
+    table, the facility still operates, and performs whatever part of
+    its purpose remains meaningful.
+
+    (For example, a function in a library to compute square roots has
+    a purpose that is entirely well-defined independent of the
+    application.  Therefore, Subsection 2d requires that any
+    application-supplied function or table used by this function must
+    be optional: if the application does not supply it, the square
+    root function must still compute square roots.)
+
+These requirements apply to the modified work as a whole.  If
+identifiable sections of that work are not derived from the Library,
+and can be reasonably considered independent and separate works in
+themselves, then this License, and its terms, do not apply to those
+sections when you distribute them as separate works.  But when you
+distribute the same sections as part of a whole which is a work based
+on the Library, the distribution of the whole must be on the terms of
+this License, whose permissions for other licensees extend to the
+entire whole, and thus to each and every part regardless of who wrote
+it.
+
+Thus, it is not the intent of this section to claim rights or contest
+your rights to work written entirely by you; rather, the intent is to
+exercise the right to control the distribution of derivative or
+collective works based on the Library.
+
+In addition, mere aggregation of another work not based on the Library
+with the Library (or with a work based on the Library) on a volume of
+a storage or distribution medium does not bring the other work under
+the scope of this License.
+
+  3. You may opt to apply the terms of the ordinary GNU General Public
 License instead of this License to a given copy of the Library.  To do
 this, you must alter all the notices that refer to this License, so
 that they refer to the ordinary GNU General Public License, version 2,
@@ -473,79 +216,65 @@ instead of to this License.  (If a newer version than version 2 of the
 ordinary GNU General Public License has appeared, then you can specify
 that version instead if you wish.)  Do not make any other change in
 these notices.
-</p>
-<p>
+
   Once this change is made in a given copy, it is irreversible for
 that copy, so the ordinary GNU General Public License applies to all
 subsequent copies and derivative works made from that copy.
-</p>
-<p>
+
   This option is useful when you wish to copy part of the code of
 the Library into a program that is not a library.
-</p>
-<p>
-<strong>4.</strong>
-You may copy and distribute the Library (or a portion or
+
+  4. You may copy and distribute the Library (or a portion or
 derivative of it, under Section 2) in object code or executable form
 under the terms of Sections 1 and 2 above provided that you accompany
 it with the complete corresponding machine-readable source code, which
 must be distributed under the terms of Sections 1 and 2 above on a
 medium customarily used for software interchange.
-</p>
-<p>
+
   If distribution of object code is made by offering access to copy
 from a designated place, then offering equivalent access to copy the
 source code from the same place satisfies the requirement to
 distribute the source code, even though third parties are not
 compelled to copy the source along with the object code.
-</p>
-<p>
-<strong>5.</strong>
-A program that contains no derivative of any portion of the
+
+  5. A program that contains no derivative of any portion of the
 Library, but is designed to work with the Library by being compiled or
 linked with it, is called a "work that uses the Library".  Such a
 work, in isolation, is not a derivative work of the Library, and
 therefore falls outside the scope of this License.
-</p>
-<p>
+
   However, linking a "work that uses the Library" with the Library
 creates an executable that is a derivative of the Library (because it
 contains portions of the Library), rather than a "work that uses the
 library".  The executable is therefore covered by this License.
 Section 6 states terms for distribution of such executables.
-</p>
-<p>
+
   When a "work that uses the Library" uses material from a header file
 that is part of the Library, the object code for the work may be a
 derivative work of the Library even though the source code is not.
 Whether this is true is especially significant if the work can be
 linked without the Library, or if the work is itself a library.  The
 threshold for this to be true is not precisely defined by law.
-</p>
-<p>
+
   If such an object file uses only numerical parameters, data
 structure layouts and accessors, and small macros and small inline
 functions (ten lines or less in length), then the use of the object
 file is unrestricted, regardless of whether it is legally a derivative
 work.  (Executables containing this object code plus portions of the
 Library will still fall under Section 6.)
-</p>
-<p>
+
   Otherwise, if the work is a derivative of the Library, you may
 distribute the object code for the work under the terms of Section 6.
 Any executables containing that work also fall under Section 6,
 whether or not they are linked directly with the Library itself.
-</p>
-<p>
-<strong>6.</strong>
-As an exception to the Sections above, you may also combine or
+
+  6. As an exception to the Sections above, you may also combine or
 link a "work that uses the Library" with the Library to produce a
 work containing portions of the Library, and distribute that work
 under terms of your choice, provided that the terms permit
 modification of the work for the customer's own use and reverse
 engineering for debugging such modifications.
-</p>
-<p>
+
   You must give prominent notice with each copy of the work that the
 Library is used in it and that the Library and its use are covered by
 this License.  You must supply a copy of this License.  If the work
@@ -553,47 +282,39 @@ during execution displays copyright notices, you must include the
 copyright notice for the Library among them, as well as a reference
 directing the user to the copy of this License.  Also, you must do one
 of these things:
-</p>
 
-<ul>
-    <li><strong>a)</strong> Accompany the work with the complete
-    corresponding machine-readable source code for the Library
-    including whatever changes were used in the work (which must be
-    distributed under Sections 1 and 2 above); and, if the work is an
-    executable linked with the Library, with the complete
-    machine-readable "work that uses the Library", as object code
-    and/or source code, so that the user can modify the Library and
-    then relink to produce a modified executable containing the
-    modified Library.  (It is understood that the user who changes the
-    contents of definitions files in the Library will not necessarily
-    be able to recompile the application to use the modified
-    definitions.)</li>
+    a) Accompany the work with the complete corresponding
+    machine-readable source code for the Library including whatever
+    changes were used in the work (which must be distributed under
+    Sections 1 and 2 above); and, if the work is an executable linked
+    with the Library, with the complete machine-readable "work that
+    uses the Library", as object code and/or source code, so that the
+    user can modify the Library and then relink to produce a modified
+    executable containing the modified Library.  (It is understood
+    that the user who changes the contents of definitions files in the
+    Library will not necessarily be able to recompile the application
+    to use the modified definitions.)
 
-    <li><strong>b)</strong> Use a suitable shared library mechanism
-    for linking with the Library.  A suitable mechanism is one that
-    (1) uses at run time a copy of the library already present on the
-    user's computer system, rather than copying library functions into
-    the executable, and (2) will operate properly with a modified
-    version of the library, if the user installs one, as long as the
-    modified version is interface-compatible with the version that the
-    work was made with.</li>
+    b) Use a suitable shared library mechanism for linking with the
+    Library.  A suitable mechanism is one that (1) uses at run time a
+    copy of the library already present on the user's computer system,
+    rather than copying library functions into the executable, and (2)
+    will operate properly with a modified version of the library, if
+    the user installs one, as long as the modified version is
+    interface-compatible with the version that the work was made with.
 
-    <li><strong>c)</strong> Accompany the work with a written offer,
-    valid for at least three years, to give the same user the
-    materials specified in Subsection 6a, above, for a charge no more
-    than the cost of performing this distribution.</li>
+    c) Accompany the work with a written offer, valid for at
+    least three years, to give the same user the materials
+    specified in Subsection 6a, above, for a charge no more
+    than the cost of performing this distribution.
 
-    <li><strong>d)</strong> If distribution of the work is made by
-    offering access to copy from a designated place, offer equivalent
-    access to copy the above specified materials from the same
-    place.</li>
+    d) If distribution of the work is made by offering access to copy
+    from a designated place, offer equivalent access to copy the above
+    specified materials from the same place.
 
-    <li><strong>e)</strong> Verify that the user has already received
-    a copy of these materials or that you have already sent this user
-    a copy.</li>
-</ul>
+    e) Verify that the user has already received a copy of these
+    materials or that you have already sent this user a copy.
 
-<p>
   For an executable, the required form of the "work that uses the
 Library" must include any data and utility programs needed for
 reproducing the executable from it.  However, as a special exception,
@@ -602,48 +323,38 @@ normally distributed (in either source or binary form) with the major
 components (compiler, kernel, and so on) of the operating system on
 which the executable runs, unless that component itself accompanies
 the executable.
-</p>
-<p>
+
   It may happen that this requirement contradicts the license
 restrictions of other proprietary libraries that do not normally
 accompany the operating system.  Such a contradiction means you cannot
 use both them and the Library together in an executable that you
 distribute.
-</p>
-<p>
-<strong>7.</strong> You may place library facilities that are a work
-based on the Library side-by-side in a single library together with
-other library facilities not covered by this License, and distribute
-such a combined library, provided that the separate distribution of
-the work based on the Library and of the other library facilities is
-otherwise permitted, and provided that you do these two things:
-</p>
+
+  7. You may place library facilities that are a work based on the
+Library side-by-side in a single library together with other library
+facilities not covered by this License, and distribute such a combined
+library, provided that the separate distribution of the work based on
+the Library and of the other library facilities is otherwise
+permitted, and provided that you do these two things:
 
-<ul>
-    <li><strong>a)</strong> Accompany the combined library with a copy
-    of the same work based on the Library, uncombined with any other
-    library facilities.  This must be distributed under the terms of
-    the Sections above.</li>
+    a) Accompany the combined library with a copy of the same work
+    based on the Library, uncombined with any other library
+    facilities.  This must be distributed under the terms of the
+    Sections above.
 
-    <li><strong>b)</strong> Give prominent notice with the combined
-    library of the fact that part of it is a work based on the
-    Library, and explaining where to find the accompanying uncombined
-    form of the same work.</li>
-</ul>
+    b) Give prominent notice with the combined library of the fact
+    that part of it is a work based on the Library, and explaining
+    where to find the accompanying uncombined form of the same work.
 
-<p>
-<strong>8.</strong> You may not copy, modify, sublicense, link with,
-or distribute the Library except as expressly provided under this
-License.  Any attempt otherwise to copy, modify, sublicense, link
-with, or distribute the Library is void, and will automatically
-terminate your rights under this License.  However, parties who have
-received copies, or rights, from you under this License will not have
-their licenses terminated so long as such parties remain in full
-compliance.
-</p>
-<p>
-<strong>9.</strong>
-You are not required to accept this License, since you have not
+  8. You may not copy, modify, sublicense, link with, or distribute
+the Library except as expressly provided under this License.  Any
+attempt otherwise to copy, modify, sublicense, link with, or
+distribute the Library is void, and will automatically terminate your
+rights under this License.  However, parties who have received copies,
+or rights, from you under this License will not have their licenses
+terminated so long as such parties remain in full compliance.
+
+  9. You are not required to accept this License, since you have not
 signed it.  However, nothing else grants you permission to modify or
 distribute the Library or its derivative works.  These actions are
 prohibited by law if you do not accept this License.  Therefore, by
@@ -651,20 +362,16 @@ modifying or distributing the Library (or any work based on the
 Library), you indicate your acceptance of this License to do so, and
 all its terms and conditions for copying, distributing or modifying
 the Library or works based on it.
-</p>
-<p>
-<strong>10.</strong>
-Each time you redistribute the Library (or any work based on the
+
+  10. Each time you redistribute the Library (or any work based on the
 Library), the recipient automatically receives a license from the
 original licensor to copy, distribute, link with or modify the Library
 subject to these terms and conditions.  You may not impose any further
 restrictions on the recipients' exercise of the rights granted herein.
 You are not responsible for enforcing compliance by third parties with
 this License.
-</p>
-<p>
-<strong>11.</strong>
-If, as a consequence of a court judgment or allegation of patent
+
+  11. If, as a consequence of a court judgment or allegation of patent
 infringement or for any other reason (not limited to patent issues),
 conditions are imposed on you (whether by court order, agreement or
 otherwise) that contradict the conditions of this License, they do not
@@ -676,13 +383,11 @@ license would not permit royalty-free redistribution of the Library by
 all those who receive copies directly or indirectly through you, then
 the only way you could satisfy both it and this License would be to
 refrain entirely from distribution of the Library.
-</p>
-<p>
+
 If any portion of this section is held invalid or unenforceable under any
 particular circumstance, the balance of the section is intended to apply,
 and the section as a whole is intended to apply in other circumstances.
-</p>
-<p>
+
 It is not the purpose of this section to induce you to infringe any
 patents or other property right claims or to contest validity of any
 such claims; this section has the sole purpose of protecting the
@@ -693,29 +398,23 @@ through that system in reliance on consistent application of that
 system; it is up to the author/donor to decide if he or she is willing
 to distribute software through any other system and a licensee cannot
 impose that choice.
-</p>
-<p>
+
 This section is intended to make thoroughly clear what is believed to
 be a consequence of the rest of this License.
-</p>
-<p>
-<strong>12.</strong>
-If the distribution and/or use of the Library is restricted in
+
+  12. If the distribution and/or use of the Library is restricted in
 certain countries either by patents or by copyrighted interfaces, the
 original copyright holder who places the Library under this License may add
 an explicit geographical distribution limitation excluding those countries,
 so that distribution is permitted only in or among countries not thus
 excluded.  In such case, this License incorporates the limitation as if
 written in the body of this License.
-</p>
-<p>
-<strong>13.</strong>
-The Free Software Foundation may publish revised and/or new
+
+  13. The Free Software Foundation may publish revised and/or new
 versions of the Lesser General Public License from time to time.
 Such new versions will be similar in spirit to the present version,
 but may differ in detail to address new problems or concerns.
-</p>
-<p>
+
 Each version is given a distinguishing version number.  If the Library
 specifies a version number of this License which applies to it and
 "any later version", you have the option of following the terms and
@@ -723,10 +422,8 @@ conditions either of that version or of any later version published by
 the Free Software Foundation.  If the Library does not specify a
 license version number, you may choose any version ever published by
 the Free Software Foundation.
-</p>
-<p>
-<strong>14.</strong>
-If you wish to incorporate parts of the Library into other free
+
+  14. If you wish to incorporate parts of the Library into other free
 programs whose distribution conditions are incompatible with these,
 write to the author to ask for permission.  For software which is
 copyrighted by the Free Software Foundation, write to the Free
@@ -734,13 +431,10 @@ Software Foundation; we sometimes make exceptions for this.  Our
 decision will be guided by the two goals of preserving the free status
 of all derivatives of our free software and of promoting the sharing
 and reuse of software generally.
-</p>
-<p>
-<strong>NO WARRANTY</strong>
-</p>
-<p>
-<strong>15.</strong>
-BECAUSE THE LIBRARY IS LICENSED FREE OF CHARGE, THERE IS NO
+
+                            NO WARRANTY
+
+  15. BECAUSE THE LIBRARY IS LICENSED FREE OF CHARGE, THERE IS NO
 WARRANTY FOR THE LIBRARY, TO THE EXTENT PERMITTED BY APPLICABLE LAW.
 EXCEPT WHEN OTHERWISE STATED IN WRITING THE COPYRIGHT HOLDERS AND/OR
 OTHER PARTIES PROVIDE THE LIBRARY "AS IS" WITHOUT WARRANTY OF ANY
@@ -749,10 +443,8 @@ IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR
 PURPOSE.  THE ENTIRE RISK AS TO THE QUALITY AND PERFORMANCE OF THE
 LIBRARY IS WITH YOU.  SHOULD THE LIBRARY PROVE DEFECTIVE, YOU ASSUME
 THE COST OF ALL NECESSARY SERVICING, REPAIR OR CORRECTION.
-</p>
-<p>
-<strong>16.</strong>
-IN NO EVENT UNLESS REQUIRED BY APPLICABLE LAW OR AGREED TO IN
+
+  16. IN NO EVENT UNLESS REQUIRED BY APPLICABLE LAW OR AGREED TO IN
 WRITING WILL ANY COPYRIGHT HOLDER, OR ANY OTHER PARTY WHO MAY MODIFY
 AND/OR REDISTRIBUTE THE LIBRARY AS PERMITTED ABOVE, BE LIABLE TO YOU
 FOR DAMAGES, INCLUDING ANY GENERAL, SPECIAL, INCIDENTAL OR
@@ -762,181 +454,48 @@ RENDERED INACCURATE OR LOSSES SUSTAINED BY YOU OR THIRD PARTIES OR A
 FAILURE OF THE LIBRARY TO OPERATE WITH ANY OTHER SOFTWARE), EVEN IF
 SUCH HOLDER OR OTHER PARTY HAS BEEN ADVISED OF THE POSSIBILITY OF SUCH
 DAMAGES.
-</p>
 
-<h4>END OF TERMS AND CONDITIONS</h4>
+                     END OF TERMS AND CONDITIONS
+
+           How to Apply These Terms to Your New Libraries
 
-<h4 id="SEC4">How to Apply These Terms to Your New Libraries</h4>
-<p>
   If you develop a new library, and you want it to be of the greatest
 possible use to the public, we recommend making it free software that
 everyone can redistribute and change.  You can do so by permitting
 redistribution under these terms (or, alternatively, under the terms of the
 ordinary General Public License).
-</p>
-<p>
+
   To apply these terms, attach the following notices to the library.  It is
 safest to attach them to the start of each source file to most effectively
 convey the exclusion of warranty; and each file should have at least the
 "copyright" line and a pointer to where the full notice is found.
-</p>
 
-<pre>
-<var>one line to give the library's name and an idea of what it does.</var>
-Copyright (C) <var>year</var>  <var>name of author</var>
+    <one line to give the library's name and a brief idea of what it does.>
+    Copyright (C) <year>  <name of author>
 
-This library is free software; you can redistribute it and/or
-modify it under the terms of the GNU Lesser General Public
-License as published by the Free Software Foundation; either
-version 2.1 of the License, or (at your option) any later version.
+    This library is free software; you can redistribute it and/or
+    modify it under the terms of the GNU Lesser General Public
+    License as published by the Free Software Foundation; either
+    version 2.1 of the License, or (at your option) any later version.
 
-This library is distributed in the hope that it will be useful,
-but WITHOUT ANY WARRANTY; without even the implied warranty of
-MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
-Lesser General Public License for more details.
+    This library is distributed in the hope that it will be useful,
+    but WITHOUT ANY WARRANTY; without even the implied warranty of
+    MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+    Lesser General Public License for more details.
 
-You should have received a copy of the GNU Lesser General Public
-License along with this library; if not, see
-&lt;<a href="https://www.gnu.org/licenses/">https://www.gnu.org/licenses/</a>&gt;.
-</pre>
+    You should have received a copy of the GNU Lesser General Public
+    License along with this library; if not, see <https://www.gnu.org/licenses/>.
 
-<p>
 Also add information on how to contact you by electronic and paper mail.
-</p>
-<p>
+
 You should also get your employer (if you work as a programmer) or your
 school, if any, to sign a "copyright disclaimer" for the library, if
 necessary.  Here is a sample; alter the names:
-</p>
 
-<pre>
-Yoyodyne, Inc., hereby disclaims all copyright interest in
-the library `Frob' (a library for tweaking knobs) written
-by James Random Hacker.
+  Yoyodyne, Inc., hereby disclaims all copyright interest in the
+  library `Frob' (a library for tweaking knobs) written by James Random Hacker.
 
-<var>signature of Moe Ghoul</var>, 1 April 1990
-Moe Ghoul, President of Vice
-</pre>
+  <signature of Moe Ghoul>, 1 April 1990
+  Moe Ghoul, President of Vice
 
-<p>
-That's all there is to it!</p>
-
-</div>
-</div>
-
-</div><!-- for id="content", starts in the include above -->
-
-              <!-- begin server/footer-text.html -->
-
-
-
-
-
-<div style="clear:both"></div>
-
-
-<div id="language-container">
- <div class="backtotop">
-  <hr class="no-display" />
-  <a href="#top"><b>&#9650;</b></a>
- </div>
- <div id="languages" class="rounded-corners">
-  <div class="button">
-   <a href="#top" class="close"><span>BACK TO TOP</span></a>
-  </div>
-  <div id="set-language" class="button">
-   <span class="gnun-split"></span>
-   <a href="/server/select-language.html?callback=/licenses/old-licenses/lgpl-2.1" rel="nofollow">
-   Set language
-   <span class="gnun-split"></span>
-   </a>
-  </div>
-  <p>Available for this page:</p>
-  <div id="translations">
-<p>
-<span dir="ltr" class="original">[en]&nbsp;<a lang="en" hreflang="en" href="/licenses/old-licenses/lgpl-2.1.en.html">English</a> &nbsp;</span>
-<span dir="ltr">[de]&nbsp;<a lang="de" hreflang="de" href="/licenses/old-licenses/lgpl-2.1.de.html">Deutsch</a> &nbsp;</span>
-<span dir="ltr">[fr]&nbsp;<a lang="fr" hreflang="fr" href="/licenses/old-licenses/lgpl-2.1.fr.html">français</a> &nbsp;</span>
-<span dir="ltr">[ja]&nbsp;<a lang="ja" hreflang="ja" href="/licenses/old-licenses/lgpl-2.1.ja.html">日本語</a> &nbsp;</span>
-<span dir="ltr">[pt-br]&nbsp;<a lang="pt-br" hreflang="pt-br" href="/licenses/old-licenses/lgpl-2.1.pt-br.html">português</a> &nbsp;</span>
-<span dir="ltr">[ru]&nbsp;<a lang="ru" hreflang="ru" href="/licenses/old-licenses/lgpl-2.1.ru.html">русский</a> &nbsp;</span>
-<span dir="ltr">[uk]&nbsp;<a lang="uk" hreflang="uk" href="/licenses/old-licenses/lgpl-2.1.uk.html">українська</a> &nbsp;</span>
-<span dir="ltr">[zh-cn]&nbsp;<a lang="zh-cn" hreflang="zh-cn" href="/licenses/old-licenses/lgpl-2.1.zh-cn.html">简体中文</a> &nbsp;</span>
-</p>
-</div>
- </div>
-</div>
-
-<div id="mission-statement" role="complementary">
- <div class="backtotop">
-  <hr class="no-display" />
-  <a href="#header"><span>BACK TO TOP </span>&#9650;</a>
- </div>
-<div style="clear: both"></div>
-<blockquote>
-<p style="direction:ltr; text-align:left"><a href="//www.fsf.org"><img id="fsfbanner"
-src="/graphics/fsf-logo-notext-small.png" alt="&nbsp;[FSF logo]&nbsp;"
-width="75" height="25" /></a><strong>
-&ldquo;The Free Software Foundation (FSF) is a nonprofit with a worldwide
-mission to promote computer user freedom. We defend the rights of all
-software users.&rdquo;</strong></p>
-</blockquote>
-
-<div id="support-the-fsf" class="button">
- <a class="join" href="//www.fsf.org/associate/support_freedom?referrer=4052">JOIN</a>
- <a class="donate" href="//donate.fsf.org/">DONATE</a>
- <a class="shop" href="//shop.fsf.org/">SHOP</a>
-</div>
-</div>
-<!-- end server/footer-text.html -->
-
-
-<div id="footer" role="contentinfo">
-<div class="unprintable">
-
-<p>Please send general FSF &amp; GNU inquiries to
-<a href="mailto:gnu@gnu.org">&lt;gnu@gnu.org&gt;</a>.
-There are also <a href="/contact/">other ways to contact</a>
-the FSF.  Broken links and other corrections or suggestions can be sent
-to <a href="mailto:webmasters@gnu.org">&lt;webmasters@gnu.org&gt;</a>.</p>
-
-<p><!-- TRANSLATORS: Ignore the original text in this paragraph,
-        replace it with the translation of these two:
-
-        We work hard and do our best to provide accurate, good quality
-        translations.  However, we are not exempt from imperfection.
-        Please send your comments and general suggestions in this regard
-        to <a href="mailto:web-translators@gnu.org">
-        &lt;web-translators@gnu.org&gt;</a>.</p>
-
-        <p>For information on coordinating and contributing translations of
-        our web pages, see <a
-        href="/server/standards/README.translations.html">Translations
-        README</a>. -->
-Please see the <a
-href="/server/standards/README.translations.html">Translations
-README</a> for information on coordinating and contributing translations
-of this article.</p>
-</div>
-
-<p>Copyright notice above.</p>
-
-<!-- start of server/bottom-notes.html -->
-<div id="bottom-notes" class="unprintable">
-<p><a href="//www.fsf.org/about/dmca-notice">Copyright Infringement Notification</a></p>
-<div id="generic">
-
-
-</div>
-</div>
-<!-- end of server/bottom-notes.html -->
-
-
-<p class="unprintable">Updated:
-<!-- timestamp start -->
-$Date: 2023/11/30 09:46:01 $
-<!-- timestamp end --></p>
-</div>
-</div><!-- for class="inner", starts in the banner include -->
-</body>
-</html>
+That's all there is to it!


### PR DESCRIPTION
Files without an extension was using the html content but it is prefered to have a plain text file.

### Checklist:

* [ ] Have you added a note in the [CHANGELOG wiki](https://github.com/project-ncl/bacon/wiki/Changelog) for your change if user-facing?
* [ ] Have you added unit tests for your change?
