### PR TITLE
Add the ability to use wildcards in artifactId that search Maven Central for all of the artifacts of that groupId

### DIFF
--- a/experimental/src/main/java/org/jboss/bacon/experimental/impl/dependencies/DependencyResolver.java
+++ b/experimental/src/main/java/org/jboss/bacon/experimental/impl/dependencies/DependencyResolver.java
@@ -49,6 +49,7 @@ public class DependencyResolver {
     private final DependencyResolutionConfig config;
     private final VersionParser versionParser = new VersionParser("redhat");
     private final LookupApi lookupApi;
+    private final MavenCentralSearcher mavenCentralSearcher = new MavenCentralSearcher();
 
     public DependencyResolver(DependencyResolutionConfig dependencyResolutionConfig) {
         this.config = dependencyResolutionConfig;
@@ -69,10 +70,7 @@ public class DependencyResolver {
         log.info("There are {} dependencies to be excluded", excludedGavs.length);
         Arrays.stream(excludedGavs).map(GACTVParser::parse).forEach(dominoConfig::addExcludePattern);
         config.getIncludeArtifacts().stream().map(GACTVParser::parse).forEach(dominoConfig::addIncludePattern);
-        Set<ArtifactCoords> artifacts = config.getAnalyzeArtifacts()
-                .stream()
-                .map(ArtifactCoords::fromString)
-                .collect(Collectors.toSet());
+        Set<ArtifactCoords> artifacts = expandAnalyzeArtifacts(config.getAnalyzeArtifacts());
 
         if (config.getAnalyzeBOM() != null) {
             dominoConfig.setProjectBom(ArtifactCoords.fromString(config.getAnalyzeBOM()));
@@ -87,6 +85,36 @@ public class DependencyResolver {
                 .setRecipeRepos(config.getRecipeRepos())
                 .setProjectArtifacts(artifacts)
                 .setIncludeAlreadyBuilt(true); // TODO
+    }
+
+    private Set<ArtifactCoords> expandAnalyzeArtifacts(Set<String> analyzeArtifacts) {
+        Set<ArtifactCoords> result = new HashSet<>();
+        for (String entry : analyzeArtifacts) {
+            String[] parts = entry.split(":");
+            if (parts.length < 2) {
+                throw new FatalException(
+                        "Invalid artifact entry '" + entry
+                                + "': must contain at least groupId:artifactId");
+            }
+            String groupId = parts[0];
+            String artifactId = parts[1];
+            if ("*".equals(artifactId)) {
+                String version = parts.length >= 3 ? parts[2] : null;
+                if (version == null || version.isEmpty()) {
+                    throw new FatalException(
+                            "Wildcard artifact entry '" + entry
+                                    + "' must specify a version (format: groupId:*:version)");
+                }
+                Set<String> expandedArtifactIds = mavenCentralSearcher.findArtifacts(groupId, version);
+                log.info("Expanded {}:*:{} to {} artifacts: {}", groupId, version, expandedArtifactIds.size(), expandedArtifactIds);
+                for (String expandedArtifactId : expandedArtifactIds) {
+                    result.add(ArtifactCoords.fromString(groupId + ":" + expandedArtifactId + ":" + version));
+                }
+            } else {
+                result.add(ArtifactCoords.fromString(entry));
+            }
+        }
+        return result;
     }
 
     public DependencyResult resolve(Path projectDir, Path dominoConfigFile) {

--- a/experimental/src/main/java/org/jboss/bacon/experimental/impl/dependencies/MavenCentralSearcher.java
+++ b/experimental/src/main/java/org/jboss/bacon/experimental/impl/dependencies/MavenCentralSearcher.java
@@ -1,0 +1,78 @@
+package org.jboss.bacon.experimental.impl.dependencies;
+
+import java.io.IOException;
+import java.net.URLEncoder;
+import java.nio.charset.StandardCharsets;
+import java.util.LinkedHashSet;
+import java.util.Set;
+
+import org.apache.http.HttpEntity;
+import org.apache.http.HttpResponse;
+import org.apache.http.client.config.RequestConfig;
+import org.apache.http.client.methods.HttpGet;
+import org.apache.http.impl.client.CloseableHttpClient;
+import org.apache.http.impl.client.HttpClientBuilder;
+import org.apache.http.util.EntityUtils;
+import org.jboss.pnc.bacon.common.exception.FatalException;
+
+import com.fasterxml.jackson.databind.JsonNode;
+import com.fasterxml.jackson.databind.ObjectMapper;
+
+import lombok.extern.slf4j.Slf4j;
+
+@Slf4j
+public class MavenCentralSearcher {
+
+    private static final String SEARCH_URL = "https://search.maven.org/solrsearch/select";
+    private static final int TIMEOUT = 120_000;
+    private static final int MAX_ROWS = 200;
+
+    private final CloseableHttpClient httpClient = HttpClientBuilder.create()
+            .setDefaultRequestConfig(
+                    RequestConfig.custom()
+                            .setConnectTimeout(TIMEOUT)
+                            .setSocketTimeout(TIMEOUT)
+                            .build())
+            .build();
+
+    private final ObjectMapper objectMapper = new ObjectMapper();
+
+    public Set<String> findArtifacts(String groupId, String version) {
+        String query = "g:" + groupId + " AND v:" + version;
+        String url = SEARCH_URL + "?q=" + URLEncoder.encode(query, StandardCharsets.UTF_8)
+                + "&rows=" + MAX_ROWS + "&wt=json";
+
+        log.info("Searching Maven Central for artifacts matching {}:*:{}", groupId, version);
+        HttpGet request = new HttpGet(url);
+        try {
+            HttpResponse response = httpClient.execute(request);
+            int statusCode = response.getStatusLine().getStatusCode();
+            if (statusCode >= 300) {
+                throw new FatalException(
+                        "Maven Central search failed with HTTP " + statusCode + ": "
+                                + response.getStatusLine().getReasonPhrase());
+            }
+            HttpEntity entity = response.getEntity();
+            String body = EntityUtils.toString(entity, StandardCharsets.UTF_8);
+            return parseResponse(body);
+        } catch (IOException e) {
+            throw new FatalException("Failed to query Maven Central search API.", e);
+        }
+    }
+
+    Set<String> parseResponse(String json) throws IOException {
+        JsonNode root = objectMapper.readTree(json);
+        JsonNode docs = root.path("response").path("docs");
+        if (!docs.isArray()) {
+            throw new FatalException("Unexpected Maven Central search response format.");
+        }
+        Set<String> artifactIds = new LinkedHashSet<>();
+        for (JsonNode doc : docs) {
+            String artifactId = doc.path("a").asText(null);
+            if (artifactId != null) {
+                artifactIds.add(artifactId);
+            }
+        }
+        return artifactIds;
+    }
+}

--- a/experimental/src/test/java/org/jboss/bacon/experimental/impl/dependencies/MavenCentralSearcherTest.java
+++ b/experimental/src/test/java/org/jboss/bacon/experimental/impl/dependencies/MavenCentralSearcherTest.java
@@ -1,0 +1,58 @@
+package org.jboss.bacon.experimental.impl.dependencies;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+
+import java.io.IOException;
+import java.util.Set;
+
+import org.jboss.pnc.bacon.common.exception.FatalException;
+import org.junit.jupiter.api.Test;
+
+public class MavenCentralSearcherTest {
+
+    private final MavenCentralSearcher searcher = new MavenCentralSearcher();
+
+    @Test
+    void parseValidResponse() throws IOException {
+        String json = "{\"response\":{\"numFound\":3,\"docs\":["
+                + "{\"g\":\"com.example\",\"a\":\"core\",\"v\":\"1.0\"},"
+                + "{\"g\":\"com.example\",\"a\":\"utils\",\"v\":\"1.0\"},"
+                + "{\"g\":\"com.example\",\"a\":\"api\",\"v\":\"1.0\"}"
+                + "]}}";
+
+        Set<String> artifacts = searcher.parseResponse(json);
+
+        assertThat(artifacts).containsExactlyInAnyOrder("core", "utils", "api");
+    }
+
+    @Test
+    void parseEmptyResponse() throws IOException {
+        String json = "{\"response\":{\"numFound\":0,\"docs\":[]}}";
+
+        Set<String> artifacts = searcher.parseResponse(json);
+
+        assertThat(artifacts).isEmpty();
+    }
+
+    @Test
+    void parseResponseWithMissingArtifactId() throws IOException {
+        String json = "{\"response\":{\"numFound\":2,\"docs\":["
+                + "{\"g\":\"com.example\",\"a\":\"core\",\"v\":\"1.0\"},"
+                + "{\"g\":\"com.example\",\"v\":\"1.0\"}"
+                + "]}}";
+
+        Set<String> artifacts = searcher.parseResponse(json);
+
+        assertThat(artifacts).containsExactly("core");
+    }
+
+    @Test
+    void parseInvalidResponseFormat() {
+        String json = "{\"unexpected\":\"format\"}";
+
+        assertThatThrownBy(() -> searcher.parseResponse(json))
+                .isInstanceOf(FatalException.class)
+                .hasMessageContaining("Unexpected Maven Central search response format");
+    }
+}


### PR DESCRIPTION
Add the ability to use wildcards in artifactId that search Maven Central for all of the artifacts of that groupId

Example : 

dependencyResolutionConfig:
    rebuildNonAutoBuilds: true
    analyzeArtifacts:
        - com.google.protobuf:*:3.21.7

will resolve to

[DEBUG] -  - com.google.protobuf:protobuf-bom:3.21.7
[DEBUG] -  - com.google.protobuf:protobuf-java:3.21.7
[DEBUG] -  - com.google.protobuf:protobuf-java-util:3.21.7
[DEBUG] -  - com.google.protobuf:protobuf-javalite:3.21.7
[DEBUG] -  - com.google.protobuf:protobuf-kotlin:3.21.7
[DEBUG] -  - com.google.protobuf:protobuf-kotlin-lite:3.21.7
[DEBUG] -  - com.google.protobuf:protobuf-parent:3.21.7
[DEBUG] -  - com.google.protobuf:protoc:3.21.7