### PR TITLE
Add skipDependencies option to build config generator

### DIFF
--- a/docs/guide/experimental.md
+++ b/docs/guide/experimental.md
@@ -82,6 +82,7 @@ buildConfigGeneratorConfig: # Configuration for how the new build configs should
     scmMapping: # SCM URLs containing the listed key are wholy replaced by the value
         "svn.example.com/foo-bar": "https://git.example.com/foo/bar.git" # "https://svn.example.com/foo-bar/branch" -> "https://git.example.com/foo/bar.git"
     buildNameSuffix: "-AUTOBUILD" # Suffix appended to generated build config names. Defaults to "-AUTOBUILD". Set to "" to disable.
+    skipDependencies: false # If true, dependencies are omitted from the generated build configuration output. Defaults to false.
     failGeneratedBuildScript: true # When generating new or copying and changing existing build config, will part to build script to make sure the build fails
     # This can be helpful to make sure the configs are manually reviewed
     allowDeprecatedEnvironments: false # If true, uses systemImageId to specify environment (to force use of specific environment) when the enviornment defined by environmentName would not be found because it was deprecated.

--- a/experimental/src/main/java/org/jboss/bacon/experimental/DependencyGenerator.java
+++ b/experimental/src/main/java/org/jboss/bacon/experimental/DependencyGenerator.java
@@ -92,15 +92,18 @@ public class DependencyGenerator {
         @Override
         public void run() {
             try {
-                ObjectHelper.print(getJsonOutput(), generatePigConfig());
+                GeneratorConfig config = loadConfig();
+                PigConfiguration pigConfig = generatePigConfig(config);
+                if (config.getBuildConfigGeneratorConfig().isSkipDependencies()) {
+                    pigConfig.getBuilds().forEach(bc -> bc.getDependencies().clear());
+                }
+                ObjectHelper.print(getJsonOutput(), pigConfig);
             } catch (JsonProcessingException e) {
                 throw new FatalException("Caught exception " + e.getMessage(), e);
             }
         }
 
-        private PigConfiguration generatePigConfig() {
-            // Load config file
-            GeneratorConfig config = loadConfig();
+        private PigConfiguration generatePigConfig(GeneratorConfig config) {
             // Initialize working classes
             DependencyResolver dependencyResolver = new DependencyResolver(config.getDependencyResolutionConfig());
             ProjectNameGenerator projectNameGenerator = new ProjectNameGenerator(

--- a/experimental/src/main/java/org/jboss/bacon/experimental/impl/config/BuildConfigGeneratorConfig.java
+++ b/experimental/src/main/java/org/jboss/bacon/experimental/impl/config/BuildConfigGeneratorConfig.java
@@ -68,4 +68,9 @@ public class BuildConfigGeneratorConfig {
      */
     @NotNull
     private String buildNameSuffix = "-AUTOBUILD";
+
+    /**
+     * If true, dependencies are omitted from the generated build configuration output.
+     */
+    private boolean skipDependencies = false;
 }


### PR DESCRIPTION
## Summary
- Adds a new `skipDependencies` boolean option to `BuildConfigGeneratorConfig` (defaults to `false`)
- When enabled, dependencies are cleared from the generated `PigConfiguration` output
- Documents the new option in the experimental guide

## Test plan
- [x] Verify build config generation works normally with `skipDependencies: false` (default)
- [x] Verify dependencies are omitted when `skipDependencies: true` is set
- [x] Verify existing behavior is unchanged when the option is not specified

🤖 Generated with [Claude Code](https://claude.com/claude-code)