### PR TITLE
Add configurable buildNameSuffix for generated build config names

### DIFF
--- a/docs/guide/experimental.md
+++ b/docs/guide/experimental.md
@@ -81,6 +81,7 @@ buildConfigGeneratorConfig: # Configuration for how the new build configs should
         "git@github.com:": "https://github.com/" # "git@github.com:foo/bar.git" -> "https://github.com/foo/bar.git"
     scmMapping: # SCM URLs containing the listed key are wholy replaced by the value
         "svn.example.com/foo-bar": "https://git.example.com/foo/bar.git" # "https://svn.example.com/foo-bar/branch" -> "https://git.example.com/foo/bar.git"
+    buildNameSuffix: "-AUTOBUILD" # Suffix appended to generated build config names. Defaults to "-AUTOBUILD". Set to "" to disable.
     failGeneratedBuildScript: true # When generating new or copying and changing existing build config, will part to build script to make sure the build fails
     # This can be helpful to make sure the configs are manually reviewed
     allowDeprecatedEnvironments: false # If true, uses systemImageId to specify environment (to force use of specific environment) when the enviornment defined by environmentName would not be found because it was deprecated.

--- a/experimental/src/main/java/org/jboss/bacon/experimental/DependencyGenerator.java
+++ b/experimental/src/main/java/org/jboss/bacon/experimental/DependencyGenerator.java
@@ -103,7 +103,8 @@ public class DependencyGenerator {
             GeneratorConfig config = loadConfig();
             // Initialize working classes
             DependencyResolver dependencyResolver = new DependencyResolver(config.getDependencyResolutionConfig());
-            ProjectNameGenerator projectNameGenerator = new ProjectNameGenerator();
+            ProjectNameGenerator projectNameGenerator = new ProjectNameGenerator(
+                    config.getBuildConfigGeneratorConfig().getBuildNameSuffix());
             ProjectFinder projectFinder = new ProjectFinder(config.getBuildConfigGeneratorConfig());
             BuildConfigGenerator buildConfigGenerator = new BuildConfigGenerator(
                     config.getBuildConfigGeneratorConfig());

--- a/experimental/src/main/java/org/jboss/bacon/experimental/impl/config/BuildConfigGeneratorConfig.java
+++ b/experimental/src/main/java/org/jboss/bacon/experimental/impl/config/BuildConfigGeneratorConfig.java
@@ -62,4 +62,10 @@ public class BuildConfigGeneratorConfig {
      * defined by environmentName would not be found because it was deprecated.
      */
     private boolean allowDeprecatedEnvironments = false;
+
+    /**
+     * Suffix appended to generated build config names. Set to empty string to disable.
+     */
+    @NotNull
+    private String buildNameSuffix = "-AUTOBUILD";
 }

--- a/experimental/src/main/java/org/jboss/bacon/experimental/impl/generator/ProjectNameGenerator.java
+++ b/experimental/src/main/java/org/jboss/bacon/experimental/impl/generator/ProjectNameGenerator.java
@@ -33,9 +33,18 @@ import lombok.extern.slf4j.Slf4j;
 @Slf4j
 public class ProjectNameGenerator {
     private final VersionParser versionParser = new VersionParser("redhat", "temporary-redhat");
+    private final String buildNameSuffix;
 
     private Set<Project> allProjects;
     private Map<GA, Set<Project>> projectsByGA;
+
+    public ProjectNameGenerator() {
+        this("-AUTOBUILD");
+    }
+
+    public ProjectNameGenerator(String buildNameSuffix) {
+        this.buildNameSuffix = buildNameSuffix;
+    }
 
     public void nameProjects(Set<Project> projects) {
         allProjects = new HashSet<>();
@@ -58,7 +67,7 @@ public class ProjectNameGenerator {
     private void nameProject(Project project) {
         GAV gav = project.getFirstGAV();
         String version = resolveVersionForName(project, gav);
-        String name = gav.getGroupId() + "-" + gav.getArtifactId() + "-" + version + "-AUTOBUILD";
+        String name = gav.getGroupId() + "-" + gav.getArtifactId() + "-" + version + buildNameSuffix;
 
         project.setName(name);
     }

--- a/experimental/src/test/java/org/jboss/bacon/experimental/impl/generator/ProjectNameGeneratorTest.java
+++ b/experimental/src/test/java/org/jboss/bacon/experimental/impl/generator/ProjectNameGeneratorTest.java
@@ -29,6 +29,7 @@ import org.junit.jupiter.api.Test;
 public class ProjectNameGeneratorTest {
 
     private ProjectNameGenerator png = new ProjectNameGenerator();
+    private ProjectNameGenerator pngNoSuffix = new ProjectNameGenerator("");
 
     @Test
     public void shouldGenerateName() {
@@ -102,5 +103,26 @@ public class ProjectNameGeneratorTest {
         assertThat(nonRedhat.getName()).isEqualTo("org.slf4j-slf4j-api-1.7.25-AUTOBUILD");
         assertThat(temporaryRedhat.isConflictingName()).isTrue();
         assertThat(temporaryRedhat.getName()).isEqualTo("org.slf4j-slf4j-api-1.7.25.temporary-redhat-00001-AUTOBUILD");
+    }
+
+    @Test
+    public void shouldGenerateNameWithEmptySuffix() {
+        Project nonRedhat = new Project();
+        nonRedhat.setGavs(Collections.singleton(new GAV("org.slf4j", "slf4j-api", "1.7.25")));
+        nonRedhat.setDependencies(Set.of());
+        pngNoSuffix.nameProjects(Set.of(nonRedhat));
+
+        assertThat(nonRedhat.getName()).isEqualTo("org.slf4j-slf4j-api-1.7.25");
+    }
+
+    @Test
+    public void shouldGenerateNameWithCustomSuffix() {
+        ProjectNameGenerator pngCustom = new ProjectNameGenerator("-CUSTOM");
+        Project nonRedhat = new Project();
+        nonRedhat.setGavs(Collections.singleton(new GAV("org.slf4j", "slf4j-api", "1.7.25")));
+        nonRedhat.setDependencies(Set.of());
+        pngCustom.nameProjects(Set.of(nonRedhat));
+
+        assertThat(nonRedhat.getName()).isEqualTo("org.slf4j-slf4j-api-1.7.25-CUSTOM");
     }
 }


### PR DESCRIPTION
## Summary
- Add a `buildNameSuffix` field to `BuildConfigGeneratorConfig` that controls the suffix appended to generated build config names
- Defaults to `-AUTOBUILD` to preserve existing behavior
- Setting `buildNameSuffix: ""` in the config removes the suffix entirely
- Documents the new option in the experimental features guide

## Test plan
- [x] Existing `ProjectNameGeneratorTest` tests pass (default `-AUTOBUILD` suffix unchanged)
- [x] New test verifies empty suffix produces names without any suffix
- [x] New test verifies custom suffix is applied correctly

🤖 Generated with [Claude Code](https://claude.com/claude-code)