### PR TITLE
[NCL-9108] Cache for RESOLVE_ONLY maven repo generation

### DIFF
--- a/pig/src/main/java/org/jboss/pnc/bacon/pig/Pig.java
+++ b/pig/src/main/java/org/jboss/pnc/bacon/pig/Pig.java
@@ -146,6 +146,12 @@ public class Pig {
                 description = "If set to false, all artifact downloads will be forcefully done and no cache store will be used")
         boolean artifactCacheDownload;
 
+        @Option(
+                names = "--useLocalM2Cache",
+                defaultValue = "true",
+                description = "If set to false, RESOLVE_ONLY Maven Repository generation will only download from Indy instead of relying on local m2 cache")
+        boolean useLocalM2Cache;
+
         /**
          * Computes a result, or throws an exception if unable to do so.
          *
@@ -307,6 +313,7 @@ public class Pig {
                     skipBranchCheck,
                     strictLicenseCheck,
                     strictDownloadSource,
+                    useLocalM2Cache,
                     skippedAddons,
                     configurationDirectory,
                     licenseExceptionsPath,
@@ -425,7 +432,8 @@ public class Pig {
                     removeGeneratedM2Dups,
                     configurationDirectory,
                     strictLicenseCheck,
-                    strictDownloadSource);
+                    strictDownloadSource,
+                    useLocalM2Cache);
             PigContext.get().setRepositoryData(result);
             PigContext.get().storeContext();
             return result;

--- a/pig/src/main/java/org/jboss/pnc/bacon/pig/PigFacade.java
+++ b/pig/src/main/java/org/jboss/pnc/bacon/pig/PigFacade.java
@@ -166,6 +166,7 @@ public final class PigFacade {
             boolean skipBranchCheck,
             boolean strictLicenseCheck,
             boolean strictDownloadSource,
+            boolean useLocalM2Cache,
             String[] skippedAddons,
             Path configurationDirectory,
             String licenseExceptionsPath,
@@ -224,7 +225,8 @@ public final class PigFacade {
                         removeGeneratedM2Dups,
                         configurationDirectory,
                         strictLicenseCheck,
-                        strictDownloadSource);
+                        strictDownloadSource,
+                        useLocalM2Cache);
             }
             context.setRepositoryData(repo);
             context.storeContext();
@@ -515,7 +517,8 @@ public final class PigFacade {
             boolean removeGeneratedM2Dups,
             Path configurationDirectory,
             boolean strictLicenseCheck,
-            boolean strictSourceDownload) {
+            boolean strictSourceDownload,
+            boolean useLocalM2Cache) {
         beforeCommand(false);
         abortIfBuildDataAbsentFromContext();
         PigContext context = context();
@@ -527,7 +530,8 @@ public final class PigFacade {
                 configurationDirectory,
                 removeGeneratedM2Dups,
                 strictLicenseCheck,
-                strictSourceDownload)) {
+                strictSourceDownload,
+                useLocalM2Cache)) {
 
             RepositoryData repositoryData = repoManager.prepare();
 

--- a/pig/src/main/java/org/jboss/pnc/bacon/pig/impl/utils/indy/Indy.java
+++ b/pig/src/main/java/org/jboss/pnc/bacon/pig/impl/utils/indy/Indy.java
@@ -38,12 +38,24 @@ public class Indy {
     }
 
     public static String getConfiguredIndySettingsXmlPath(boolean tempBuild) {
+        return getConfiguredIndySettingsXmlPath(tempBuild, false);
+    }
+
+    public static String getConfiguredIndySettingsXmlPath(boolean tempBuild, boolean useLocalM2Cache) {
         String settingsXml;
+
+        String filename;
+        if (useLocalM2Cache) {
+            filename = "/indy-cache";
+        } else {
+            filename = "/indy";
+        }
         if (tempBuild) {
-            settingsXml = ResourceUtils.extractToTmpFile("/indy-temp-settings.xml", "settings", ".xml")
+            settingsXml = ResourceUtils.extractToTmpFile(filename + "-temp-settings.xml", "settings", ".xml")
                     .getAbsolutePath();
         } else {
-            settingsXml = ResourceUtils.extractToTmpFile("/indy-settings.xml", "settings", ".xml").getAbsolutePath();
+            settingsXml = ResourceUtils.extractToTmpFile(filename + "-settings.xml", "settings", ".xml")
+                    .getAbsolutePath();
         }
         FileUtils.replaceFileString("\\$\\{INDY_TMP_URL}", Indy.getIndyTempUrl(), settingsXml);
         FileUtils.replaceFileString("\\$\\{INDY_URL}", Indy.getIndyUrl(), settingsXml);

--- a/pig/src/main/resources/indy-cache-settings.xml
+++ b/pig/src/main/resources/indy-cache-settings.xml
@@ -19,31 +19,6 @@
     <localRepository>${user.home}/.m2/repository</localRepository>
     <profiles>
         <profile>
-            <id>indy-repositories</id>
-            <repositories>
-                <repository>
-                    <id>indy</id>
-                    <url>${INDY_URL}</url>
-                </repository>
-                <repository>
-                    <id>indy-temp</id>
-                    <url>${INDY_TMP_URL}/</url>
-                </repository>
-                <!--${ADDITIONAL_REPOS}-->
-            </repositories>
-            <pluginRepositories>
-                <pluginRepository>
-                    <id>indy</id>
-                    <url>${INDY_URL}</url>
-                </pluginRepository>
-                <pluginRepository>
-                    <id>indy-temp</id>
-                    <url>${INDY_TMP_URL}</url>
-                </pluginRepository>
-                <!--${ADDITIONAL_PLUGIN_REPOS}-->
-            </pluginRepositories>
-        </profile>
-        <profile>
             <id>maven-central</id>
             <repositories>
                 <repository>
@@ -58,8 +33,39 @@
                 </pluginRepository>
             </pluginRepositories>
         </profile>
+        <profile>
+            <id>indy-repositories</id>
+            <repositories>
+                <repository>
+                    <id>indy</id>
+                    <url>${INDY_URL}</url>
+                </repository>
+            </repositories>
+            <pluginRepositories>
+                <pluginRepository>
+                    <id>indy</id>
+                    <url>${INDY_URL}</url>
+                </pluginRepository>
+            </pluginRepositories>
+        </profile>
+        <profile>
+            <id>local-m2-cache</id>
+            <repositories>
+                <repository>
+                    <id>local-m2-cache</id>
+                     <url>file://${user.home}/.cache/bacon/m2-cache</url>
+                </repository>
+            </repositories>
+            <pluginRepositories>
+                <pluginRepository>
+                    <id>local-m2-cache</id>
+                    <url>file://${user.home}/.cache/bacon/m2-cache</url>
+                </pluginRepository>
+            </pluginRepositories>
+        </profile>
     </profiles>
     <activeProfiles>
+        <activeProfile>local-m2-cache</activeProfile>
         <activeProfile>indy-repositories</activeProfile>
         <activeProfile>maven-central</activeProfile>
     </activeProfiles>

--- a/pig/src/main/resources/indy-cache-temp-settings.xml
+++ b/pig/src/main/resources/indy-cache-temp-settings.xml
@@ -58,8 +58,24 @@
                 </pluginRepository>
             </pluginRepositories>
         </profile>
+        <profile>
+            <id>local-m2-cache</id>
+            <repositories>
+                <repository>
+                    <id>local-m2-cache</id>
+                    <url>file://${user.home}/.cache/bacon/m2-cache</url>
+                </repository>
+            </repositories>
+            <pluginRepositories>
+                <pluginRepository>
+                    <id>local-m2-cache</id>
+                    <url>file://${user.home}/.cache/bacon/m2-cache</url>
+                </pluginRepository>
+            </pluginRepositories>
+        </profile>
     </profiles>
     <activeProfiles>
+        <activeProfile>local-m2-cache</activeProfile>
         <activeProfile>indy-repositories</activeProfile>
         <activeProfile>maven-central</activeProfile>
     </activeProfiles>

--- a/pig/src/test/java/org/jboss/pnc/bacon/pig/impl/repo/MultiStepBomBasedRepositoryTestBase.java
+++ b/pig/src/test/java/org/jboss/pnc/bacon/pig/impl/repo/MultiStepBomBasedRepositoryTestBase.java
@@ -391,6 +391,10 @@ public abstract class MultiStepBomBasedRepositoryTestBase {
         String pathToTestSettingsFile = testMavenSettings.getAbsolutePath();
         MockedStatic<Indy> indyMockedStatic = Mockito.mockStatic(Indy.class);
         indyMockedStatic.when(() -> Indy.getConfiguredIndySettingsXmlPath(false)).thenReturn(pathToTestSettingsFile);
+        indyMockedStatic.when(() -> Indy.getConfiguredIndySettingsXmlPath(false, true))
+                .thenReturn(pathToTestSettingsFile);
+        indyMockedStatic.when(() -> Indy.getConfiguredIndySettingsXmlPath(false, false))
+                .thenReturn(pathToTestSettingsFile);
         indyMockedStatic.when(() -> Indy.getIndyUrl()).thenReturn("https://mock.indy.org/maven");
     }
 

--- a/pig/src/test/java/org/jboss/pnc/bacon/pig/impl/repo/ResolveOnlyRepositoryTest.java
+++ b/pig/src/test/java/org/jboss/pnc/bacon/pig/impl/repo/ResolveOnlyRepositoryTest.java
@@ -160,6 +160,10 @@ public class ResolveOnlyRepositoryTest {
         String pathToTestSettingsFile = testMavenSettings.getAbsolutePath();
         MockedStatic<Indy> indyMockedStatic = Mockito.mockStatic(Indy.class);
         indyMockedStatic.when(() -> Indy.getConfiguredIndySettingsXmlPath(false)).thenReturn(pathToTestSettingsFile);
+        indyMockedStatic.when(() -> Indy.getConfiguredIndySettingsXmlPath(false, true))
+                .thenReturn(pathToTestSettingsFile);
+        indyMockedStatic.when(() -> Indy.getConfiguredIndySettingsXmlPath(false, false))
+                .thenReturn(pathToTestSettingsFile);
     }
 
     private PigConfiguration mockPigConfigurationAndMethods() {


### PR DESCRIPTION
This commit adds caching features to the maven repo generation:
- RESOLVE_ONLY
- GENERATE
- (anything BOM based)

It does so by adding a new local m2 cache folder `~/.cache/bacon/m2-cache` which is initially empty. The first run of Maven repository generation will generate the maven repository. This repository content is then copied to the local m2 cache folder.

On subsequent runs, this m2 cache folder will be checked for content before trying to download from Indy. This should significantly speed up Maven repo generation.

This is useful when testing locally for different variants of the maven repository generation, where the BOM content won't change that much from runs.

To disable this feature, you can use the `--useLocalM2Cache=false` to disable the cache feature. It is set to true by default.

### Checklist:

* [ ] Have you added a note in the [CHANGELOG wiki](https://github.com/project-ncl/bacon/wiki/Changelog) for your change if user-facing?
* [ ] Have you added unit tests for your change?
