### PR TITLE
Add rex maintenance cli command

### DIFF
--- a/common/src/main/java/org/jboss/pnc/bacon/common/CustomRestHeaderFilter.java
+++ b/common/src/main/java/org/jboss/pnc/bacon/common/CustomRestHeaderFilter.java
@@ -1,4 +1,4 @@
-package org.jboss.bacon.da;
+package org.jboss.pnc.bacon.common;
 
 import java.io.IOException;
 

--- a/common/src/main/java/org/jboss/pnc/bacon/common/TokenAuthenticator.java
+++ b/common/src/main/java/org/jboss/pnc/bacon/common/TokenAuthenticator.java
@@ -1,0 +1,22 @@
+package org.jboss.pnc.bacon.common;
+
+import java.io.IOException;
+import java.util.function.Supplier;
+
+import javax.ws.rs.client.ClientRequestContext;
+import javax.ws.rs.client.ClientRequestFilter;
+import javax.ws.rs.core.MultivaluedMap;
+
+public class TokenAuthenticator implements ClientRequestFilter {
+
+    private final Supplier<String> tokenSupplier;
+
+    public TokenAuthenticator(Supplier<String> tokenSupplier) {
+        this.tokenSupplier = tokenSupplier;
+    }
+
+    public void filter(ClientRequestContext requestContext) throws IOException {
+        MultivaluedMap<String, Object> headers = requestContext.getHeaders();
+        headers.add("Authorization", "Bearer " + this.tokenSupplier.get());
+    }
+}

--- a/config.yaml
+++ b/config.yaml
@@ -32,6 +32,8 @@ profile:
       indyUrl: ""
   da:
       url: ""
+  rex:
+      url: ""
 # ******************************************************************************
 # Authentication information
 #

--- a/config/src/main/java/org/jboss/pnc/bacon/config/ConfigProfile.java
+++ b/config/src/main/java/org/jboss/pnc/bacon/config/ConfigProfile.java
@@ -32,6 +32,7 @@ public class ConfigProfile {
     private PigConfig pig;
     private KeycloakConfig keycloak;
     private AutobuildConfig autobuild;
+    private RexConfig rex;
     private boolean enableExperimental;
 
     private Map<String, Map<String, ?>> addOns;

--- a/config/src/main/java/org/jboss/pnc/bacon/config/RexConfig.java
+++ b/config/src/main/java/org/jboss/pnc/bacon/config/RexConfig.java
@@ -1,0 +1,17 @@
+package org.jboss.pnc.bacon.config;
+
+import lombok.Data;
+import lombok.extern.slf4j.Slf4j;
+
+@Data
+@Slf4j
+public class RexConfig implements Validate {
+
+    // Url of Rex server
+    private String url;
+
+    @Override
+    public void validate() {
+        Validate.validateUrl(url, "Rex");
+    }
+}

--- a/da/src/main/java/org/jboss/bacon/da/DaHelper.java
+++ b/da/src/main/java/org/jboss/bacon/da/DaHelper.java
@@ -17,17 +17,11 @@
  */
 package org.jboss.bacon.da;
 
-import java.io.IOException;
 import java.util.ArrayList;
 import java.util.List;
 import java.util.Map;
 import java.util.Set;
-import java.util.function.Supplier;
 import java.util.stream.Collectors;
-
-import javax.ws.rs.client.ClientRequestContext;
-import javax.ws.rs.client.ClientRequestFilter;
-import javax.ws.rs.core.MultivaluedMap;
 
 import org.jboss.bacon.da.rest.endpoint.ListingsApi;
 import org.jboss.bacon.da.rest.endpoint.LookupApi;
@@ -38,6 +32,8 @@ import org.jboss.da.lookup.model.MavenLookupResult;
 import org.jboss.da.lookup.model.NPMLookupResult;
 import org.jboss.da.model.rest.GAV;
 import org.jboss.da.model.rest.NPMPackage;
+import org.jboss.pnc.bacon.common.CustomRestHeaderFilter;
+import org.jboss.pnc.bacon.common.TokenAuthenticator;
 import org.jboss.pnc.bacon.common.Utils;
 import org.jboss.pnc.bacon.config.Config;
 import org.jboss.pnc.bacon.config.DaConfig;
@@ -267,19 +263,5 @@ public class DaHelper {
         }
 
         return ordered;
-    }
-
-    private static class TokenAuthenticator implements ClientRequestFilter {
-
-        private final Supplier<String> tokenSupplier;
-
-        TokenAuthenticator(Supplier<String> tokenSupplier) {
-            this.tokenSupplier = tokenSupplier;
-        }
-
-        public void filter(ClientRequestContext requestContext) throws IOException {
-            MultivaluedMap<String, Object> headers = requestContext.getHeaders();
-            headers.add("Authorization", "Bearer " + this.tokenSupplier.get());
-        }
     }
 }

--- a/pnc/pom.xml
+++ b/pnc/pom.xml
@@ -30,6 +30,19 @@
             <groupId>org.projectlombok</groupId>
             <artifactId>lombok</artifactId>
         </dependency>
+        <dependency>
+            <groupId>org.jboss.pnc.rex</groupId>
+            <artifactId>rex-api</artifactId>
+            <classifier>javax</classifier>
+        </dependency>
+        <dependency>
+            <groupId>org.jboss.pnc.rex</groupId>
+            <artifactId>rex-model</artifactId>
+        </dependency>
+        <dependency>
+            <groupId>org.jboss.pnc.rex</groupId>
+            <artifactId>rex-common</artifactId>
+        </dependency>
 
         <dependency>
             <groupId>org.assertj</groupId>

--- a/pnc/src/main/java/org/jboss/pnc/bacon/pnc/AdminCli.java
+++ b/pnc/src/main/java/org/jboss/pnc/bacon/pnc/AdminCli.java
@@ -19,12 +19,13 @@ package org.jboss.pnc.bacon.pnc;
 
 import org.jboss.pnc.bacon.pnc.admin.AnnouncementBannerCli;
 import org.jboss.pnc.bacon.pnc.admin.MaintenanceModeCli;
+import org.jboss.pnc.bacon.pnc.admin.RexCli;
 
 import picocli.CommandLine.Command;
 
 @Command(
         name = "admin",
         description = "Admin related tasks",
-        subcommands = { AnnouncementBannerCli.class, MaintenanceModeCli.class })
+        subcommands = { AnnouncementBannerCli.class, MaintenanceModeCli.class, RexCli.class })
 public class AdminCli {
 }

--- a/pnc/src/main/java/org/jboss/pnc/bacon/pnc/admin/RexCli.java
+++ b/pnc/src/main/java/org/jboss/pnc/bacon/pnc/admin/RexCli.java
@@ -1,0 +1,73 @@
+package org.jboss.pnc.bacon.pnc.admin;
+
+import java.util.concurrent.Callable;
+
+import org.jboss.pnc.bacon.common.CustomRestHeaderFilter;
+import org.jboss.pnc.bacon.common.TokenAuthenticator;
+import org.jboss.pnc.bacon.config.Config;
+import org.jboss.pnc.bacon.config.RexConfig;
+import org.jboss.pnc.bacon.pnc.client.PncClientHelper;
+import org.jboss.pnc.client.Configuration;
+import org.jboss.pnc.rex.api.MaintenanceEndpoint;
+import org.jboss.resteasy.client.jaxrs.ResteasyClient;
+import org.jboss.resteasy.client.jaxrs.ResteasyClientBuilder;
+import org.jboss.resteasy.client.jaxrs.ResteasyWebTarget;
+import org.jboss.resteasy.plugins.providers.RegisterBuiltin;
+import org.jboss.resteasy.spi.ResteasyProviderFactory;
+
+import com.redhat.resilience.otel.OTelCLIHelper;
+
+import io.opentelemetry.api.trace.Span;
+import picocli.CommandLine;
+
+@CommandLine.Command(
+        name = "rex",
+        description = "Rex related tasks",
+        subcommands = {
+                RexCli.ClearAll.class })
+public class RexCli {
+
+    private static ResteasyClientBuilder builder;
+    private static String rexUrl;
+
+    @CommandLine.Command(name = "clear-all", description = "[WARNING] This will clear all the tasks in Rex")
+    public static class ClearAll implements Callable<Integer> {
+
+        @Override
+        public Integer call() throws Exception {
+            getMaintenanceEndpointClient().clearAll();
+            return 0;
+        }
+    }
+
+    private static ResteasyWebTarget getClient() {
+
+        if (builder == null) {
+            builder = new ResteasyClientBuilder();
+            ResteasyProviderFactory factory = ResteasyProviderFactory.getInstance();
+            builder.providerFactory(factory);
+            ResteasyProviderFactory.setRegisterBuiltinByDefault(true);
+            RegisterBuiltin.register(factory);
+
+            RexConfig rexConfig = Config.instance().getActiveProfile().getRex();
+            rexUrl = rexConfig.getUrl();
+        }
+        ResteasyClient resteasyClient = builder.build();
+        if (OTelCLIHelper.otelEnabled()) {
+            resteasyClient.register(new CustomRestHeaderFilter(Span.current().getSpanContext()));
+        }
+        return resteasyClient.target(rexUrl);
+    }
+
+    private static ResteasyWebTarget getAuthenticatedClient() {
+
+        ResteasyWebTarget target = getClient();
+        Configuration pncConfiguration = PncClientHelper.getPncConfiguration();
+        target.register(new TokenAuthenticator(pncConfiguration.getBearerTokenSupplier()));
+        return target;
+    }
+
+    public static MaintenanceEndpoint getMaintenanceEndpointClient() {
+        return getAuthenticatedClient().proxy(MaintenanceEndpoint.class);
+    }
+}

--- a/pom.xml
+++ b/pom.xml
@@ -112,6 +112,7 @@
         <surefire.plugin.version>3.2.5</surefire.plugin.version>
         <tagSuffix />
         <undertow.version>2.3.18.Final</undertow.version>
+        <version.rex>1.1.0-SNAPSHOT</version.rex>
     </properties>
 
     <dependencyManagement>
@@ -704,6 +705,23 @@
                         <artifactId>jboss-annotations-api_1.3_spec</artifactId>
                     </exclusion>
                 </exclusions>
+            </dependency>
+
+            <dependency>
+                <groupId>org.jboss.pnc.rex</groupId>
+                <artifactId>rex-api</artifactId>
+                <version>${version.rex}</version>
+                <classifier>javax</classifier>
+            </dependency>
+            <dependency>
+                <groupId>org.jboss.pnc.rex</groupId>
+                <artifactId>rex-model</artifactId>
+                <version>${version.rex}</version>
+            </dependency>
+            <dependency>
+                <groupId>org.jboss.pnc.rex</groupId>
+                <artifactId>rex-common</artifactId>
+                <version>${version.rex}</version>
             </dependency>
 
             <dependency>


### PR DESCRIPTION
Right now it's just clear-all, but we can expand it in the future. This will provide the framework to add more useful Rex CLI admin commands in the future.

Usage:
```
bacon pnc admin rex clear-all
```

For now, I am grouping the 'rex' sub-command inside 'pnc admin'. Maybe in the future it should be its own dedicated command?

### Checklist:

* [ ] Have you added a note in the [CHANGELOG wiki](https://github.com/project-ncl/bacon/wiki/Changelog) for your change if user-facing?
* [ ] Have you added unit tests for your change?
