### PR TITLE
Add jbang-catalog.json and document JBang usage in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -12,5 +12,39 @@ Contributions are welcome! Please see the [Developer's guide](https://github.com
 Finally, our [changelog](https://project-ncl.github.io/bacon/changelog.html) lists the changes that happened in releases.
 
 ---
+# Installation via JBang
+
+[JBang](https://www.jbang.dev) lets you run or install bacon directly from Maven Central with no manual download. Requires Java 17+.
+
+## Run directly
+
+```shell
+jbang bacon@project-ncl pnc build list
+jbang pnc@project-ncl build list
+jbang da@project-ncl
+jbang pig@project-ncl
+```
+
+## Install as a local command
+
+```shell
+jbang app install bacon@project-ncl
+jbang app install pnc@project-ncl
+jbang app install da@project-ncl
+jbang app install pig@project-ncl
+```
+
+After installing, `bacon`, `pnc`, `da`, and `pig` are available on your `PATH`.
+
+## Snapshot builds
+
+Append `-snapshot` to use the latest snapshot from Maven Central:
+
+```shell
+jbang bacon-snapshot@project-ncl pnc build list
+jbang app install bacon-snapshot@project-ncl
+```
+
+---
 # Reporting an issue
 To report an issue, please use the NCLSUP/NCL projects in the internal JIRA instance. The Github issues usage is now disabled.

--- a/jbang-catalog.json
+++ b/jbang-catalog.json
@@ -1,0 +1,54 @@
+{
+  "aliases": {
+    "bacon": {
+      "script-ref": "org.jboss.pnc.bacon:cli:RELEASE:shaded",
+      "description": "PNC/DA/PiG CLI for ProjectNCL 2.0",
+      "java": "17+"
+    },
+    "pnc": {
+      "script-ref": "org.jboss.pnc.bacon:cli:RELEASE:shaded",
+      "arguments": ["pnc"],
+      "description": "PNC CLI (via bacon)",
+      "java": "17+"
+    },
+    "da": {
+      "script-ref": "org.jboss.pnc.bacon:cli:RELEASE:shaded",
+      "arguments": ["da"],
+      "description": "Dependency Analysis CLI (via bacon)",
+      "java": "17+"
+    },
+    "pig": {
+      "script-ref": "org.jboss.pnc.bacon:cli:RELEASE:shaded",
+      "arguments": ["pig"],
+      "description": "PiG CLI (via bacon)",
+      "java": "17+"
+    },
+    "bacon-snapshot": {
+      "script-ref": "org.jboss.pnc.bacon:cli:LATEST:shaded",
+      "description": "PNC/DA/PiG CLI for ProjectNCL 2.0 (snapshot)",
+      "java": "17+",
+      "repositories": ["mavenlocal", "central", "central-portal-snapshots"]
+    },
+    "pnc-snapshot": {
+      "script-ref": "org.jboss.pnc.bacon:cli:LATEST:shaded",
+      "arguments": ["pnc"],
+      "description": "PNC CLI (via bacon, snapshot)",
+      "java": "17+",
+      "repositories": ["mavenlocal", "central", "central-portal-snapshots"]
+    },
+    "da-snapshot": {
+      "script-ref": "org.jboss.pnc.bacon:cli:LATEST:shaded",
+      "arguments": ["da"],
+      "description": "Dependency Analysis CLI (via bacon, snapshot)",
+      "java": "17+",
+      "repositories": ["mavenlocal", "central", "central-portal-snapshots"]
+    },
+    "pig-snapshot": {
+      "script-ref": "org.jboss.pnc.bacon:cli:LATEST:shaded",
+      "arguments": ["pig"],
+      "description": "PiG CLI (via bacon, snapshot)",
+      "java": "17+",
+      "repositories": ["mavenlocal", "central", "central-portal-snapshots"]
+    }
+  }
+}


### PR DESCRIPTION
Adds a JBang catalog so users can run/install bacon directly from Maven Central:

```shell
jbang bacon@project-ncl pnc build list
jbang app install bacon@project-ncl
```

**Changes:**
- `jbang-catalog.json` with aliases: `bacon`, `pnc`, `da`, `pig` (+ snapshot variants)
- README section documenting run, install,  and snapshot usage