### PR TITLE
[NCL-9108] Add backend option to cache artifacts downloaded from Indy

### DIFF
--- a/pig/pom.xml
+++ b/pig/pom.xml
@@ -153,6 +153,10 @@
             <groupId>org.glassfish</groupId>
             <artifactId>javax.el</artifactId>
         </dependency>
+        <dependency>
+            <groupId>org.mapdb</groupId>
+            <artifactId>mapdb</artifactId>
+        </dependency>
 
         <dependency>
             <groupId>org.junit.jupiter</groupId>

--- a/pig/src/main/java/org/jboss/pnc/bacon/pig/impl/utils/FileCache.java
+++ b/pig/src/main/java/org/jboss/pnc/bacon/pig/impl/utils/FileCache.java
@@ -1,0 +1,72 @@
+package org.jboss.pnc.bacon.pig.impl.utils;
+
+import java.io.File;
+import java.io.IOException;
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.util.concurrent.ConcurrentMap;
+
+import org.mapdb.DB;
+import org.mapdb.DBMaker;
+import org.mapdb.Serializer;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+public class FileCache {
+
+    private static final Logger log = LoggerFactory.getLogger(FileCache.class);
+    private static final int MAX_SIZE_GB = 5;
+
+    private DB db;
+    private ConcurrentMap<String, byte[]> cachedMap;
+
+    public FileCache(Path cacheFile) {
+
+        // if cache file parent folder doesn't exist, create it
+        if (!Files.exists(cacheFile.getParent())) {
+            try {
+                Files.createDirectories(cacheFile.getParent());
+            } catch (IOException e) {
+                log.error("Unable to create directory {}", cacheFile.getParent(), e);
+                throw new RuntimeException(e);
+            }
+        }
+
+        db = DBMaker.fileDB(cacheFile.toString())
+                .closeOnJvmShutdown()
+                .make();
+
+        cachedMap = db.hashMap("file-map", Serializer.STRING, Serializer.BYTE_ARRAY)
+                .expireStoreSize(MAX_SIZE_GB * 1024L * 1024L) // max size in bytes,
+                .expireAfterGet()
+                .expireAfterCreate()
+                .createOrOpen();
+    }
+
+    public void put(String key, File file) {
+        try {
+            cachedMap.put(key, Files.readAllBytes(file.toPath()));
+            db.commit();
+        } catch (IOException e) {
+            log.warn("Error writing file {} for cache. Skipping!", file.getAbsolutePath(), e);
+        }
+    }
+
+    public boolean copyTo(String key, File targetPath) {
+        try {
+
+            byte[] data = cachedMap.get(key);
+
+            if (data == null) {
+                // either not present in cache, or evicted
+                return false;
+            }
+            Files.write(targetPath.toPath(), data);
+            return true;
+        } catch (IOException e) {
+            log.warn("Error reading file {} from cache. Skipping!", targetPath.getAbsolutePath(), e);
+            return false;
+        }
+    }
+
+}

--- a/pig/src/test/java/org/jboss/pnc/bacon/pig/impl/utils/FileCacheTest.java
+++ b/pig/src/test/java/org/jboss/pnc/bacon/pig/impl/utils/FileCacheTest.java
@@ -1,0 +1,43 @@
+package org.jboss.pnc.bacon.pig.impl.utils;
+
+import static org.junit.jupiter.api.Assertions.*;
+
+import java.io.IOException;
+import java.nio.file.Files;
+import java.nio.file.Path;
+
+import org.junit.jupiter.api.Test;
+
+class FileCacheTest {
+
+    @Test
+    void testBasicFunctionality() {
+
+        String textToCache = "hello-world";
+
+        try {
+            Path tempCacheFile = Files.createTempFile("bacon-test-", "-file-cache");
+            Files.delete(tempCacheFile); // if the file exists but is empty, MapDB complains
+
+            FileCache fileCache = new FileCache(tempCacheFile);
+
+            Path tempFileToCache = Files.createTempFile("bacon-test-file-to-cache", "-file-cache");
+            Files.writeString(tempFileToCache, textToCache);
+
+            fileCache.put("test", tempFileToCache.toFile());
+
+            Path tempFileFromCache = Files.createTempFile("bacon-test-file-from-cache", "-file-cache");
+            boolean fetched = fileCache.copyTo("test", tempFileFromCache.toFile());
+            assertTrue(fetched);
+
+            String retrievedValue = Files.readString(tempFileFromCache);
+            assertEquals(textToCache, retrievedValue);
+
+            assertFalse(fileCache.copyTo("non-existent-key", tempFileFromCache.toFile()));
+
+        } catch (IOException e) {
+            e.printStackTrace();
+        }
+    }
+
+}

--- a/pom.xml
+++ b/pom.xml
@@ -723,6 +723,11 @@
                 <artifactId>rex-common</artifactId>
                 <version>${version.rex}</version>
             </dependency>
+            <dependency>
+                <groupId>org.mapdb</groupId>
+                <artifactId>mapdb</artifactId>
+                <version>3.1.0</version>
+            </dependency>
 
             <dependency>
                 <groupId>org.projectlombok</groupId>


### PR DESCRIPTION
Note: this feature is currently disabled in this commit until we can customize it on the frontend CLI side.

Generating huge maven repositories involve downloading a lot of artifacts from Indy. This is true for Maven repository generation types of:

- GENERATE
- BUILD_GROUP
- DOWNLOAD
- BUILD_CONFIGS
- MILESTONE

If we need to run the maven repository generations several times in the same machine, the same downloads happen and this can consume a lot of time. It would be nice if we could cache those downloads to speed up the maven repository generations for re-runs.

This commit adds the ability to cache the downloads into a cache file, managed my MapDB. The cache file is limited to a max disk size of 5GB, and the older contents in the cache will automatically get evicted.

The key of the cache is the download url, and the value is the byte array of the content of the downloaded file. The cache file location is in: `${user.home}/.cache/pnc-bacon/pnc-bacon-artifact-cache.db`.

It is currently disabled in the backend, but we'll expose a flag on the frontend in a future commit to enable/disable the cache feature.

### Checklist:

* [ ] Have you added a note in the [CHANGELOG wiki](https://github.com/project-ncl/bacon/wiki/Changelog) for your change if user-facing?
* [ ] Have you added unit tests for your change?
