### PR TITLE
[NCL-9931] Hide keep-pod-alive build trigger option

### DIFF
--- a/bacon_completion
+++ b/bacon_completion
@@ -3246,7 +3246,7 @@ function _picocli_bacon_pnc_build_start() {
   local prev_word=${COMP_WORDS[COMP_CWORD-1]}
 
   local commands=""
-  local flag_opts="'--keep-pod-on-failure' '--timestamp-alignment' '--temporary-build' '--wait' '--no-build-dependencies' '--dry-run' '-o' '--jsonOutput' '--no-color' '-v' '--verbose' '-q' '--quiet' '-h' '--help' '-V' '--version'"
+  local flag_opts="'--timestamp-alignment' '--temporary-build' '--wait' '--no-build-dependencies' '--dry-run' '-o' '--jsonOutput' '--no-color' '-v' '--verbose' '-q' '--quiet' '-h' '--help' '-V' '--version'"
   local arg_opts="'--rebuild-mode' '--timeout' '--revision' '-p' '--configPath' '--profile'"
 
   type compopt &>/dev/null && compopt +o default

--- a/pnc/src/main/java/org/jboss/pnc/bacon/pnc/BuildCli.java
+++ b/pnc/src/main/java/org/jboss/pnc/bacon/pnc/BuildCli.java
@@ -99,7 +99,10 @@ public class BuildCli {
                 names = "--rebuild-mode",
                 description = "Default: IMPLICIT_DEPENDENCY_CHECK. Other options are: EXPLICIT_DEPENDENCY_CHECK, FORCE")
         private String rebuildMode;
-        @Option(names = "--keep-pod-on-failure", description = "Keep the builder pod online after the build fails.")
+        @Option(
+                names = "--keep-pod-on-failure",
+                description = "Keep the builder pod online after the build fails. Admin only.",
+                hidden = true)
         private boolean keepPodOnFailure = false;
         @Option(
                 names = "--timestamp-alignment",


### PR DESCRIPTION
### Checklist:

* [ ] Have you added a note in the [CHANGELOG wiki](https://github.com/project-ncl/bacon/wiki/Changelog) for your change if user-facing?
* [ ] Have you added unit tests for your change?
