### PR TITLE
Use force to regenerate autocompletion file

### DIFF
--- a/cli/pom.xml
+++ b/cli/pom.xml
@@ -174,6 +174,7 @@
                             <mainClass>picocli.AutoComplete</mainClass>
                             <arguments>
                                 <argument>org.jboss.pnc.bacon.cli.App</argument>
+                                <argument>--force</argument>
                             </arguments>
                             <classpathScope>compile</classpathScope>
                         </configuration>


### PR DESCRIPTION
This will regenerate bacon_completion file every build, otherwise it just complained file is there and won't generate it. If there is no change in commands, file is identical and not flagged in git changes.
