### PR TITLE
Capture the repository coordinates and add them to the provenance resolvedDependencies

### DIFF
--- a/.github/workflows/maven-pr.yml
+++ b/.github/workflows/maven-pr.yml
@@ -23,6 +23,6 @@ jobs:
         # Weirdly it needs to be present in our .m2/repository folder for the
         # test to pass. I thought it would be downloaded by the Maven resolver
         # directly.
-        build_command: mvn dependency:get -Dartifact=junit:junit:4.12 && mvn -B -V -DextraSurefireJvmArgs="-Xms256m -Xmx3g" clean install
+        build_command: mvn dependency:get -Dartifact=junit:junit:4.12 && mvn -B -V -DextraSurefireJvmArgs="-Xms256m -Xmx4g" clean install
         java_version: 17
         upload_artifacts: true

--- a/pig/src/main/java/org/jboss/pnc/bacon/pig/impl/addons/provenance/GitInfo.java
+++ b/pig/src/main/java/org/jboss/pnc/bacon/pig/impl/addons/provenance/GitInfo.java
@@ -1,0 +1,125 @@
+/*
+ * JBoss, Home of Professional Open Source.
+ * Copyright 2017 Red Hat, Inc., and individual contributors
+ * as indicated by the @author tags.
+ * <p>
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ * <p>
+ * http://www.apache.org/licenses/LICENSE-2.0
+ * <p>
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.jboss.pnc.bacon.pig.impl.addons.provenance;
+
+import java.io.BufferedReader;
+import java.io.InputStreamReader;
+import java.nio.file.Path;
+import java.util.Optional;
+import java.util.concurrent.TimeUnit;
+
+import lombok.extern.slf4j.Slf4j;
+
+/**
+ * Utility class to retrieve Git repository information from the current working directory.
+ * This is used to capture the configuration repository context when the Bacon CLI is executed.
+ */
+@Slf4j
+public final class GitInfo {
+
+    private final String repositoryUrl;
+    private final String commitHash;
+
+    private GitInfo(String repositoryUrl, String commitHash) {
+        this.repositoryUrl = repositoryUrl;
+        this.commitHash = commitHash;
+    }
+
+    public String getRepositoryUrl() {
+        return repositoryUrl;
+    }
+
+    public String getCommitHash() {
+        return commitHash;
+    }
+
+    /**
+     * Attempts to retrieve Git repository information from the specified directory.
+     *
+     * @param workingDirectory the directory to check for git repository information
+     * @return Optional containing GitInfo if successful, empty otherwise
+     */
+    public static Optional<GitInfo> fromDirectory(Path workingDirectory) {
+        try {
+            String repoUrl = executeGitCommand(workingDirectory, "git", "config", "--get", "remote.origin.url");
+            String commitHash = executeGitCommand(workingDirectory, "git", "rev-parse", "HEAD");
+
+            if (repoUrl != null && !repoUrl.isEmpty() && commitHash != null && !commitHash.isEmpty()) {
+                log.debug("Retrieved git info from {}: repo={}, commit={}", workingDirectory, repoUrl, commitHash);
+                return Optional.of(new GitInfo(repoUrl.trim(), commitHash.trim()));
+            } else {
+                log.debug("Git repository information incomplete in {}", workingDirectory);
+                return Optional.empty();
+            }
+        } catch (Exception e) {
+            log.debug("Failed to retrieve git information from {}: {}", workingDirectory, e.getMessage());
+            return Optional.empty();
+        }
+    }
+
+    /**
+     * Attempts to retrieve Git repository information from the current working directory.
+     *
+     * @return Optional containing GitInfo if successful, empty otherwise
+     */
+    public static Optional<GitInfo> fromCurrentDirectory() {
+        return fromDirectory(Path.of(System.getProperty("user.dir")));
+    }
+
+    /**
+     * Executes a git command and returns the output.
+     *
+     * @param workingDir the directory to execute the command in
+     * @param command the command and arguments to execute
+     * @return the command output, or null if the command failed
+     */
+    private static String executeGitCommand(Path workingDir, String... command) throws Exception {
+        ProcessBuilder pb = new ProcessBuilder(command);
+        pb.directory(workingDir.toFile());
+        pb.redirectErrorStream(true);
+
+        Process process = pb.start();
+        StringBuilder output = new StringBuilder();
+
+        try (BufferedReader reader = new BufferedReader(new InputStreamReader(process.getInputStream()))) {
+            String line;
+            while ((line = reader.readLine()) != null) {
+                output.append(line).append("\n");
+            }
+        }
+
+        boolean finished = process.waitFor(5, TimeUnit.SECONDS);
+        if (!finished) {
+            process.destroyForcibly();
+            throw new RuntimeException("Git command timed out");
+        }
+
+        int exitCode = process.exitValue();
+        if (exitCode != 0) {
+            log.trace("Git command failed with exit code {}: {}", exitCode, output.toString().trim());
+            return null;
+        }
+
+        return output.toString().trim();
+    }
+
+    @Override
+    public String toString() {
+        return "GitInfo{repositoryUrl='" + repositoryUrl + "', commitHash='" + commitHash + "'}";
+    }
+}

--- a/pig/src/main/java/org/jboss/pnc/bacon/pig/impl/addons/provenance/SlsaProvenanceV1Utils.java
+++ b/pig/src/main/java/org/jboss/pnc/bacon/pig/impl/addons/provenance/SlsaProvenanceV1Utils.java
@@ -118,6 +118,7 @@ public final class SlsaProvenanceV1Utils {
         // - bacon github URI
         // - preprocessed build-config.yaml digest (after substitution of variables)
         // - Pig config dir hash (context hash)
+        // - configuration repository git information (if available)
         // - any DeliverableInput materials registered
         List<ResourceDescriptor> deps = new ArrayList<>();
         deps.add(
@@ -147,6 +148,18 @@ public final class SlsaProvenanceV1Utils {
                             .digest(Map.of("sha512", ctx.getConfigSha()))
                             .build());
         }
+
+        // 3) Git repository information from the current working directory
+        //    This captures the configuration repository context when the CLI is executed
+        GitInfo.fromCurrentDirectory().ifPresent(gitInfo -> {
+            log.debug("Adding git repository information to provenance: {}", gitInfo);
+            deps.add(
+                    ResourceDescriptor.builder()
+                            .name("repository")
+                            .uri(gitInfo.getRepositoryUrl())
+                            .digest(Map.of("gitCommit", gitInfo.getCommitHash()))
+                            .build());
+        });
 
         return BuildDefinition.builder()
                 .buildType(BUILD_TYPE)

--- a/pig/src/test/java/org/jboss/pnc/bacon/pig/impl/addons/provenance/GitInfoTest.java
+++ b/pig/src/test/java/org/jboss/pnc/bacon/pig/impl/addons/provenance/GitInfoTest.java
@@ -1,0 +1,166 @@
+package org.jboss.pnc.bacon.pig.impl.addons.provenance;
+
+import static org.junit.jupiter.api.Assertions.*;
+
+import java.io.File;
+import java.io.IOException;
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.util.Optional;
+
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.io.TempDir;
+
+/**
+ * Tests for GitInfo utility class that retrieves git repository information.
+ */
+class GitInfoTest {
+
+    @Test
+    void testFromCurrentDirectory_WhenInGitRepo() {
+        // This test will only pass if the test is run from within a git repository
+        // In a real git repo, this should return a valid GitInfo
+        Optional<GitInfo> gitInfo = GitInfo.fromCurrentDirectory();
+
+        // We can't assert it's present because tests might run outside a git repo
+        // But we can verify the method doesn't throw exceptions
+        assertNotNull(gitInfo);
+    }
+
+    @Test
+    void testFromDirectory_WithNonGitDirectory(@TempDir Path tempDir) {
+        // Test with a directory that is not a git repository
+        Optional<GitInfo> gitInfo = GitInfo.fromDirectory(tempDir);
+
+        // Should return empty Optional for non-git directories
+        assertTrue(gitInfo.isEmpty(), "Should return empty Optional for non-git directory");
+    }
+
+    @Test
+    void testFromDirectory_WithNullPath() {
+        // Test with null path
+        Optional<GitInfo> gitInfo = GitInfo.fromDirectory(null);
+
+        // Should return empty Optional for null directories
+        assertTrue(gitInfo.isEmpty(), "Should return empty Optional for null directory");
+    }
+
+    @Test
+    void testFromDirectory_WithNonExistentPath() {
+        // Test with a path that doesn't exist
+        Path nonExistent = Path.of("/tmp/non-existent-directory-" + System.currentTimeMillis());
+        Optional<GitInfo> gitInfo = GitInfo.fromDirectory(nonExistent);
+
+        // Should return empty Optional for non-existent directories
+        assertTrue(gitInfo.isEmpty(), "Should return empty Optional for non-existent directory");
+    }
+
+    @Test
+    void testGitInfo_GettersReturnCorrectValues() {
+        // Create a GitInfo instance using reflection to test getters
+        // Since constructor is private, we test through the factory method
+
+        // If we're in a git repo, test the getters
+        Optional<GitInfo> gitInfoOpt = GitInfo.fromCurrentDirectory();
+
+        gitInfoOpt.ifPresent(gitInfo -> {
+            assertNotNull(gitInfo.getRepositoryUrl(), "Repository URL should not be null");
+            assertNotNull(gitInfo.getCommitHash(), "Commit hash should not be null");
+            assertFalse(gitInfo.getRepositoryUrl().isEmpty(), "Repository URL should not be empty");
+            assertFalse(gitInfo.getCommitHash().isEmpty(), "Commit hash should not be empty");
+
+            // Commit hash should be a valid SHA-1 (40 hex characters)
+            assertTrue(
+                    gitInfo.getCommitHash().matches("[0-9a-f]{40}"),
+                    "Commit hash should be a valid SHA-1 hash");
+
+            // Repository URL should be a valid URL or git path
+            String repoUrl = gitInfo.getRepositoryUrl();
+            assertTrue(
+                    repoUrl.startsWith("http://") ||
+                            repoUrl.startsWith("https://") ||
+                            repoUrl.startsWith("git@") ||
+                            repoUrl.startsWith("file://") ||
+                            repoUrl.startsWith("/"),
+                    "Repository URL should be a valid git URL format");
+        });
+    }
+
+    @Test
+    void testGitInfo_ToStringContainsRelevantInfo() {
+        Optional<GitInfo> gitInfoOpt = GitInfo.fromCurrentDirectory();
+
+        gitInfoOpt.ifPresent(gitInfo -> {
+            String toString = gitInfo.toString();
+            assertNotNull(toString);
+            assertTrue(toString.contains("GitInfo"), "toString should contain class name");
+            assertTrue(toString.contains("repositoryUrl"), "toString should contain repositoryUrl field");
+            assertTrue(toString.contains("commitHash"), "toString should contain commitHash field");
+            assertTrue(toString.contains(gitInfo.getRepositoryUrl()), "toString should contain actual URL");
+            assertTrue(toString.contains(gitInfo.getCommitHash()), "toString should contain actual commit hash");
+        });
+    }
+
+    @Test
+    void testFromDirectory_WithGitRepoSimulation(@TempDir Path tempDir) throws IOException, InterruptedException {
+        // Create a minimal git repository for testing
+        File gitDir = new File(tempDir.toFile(), ".git");
+        if (gitDir.mkdir()) {
+            // Create a minimal git config
+            File configDir = new File(gitDir, "config");
+            Files.writeString(
+                    configDir.toPath(),
+                    "[core]\n" +
+                            "    repositoryformatversion = 0\n" +
+                            "[remote \"origin\"]\n" +
+                            "    url = https://github.com/test/repo.git\n");
+
+            // Initialize git repo properly
+            ProcessBuilder pb = new ProcessBuilder("git", "init");
+            pb.directory(tempDir.toFile());
+            Process process = pb.start();
+            process.waitFor();
+
+            // Add remote
+            pb = new ProcessBuilder("git", "remote", "add", "origin", "https://github.com/test/repo.git");
+            pb.directory(tempDir.toFile());
+            process = pb.start();
+            process.waitFor();
+
+            // Create initial commit
+            pb = new ProcessBuilder("git", "config", "user.email", "test@example.com");
+            pb.directory(tempDir.toFile());
+            process = pb.start();
+            process.waitFor();
+
+            pb = new ProcessBuilder("git", "config", "user.name", "Test User");
+            pb.directory(tempDir.toFile());
+            process = pb.start();
+            process.waitFor();
+
+            Files.writeString(tempDir.resolve("test.txt"), "test content");
+
+            pb = new ProcessBuilder("git", "add", ".");
+            pb.directory(tempDir.toFile());
+            process = pb.start();
+            process.waitFor();
+
+            pb = new ProcessBuilder("git", "commit", "-m", "Initial commit");
+            pb.directory(tempDir.toFile());
+            process = pb.start();
+            int exitCode = process.waitFor();
+
+            if (exitCode == 0) {
+                // Now test GitInfo
+                Optional<GitInfo> gitInfo = GitInfo.fromDirectory(tempDir);
+
+                assertTrue(gitInfo.isPresent(), "Should find git info in initialized repo");
+                gitInfo.ifPresent(info -> {
+                    assertEquals("https://github.com/test/repo.git", info.getRepositoryUrl());
+                    assertNotNull(info.getCommitHash());
+                    assertTrue(info.getCommitHash().matches("[0-9a-f]{40}"));
+                });
+            }
+        }
+    }
+}

--- a/pig/src/test/java/org/jboss/pnc/bacon/pig/impl/addons/provenance/SlsaProvenanceV1UtilsTest.java
+++ b/pig/src/test/java/org/jboss/pnc/bacon/pig/impl/addons/provenance/SlsaProvenanceV1UtilsTest.java
@@ -1,0 +1,226 @@
+package org.jboss.pnc.bacon.pig.impl.addons.provenance;
+
+import static org.junit.jupiter.api.Assertions.*;
+
+import java.nio.file.Path;
+import java.nio.file.Paths;
+import java.time.Instant;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+import java.util.Optional;
+
+import org.jboss.pnc.api.slsa.dto.provenance.v1.BuildDefinition;
+import org.jboss.pnc.api.slsa.dto.provenance.v1.Provenance;
+import org.jboss.pnc.api.slsa.dto.provenance.v1.ResourceDescriptor;
+import org.jboss.pnc.bacon.common.deliverables.DeliverableRecord;
+import org.jboss.pnc.bacon.common.deliverables.DeliverableType;
+import org.jboss.pnc.bacon.pig.impl.PigContext;
+import org.jboss.pnc.bacon.pig.impl.config.PigConfiguration;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+
+/**
+ * Tests for SlsaProvenanceV1Utils to verify provenance generation including git information.
+ */
+class SlsaProvenanceV1UtilsTest {
+
+    private PigContext mockContext;
+    private InvocationInfo mockInvocation;
+    private DeliverableRecord mockDeliverable;
+
+    @BeforeEach
+    void setUp() {
+        // Create a minimal PigContext for testing
+        mockContext = new PigContext();
+
+        // Set up basic configuration
+        PigConfiguration config = new PigConfiguration();
+        config.setVersion("1.0.0");
+
+        // Initialize context with test values
+        Path testPath = Paths.get("target", "test");
+        mockContext.setPigConfiguration(config);
+        mockContext.setTargetPath(testPath.toString());
+        mockContext.setReleasePath(testPath.resolve("release").toString());
+        mockContext.setExtrasPath(testPath.resolve("extras").toString());
+        mockContext.setPrefix("test-prefix");
+        mockContext.setFullVersion("1.0.0.Final");
+        mockContext.setReleaseDirName("test-release");
+
+        // Create mock invocation info
+        Map<String, String> configDigests = new HashMap<>();
+        configDigests.put("build-config.preprocessed.sha256", "abc123def456");
+
+        mockInvocation = new InvocationInfo(
+                "0.1.0-test",
+                "bacon pig build",
+                "test-invocation-id",
+                Instant.now(),
+                Instant.now(),
+                configDigests);
+
+        // Create mock deliverable
+        Map<String, String> digests = new HashMap<>();
+        digests.put("sha256", "deliverable123abc");
+
+        mockDeliverable = DeliverableRecord.create(
+                DeliverableType.MAVEN_REPO_ZIP,
+                Paths.get("test-deliverable.zip"),
+                "test-creator",
+                Map.of());
+        mockDeliverable.setDigests(digests);
+    }
+
+    @Test
+    void testToProvenance_CreatesValidProvenance() {
+        Provenance provenance = SlsaProvenanceV1Utils.toProvenance(mockContext, mockInvocation, mockDeliverable);
+
+        assertNotNull(provenance, "Provenance should not be null");
+        assertEquals("https://in-toto.io/Statement/v1", provenance.getType());
+        assertEquals("https://slsa.dev/provenance/v1", provenance.getPredicateType());
+        assertNotNull(provenance.getPredicate(), "Predicate should not be null");
+        assertNotNull(provenance.getSubject(), "Subject should not be null");
+        assertFalse(provenance.getSubject().isEmpty(), "Subject should not be empty");
+    }
+
+    @Test
+    void testToProvenance_ContainsBuildDefinition() {
+        Provenance provenance = SlsaProvenanceV1Utils.toProvenance(mockContext, mockInvocation, mockDeliverable);
+
+        BuildDefinition buildDef = provenance.getPredicate().getBuildDefinition();
+        assertNotNull(buildDef, "BuildDefinition should not be null");
+        assertEquals("https://project-ncl.github.io/slsa-pnc-cli-buildtypes/workflow/v1", buildDef.getBuildType());
+        assertNotNull(buildDef.getExternalParameters(), "External parameters should not be null");
+        assertNotNull(buildDef.getInternalParameters(), "Internal parameters should not be null");
+        assertNotNull(buildDef.getResolvedDependencies(), "Resolved dependencies should not be null");
+    }
+
+    @Test
+    void testToProvenance_ContainsBaconDependency() {
+        Provenance provenance = SlsaProvenanceV1Utils.toProvenance(mockContext, mockInvocation, mockDeliverable);
+
+        List<ResourceDescriptor> deps = provenance.getPredicate().getBuildDefinition().getResolvedDependencies();
+
+        Optional<ResourceDescriptor> baconDep = deps.stream()
+                .filter(d -> "bacon".equals(d.getName()))
+                .findFirst();
+
+        assertTrue(baconDep.isPresent(), "Should contain bacon dependency");
+        assertEquals("https://github.com/project-ncl/bacon", baconDep.get().getUri());
+        assertNotNull(baconDep.get().getAnnotations(), "Bacon dependency should have annotations");
+    }
+
+    @Test
+    void testToProvenance_ContainsPreprocessedConfigDependency() {
+        Provenance provenance = SlsaProvenanceV1Utils.toProvenance(mockContext, mockInvocation, mockDeliverable);
+
+        List<ResourceDescriptor> deps = provenance.getPredicate().getBuildDefinition().getResolvedDependencies();
+
+        Optional<ResourceDescriptor> configDep = deps.stream()
+                .filter(d -> d.getName() != null && d.getName().contains("build-config.yaml"))
+                .findFirst();
+
+        assertTrue(configDep.isPresent(), "Should contain preprocessed config dependency");
+        assertNotNull(configDep.get().getDigest(), "Config dependency should have digest");
+        assertTrue(configDep.get().getDigest().containsKey("sha256"), "Config should have sha256 digest");
+    }
+
+    @Test
+    void testToProvenance_MayContainGitRepositoryInfo() {
+        Provenance provenance = SlsaProvenanceV1Utils.toProvenance(mockContext, mockInvocation, mockDeliverable);
+
+        List<ResourceDescriptor> deps = provenance.getPredicate().getBuildDefinition().getResolvedDependencies();
+
+        // Check if git repository info is present (it may or may not be, depending on test environment)
+        Optional<ResourceDescriptor> gitDep = deps.stream()
+                .filter(d -> "repository".equals(d.getName()))
+                .findFirst();
+
+        // If present, verify its structure
+        gitDep.ifPresent(dep -> {
+            assertNotNull(dep.getUri(), "Git repository should have URI");
+            assertNotNull(dep.getDigest(), "Git repository should have digest");
+            assertTrue(dep.getDigest().containsKey("gitCommit"), "Git repository should have gitCommit in digest");
+
+            String commitHash = dep.getDigest().get("gitCommit");
+            assertNotNull(commitHash, "Commit hash should not be null");
+            assertTrue(
+                    commitHash.matches("[0-9a-f]{40}"),
+                    "Commit hash should be a valid SHA-1 hash (40 hex chars)");
+
+            String repoUrl = dep.getUri();
+            assertTrue(
+                    repoUrl.startsWith("http://") ||
+                            repoUrl.startsWith("https://") ||
+                            repoUrl.startsWith("git@") ||
+                            repoUrl.startsWith("file://") ||
+                            repoUrl.startsWith("/"),
+                    "Repository URL should be a valid git URL format");
+        });
+    }
+
+    @Test
+    void testToProvenance_ContainsRunDetails() {
+        Provenance provenance = SlsaProvenanceV1Utils.toProvenance(mockContext, mockInvocation, mockDeliverable);
+
+        assertNotNull(provenance.getPredicate().getRunDetails(), "RunDetails should not be null");
+        assertNotNull(provenance.getPredicate().getRunDetails().getBuilder(), "Builder should not be null");
+        assertNotNull(provenance.getPredicate().getRunDetails().getMetadata(), "Metadata should not be null");
+
+        // Verify builder ID format
+        String builderId = provenance.getPredicate().getRunDetails().getBuilder().getId();
+        assertTrue(builderId.startsWith("urn:uuid:"), "Builder ID should start with urn:uuid:");
+
+        // Verify metadata
+        assertEquals("test-invocation-id", provenance.getPredicate().getRunDetails().getMetadata().getInvocationId());
+        assertNotNull(provenance.getPredicate().getRunDetails().getMetadata().getStartedOn());
+        assertNotNull(provenance.getPredicate().getRunDetails().getMetadata().getFinishedOn());
+    }
+
+    @Test
+    void testToProvenance_ContainsSubjectWithCorrectDigest() {
+        Provenance provenance = SlsaProvenanceV1Utils.toProvenance(mockContext, mockInvocation, mockDeliverable);
+
+        List<ResourceDescriptor> subjects = provenance.getSubject();
+        assertEquals(1, subjects.size(), "Should have exactly one subject");
+
+        ResourceDescriptor subject = subjects.get(0);
+        assertEquals("test-deliverable.zip", subject.getName());
+        assertNotNull(subject.getDigest(), "Subject should have digest");
+        assertEquals("deliverable123abc", subject.getDigest().get("sha256"));
+    }
+
+    @Test
+    void testToProvenance_ExternalParametersContainExpectedFields() {
+        Provenance provenance = SlsaProvenanceV1Utils.toProvenance(mockContext, mockInvocation, mockDeliverable);
+
+        Map<String, Object> externalParams = provenance.getPredicate().getBuildDefinition().getExternalParameters();
+
+        assertTrue(externalParams.containsKey("commandLine"), "Should contain commandLine");
+        assertTrue(externalParams.containsKey("prefix"), "Should contain prefix");
+        assertTrue(externalParams.containsKey("fullVersion"), "Should contain fullVersion");
+        assertTrue(externalParams.containsKey("tempBuild"), "Should contain tempBuild");
+        assertTrue(externalParams.containsKey("targetPath"), "Should contain targetPath");
+        assertTrue(externalParams.containsKey("releaseDirName"), "Should contain releaseDirName");
+
+        assertEquals("bacon pig build", externalParams.get("commandLine"));
+        assertEquals("test-prefix", externalParams.get("prefix"));
+        assertEquals("1.0.0.Final", externalParams.get("fullVersion"));
+    }
+
+    @Test
+    void testToProvenance_InternalParametersContainDeliverableInfo() {
+        Provenance provenance = SlsaProvenanceV1Utils.toProvenance(mockContext, mockInvocation, mockDeliverable);
+
+        Map<String, Object> internalParams = provenance.getPredicate().getBuildDefinition().getInternalParameters();
+
+        assertTrue(internalParams.containsKey("deliverableType"), "Should contain deliverableType");
+        assertTrue(internalParams.containsKey("createdBy"), "Should contain createdBy");
+        assertTrue(internalParams.containsKey("createdAt"), "Should contain createdAt");
+
+        assertEquals("MAVEN_REPO_ZIP", internalParams.get("deliverableType"));
+        assertEquals("test-creator", internalParams.get("createdBy"));
+    }
+
+}


### PR DESCRIPTION
This patch is enhancing the provenance information, retrieving any Git repository information from the current working directory where the Bacon CLI is executed, and adding it to the `predicate.buildDefinition.resolvedDependencies`.
