### PR TITLE
Change the default gradle command to gradle -x publish

### DIFF
--- a/experimental/src/main/java/org/jboss/bacon/experimental/impl/generator/BuildConfigGenerator.java
+++ b/experimental/src/main/java/org/jboss/bacon/experimental/impl/generator/BuildConfigGenerator.java
@@ -199,7 +199,7 @@ public class BuildConfigGenerator {
         buildConfig.setEnvironmentName(selectedEnv.getName());
 
         if (buildInfo.getBuildType() == BuildType.GRADLE) {
-            buildConfig.setBuildScript(generateBuildScript(taintedMessage(project), "gradle build"));
+            buildConfig.setBuildScript(generateBuildScript(taintedMessage(project), "gradle -x test publish"));
         } else {
             buildConfig.setBuildScript(generateBuildScript(taintedMessage(project)));
         }


### PR DESCRIPTION
Change the default gradle command to gradle -x publish - gradle build alone will not deploy artifacts
