### PR TITLE
Change python library for download to fix 403 error

### DIFF
--- a/bacon_install.py
+++ b/bacon_install.py
@@ -137,16 +137,15 @@ def download_link(link, folder, filename, fail=True, retries=7):
     """
 
     print("Downloading: " + link)
-    if sys.version_info[0] >= 3:
-        import urllib.request as request
-    else:
-        import urllib2 as request
+    import urllib3
+    http = urllib3.PoolManager()
+
 
     try:
-        r = request.urlopen(link).read()
+        response = http.request("GET", link)
 
         with open(folder + "/" + filename, "wb") as f:
-            f.write(r)
+            f.write(response.data)
     except Exception as error:
         if retries > 0:
             # exponential backoff time based on 1/retries


### PR DESCRIPTION
This approach works, I removed python <= 2 support as this is only place where I found we distinguish between those.(is this correct?) I don't know how to make old approach to work, if you know how I will change this PR :(