### PR TITLE
NCL-9218 Add reqourConfig and simplify imports

### DIFF
--- a/common/pom.xml
+++ b/common/pom.xml
@@ -37,7 +37,12 @@
         </dependency>
         <dependency>
             <groupId>org.jboss.pnc</groupId>
-            <artifactId>rest-client</artifactId>
+            <artifactId>rest-api</artifactId>
+            <classifier>java-client</classifier>
+        </dependency>
+        <dependency>
+            <groupId>org.jboss.pnc</groupId>
+            <artifactId>common</artifactId>
         </dependency>
         <dependency>
             <groupId>com.fasterxml.jackson.dataformat</groupId>

--- a/config/src/main/java/org/jboss/pnc/bacon/config/ReqourConfig.java
+++ b/config/src/main/java/org/jboss/pnc/bacon/config/ReqourConfig.java
@@ -17,24 +17,14 @@
  */
 package org.jboss.pnc.bacon.config;
 
-import java.util.Map;
-
 import lombok.Data;
 
 @Data
-public class ConfigProfile {
+public class ReqourConfig implements Validate {
+    private String url;
 
-    private String name;
-    private String keycloakUrl;
-    private PncConfig pnc;
-    private DaConfig da;
-    private IndyConfig indy;
-    private PigConfig pig;
-    private KeycloakConfig keycloak;
-    private AutobuildConfig autobuild;
-    private RexConfig rex;
-    private ReqourConfig reqour;
-    private boolean enableExperimental;
-
-    private Map<String, Map<String, ?>> addOns;
+    @Override
+    public void validate() {
+        Validate.validateUrl(url, "Reqour URL");
+    }
 }

--- a/pom.xml
+++ b/pom.xml
@@ -185,6 +185,17 @@
             </dependency>
             <dependency>
                 <groupId>org.jboss.pnc</groupId>
+                <artifactId>rest-api</artifactId>
+                <version>${pnc.version}</version>
+                <classifier>java-client</classifier>
+            </dependency>
+            <dependency>
+                <groupId>org.jboss.pnc</groupId>
+                <artifactId>common</artifactId>
+                <version>${pnc.version}</version>
+            </dependency>
+            <dependency>
+                <groupId>org.jboss.pnc</groupId>
                 <artifactId>dto</artifactId>
                 <version>${pnc.version}</version>
             </dependency>


### PR DESCRIPTION
@jomrazek The idea here is to allow the bacon code to be more easily reusable without conflicting with Quarkus. By changing the imports to only whats needed it avoids bringing the rest-client module which which brings in resteasy. I have also added a section to be able to configure Reqour in future.